### PR TITLE
refactor : 대시보드(ProjectArea) 좌표 체계 PostGIS 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,10 @@ dependencies {
 	// fcm
 	implementation 'com.google.firebase:firebase-admin:9.7.0'
 
+	// PostGIS
+	implementation 'org.hibernate.orm:hibernate-spatial'
+	implementation 'org.locationtech.jts:jts-core:1.19.0'
+
 }
 
 

--- a/project_context.txt
+++ b/project_context.txt
@@ -1865,7 +1865,7 @@ public enum Weather {
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\controller\DashboardController.java
+File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\controller\AdminDashboardController.java
 ================================================================================
 
 package com.ocean.piuda.admin.dashboard.controller;
@@ -1889,9 +1889,9 @@ import org.springframework.web.bind.annotation.RestController;
         name = "Admin Dashboard",
         description = "관리자 대시보드 통계 API입니다. 전체 제출 현황 통계를 조회할 수 있습니다."
 )
-public class DashboardController {
+public class AdminDashboardController {
 
-    private final DashboardService dashboardService;
+    private final AdminDashboardService adminDashboardService;
 
     /**
      * 대시보드 통계 조회
@@ -1903,40 +1903,40 @@ public class DashboardController {
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
-    public ApiData<DashboardSummaryResponse> getDashboardSummary() {
-        DashboardSummaryResponse summary = dashboardService.getDashboardSummary();
+    public ApiData<AdminDashboardSummaryResponse> getDashboardSummary() {
+        AdminDashboardSummaryResponse summary = adminDashboardService.getDashboardSummary();
         return ApiData.ok(summary);
     }
 }
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\dto\DashboardSummaryResponse.java
+File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\dto\AdminDashboardSummaryResponse.java
 ================================================================================
 
 package com.ocean.piuda.admin.dashboard.dto;
 
-public record DashboardSummaryResponse(
+public record AdminDashboardSummaryResponse(
         Long totalSubmissions,
         Long pending,
         Long approved,
         Long rejected,
         Long deleted
 ) {
-    public static DashboardSummaryResponse of(
+    public static AdminDashboardSummaryResponse of(
             long total,
             long pending,
             long approved,
             long rejected,
             long deleted
     ) {
-        return new DashboardSummaryResponse(total, pending, approved, rejected, deleted);
+        return new AdminDashboardSummaryResponse(total, pending, approved, rejected, deleted);
     }
 }
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\service\DashboardService.java
+File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\service\AdminDashboardService.java
 ================================================================================
 
 package com.ocean.piuda.admin.dashboard.service;
@@ -1951,21 +1951,21 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 @Service
 @RequiredArgsConstructor
-public class DashboardService {
+public class AdminDashboardService {
 
     private final SubmissionRepository submissionRepository;
 
     /**
      * 대시보드 통계 조회
      */
-    public DashboardSummaryResponse getDashboardSummary() {
+    public AdminDashboardSummaryResponse getDashboardSummary() {
         long total = submissionRepository.count();
         long pending = submissionRepository.countByStatus(SubmissionStatus.PENDING);
         long approved = submissionRepository.countByStatus(SubmissionStatus.APPROVED);
         long rejected = submissionRepository.countByStatus(SubmissionStatus.REJECTED);
         long deleted = submissionRepository.countByStatus(SubmissionStatus.DELETED);
 
-        return DashboardSummaryResponse.of(total, pending, approved, rejected, deleted);
+        return AdminDashboardSummaryResponse.of(total, pending, approved, rejected, deleted);
     }
 }
 
@@ -6310,6 +6310,786 @@ public enum BioGroup {
 
 }
 
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\controller\DashboardController.java
+================================================================================
+
+package com.ocean.piuda.dashboard.controller;
+
+import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
+import com.ocean.piuda.dashboard.service.DashboardQueryService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/dashboard")
+@RequiredArgsConstructor
+@Tag(name = "Dashboard API", description = "대시보드 작업 영역 및 통계 데이터 조회")
+public class DashboardController {
+
+    private final DashboardQueryService dashboardQueryService;
+
+    @GetMapping("/areas/{id}")
+    @Operation(summary = "작업 영역 상세 조회", description = "ID 기반으로 작업 영역의 상세 데이터(성장률, 수질 등)를 조회합니다.")
+    public ApiData<AreaDetailResponse> getAreaDetail(@PathVariable Long id) {
+        return ApiData.ok(dashboardQueryService.getAreaDetail(id));
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaDetailResponse.java
+================================================================================
+
+package com.ocean.piuda.dashboard.dto.response;
+
+import com.ocean.piuda.dashboard.entity.*;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.Comparator;
+import java.util.List;
+
+@Builder
+@Getter
+public class AreaDetailResponse {
+
+    private Long id;
+    private BasicInfo basic;
+
+    // Row-Oriented Lists (Standard REST)
+    private List<TransplantDto> transplants;
+    private List<GrowthLogDto> growthLogs;
+    private List<WaterLogDto> waterLogs;
+    private BiodiversityDto biodiversity;
+    private List<MediaDto> mediaLogs;
+
+    // --- Inner DTOs ---
+
+    @Builder @Getter
+    public static class BasicInfo {
+        private String name;
+        private LocalDate startDate;
+        private String habitat;
+        private Double depth;
+        private Double areaSize;
+        private String stage;
+        private Double lat;
+        private Double lon;
+    }
+
+    @Builder @Getter
+    public static class TransplantDto {
+        private String species;
+        private Integer count;
+        private Double area;
+    }
+
+    @Builder @Getter
+    public static class GrowthLogDto {
+        private LocalDate date;
+        private Double attachmentRate;
+        private Double survivalRate;
+        private Double growthLength;
+    }
+
+    @Builder @Getter
+    public static class WaterLogDto {
+        private LocalDate date;
+        private Double temperature;
+        private Double dissolvedOxygen;
+        private Double nutrient;
+    }
+
+    @Builder @Getter
+    public static class BiodiversityDto {
+        private Stat before;
+        private Stat after;
+
+        @Builder @Getter
+        public static class Stat {
+            private Integer fishCount;
+            private Integer invertCount;
+            private Double shannonIndex;
+        }
+    }
+
+    @Builder @Getter
+    public static class MediaDto {
+        private LocalDate date;
+        private String url;
+        private String caption;
+    }
+
+    // --- Converter ---
+    public static AreaDetailResponse fromEntity(ProjectArea entity) {
+        return AreaDetailResponse.builder()
+                .id(entity.getId())
+                .basic(BasicInfo.builder()
+                        .name(entity.getName())
+                        .startDate(entity.getStartDate())
+                        .habitat(entity.getHabitat() != null ? entity.getHabitat().getDescription() : null)
+                        .depth(entity.getDepth())
+                        .areaSize(entity.getAreaSize())
+                        .stage(entity.getStatus() != null ? entity.getStatus().getDescription() : null)
+                        .lat(entity.getLat())
+                        .lon(entity.getLon())
+                        .build())
+
+                .transplants(entity.getTransplants().stream()
+                        .map(t -> TransplantDto.builder()
+                                .species(t.getSpeciesName())
+                                .count(t.getCount())
+                                .area(t.getAreaSize())
+                                .build())
+                        .toList())
+
+                .growthLogs(entity.getGrowthLogs().stream()
+                        .sorted(Comparator.comparing(GrowthLog::getRecordDate))
+                        .map(g -> GrowthLogDto.builder()
+                                .date(g.getRecordDate())
+                                .attachmentRate(g.getAttachmentRate())
+                                .survivalRate(g.getSurvivalRate())
+                                .growthLength(g.getGrowthLength())
+                                .build())
+                        .toList())
+
+                .waterLogs(entity.getWaterLogs().stream()
+                        .sorted(Comparator.comparing(WaterLog::getRecordDate))
+                        .map(w -> WaterLogDto.builder()
+                                .date(w.getRecordDate())
+                                .temperature(w.getTemperature())
+                                .dissolvedOxygen(w.getDissolvedOxygen())
+                                .nutrient(w.getNutrient())
+                                .build())
+                        .toList())
+
+                .biodiversity(entity.getBiodiversity() != null ? BiodiversityDto.builder()
+                        .before(BiodiversityDto.Stat.builder()
+                                .fishCount(entity.getBiodiversity().getFishCountBefore())
+                                .invertCount(entity.getBiodiversity().getInvertCountBefore())
+                                .shannonIndex(entity.getBiodiversity().getShannonIndexBefore())
+                                .build())
+                        .after(BiodiversityDto.Stat.builder()
+                                .fishCount(entity.getBiodiversity().getFishCountAfter())
+                                .invertCount(entity.getBiodiversity().getInvertCountAfter())
+                                .shannonIndex(entity.getBiodiversity().getShannonIndexAfter())
+                                .build())
+                        .build() : null)
+
+                .mediaLogs(entity.getMediaLogs().stream()
+                        .sorted(Comparator.comparing(MediaLog::getRecordDate))
+                        .map(m -> MediaDto.builder()
+                                .date(m.getRecordDate())
+                                .url(m.getMediaUrl())
+                                .caption(m.getCaption())
+                                .build())
+                        .toList())
+                .build();
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\BiodiversitySummary.java
+================================================================================
+
+package com.ocean.piuda.dashboard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "biodiversity_summaries")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class BiodiversitySummary {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id")
+    @Setter
+    private ProjectArea projectArea;
+
+    // 복원 전
+    private Integer fishCountBefore;
+    private Integer invertCountBefore;
+    private Double shannonIndexBefore;
+
+    // 복원 후
+    private Integer fishCountAfter;
+    private Integer invertCountAfter;
+    private Double shannonIndexAfter;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\GrowthLog.java
+================================================================================
+
+package com.ocean.piuda.dashboard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "growth_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class GrowthLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id")
+    @Setter
+    private ProjectArea projectArea;
+
+    private LocalDate recordDate; // 기록 날짜 (YYYY-MM-DD)
+
+    private Double attachmentRate; // 착생률 (%)
+    private Double survivalRate;   // 생존률 (%)
+    private Double growthLength;   // 성장 길이 (mm)
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\MediaLog.java
+================================================================================
+
+package com.ocean.piuda.dashboard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "media_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class MediaLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id")
+    @Setter
+    private ProjectArea projectArea;
+
+    private LocalDate recordDate;
+    private String mediaUrl;
+    private String caption; // 설명 (선택)
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\ProjectArea.java
+================================================================================
+
+package com.ocean.piuda.dashboard.entity;
+
+import com.ocean.piuda.dashboard.enums.HabitatType;
+import com.ocean.piuda.dashboard.enums.ProjectStatus;
+import com.ocean.piuda.global.api.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "project_areas")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class ProjectArea extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "area_id")
+    private Long id;
+
+    @Column(nullable = false)
+    private String name; // 예: "작업 영역 1"
+
+    private String description; // 상세 설명
+
+    private LocalDate startDate;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private HabitatType habitat; // String -> HabitatType
+
+    private Double depth; // 수심 (m)
+
+    private Double areaSize; // 면적 (m2) - 숫자형으로 관리 권장
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 20)
+    private ProjectStatus status;
+
+    // 좌표 (GeoSpatial 타입 도입 전에는 Double 사용)
+    private Double lat;
+    private Double lon;
+
+    // --- 하위 연관 관계 (Cascade 설정) ---
+
+    @OneToMany(mappedBy = "projectArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<TransplantLog> transplants = new ArrayList<>();
+
+    @OneToMany(mappedBy = "projectArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<GrowthLog> growthLogs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "projectArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<WaterLog> waterLogs = new ArrayList<>();
+
+    @OneToOne(mappedBy = "projectArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    private BiodiversitySummary biodiversity;
+
+    @OneToMany(mappedBy = "projectArea", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<MediaLog> mediaLogs = new ArrayList<>();
+
+    // --- 연관관계 편의 메서드 ---
+    public void addTransplant(TransplantLog log) { this.transplants.add(log); log.setProjectArea(this); }
+    public void addGrowth(GrowthLog log) { this.growthLogs.add(log); log.setProjectArea(this); }
+    public void addWater(WaterLog log) { this.waterLogs.add(log); log.setProjectArea(this); }
+    public void setBiodiversity(BiodiversitySummary bio) { this.biodiversity = bio; bio.setProjectArea(this); }
+    public void addMedia(MediaLog log) { this.mediaLogs.add(log); log.setProjectArea(this); }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\TransplantLog.java
+================================================================================
+
+package com.ocean.piuda.dashboard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "transplant_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class TransplantLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id")
+    @Setter
+    private ProjectArea projectArea;
+
+    private String speciesName; // 감태, 다시마
+    private Integer count;      // 개체수
+    private Double areaSize;    // 이식 면적 (m2)
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\WaterLog.java
+================================================================================
+
+package com.ocean.piuda.dashboard.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "water_logs")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class WaterLog {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "area_id")
+    @Setter
+    private ProjectArea projectArea;
+
+    private LocalDate recordDate;
+
+    private Double temperature;     // 수온
+    private Double dissolvedOxygen; // DO
+    private Double nutrient;        // 영양염류
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\HabitatType.java
+================================================================================
+
+package com.ocean.piuda.dashboard.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum HabitatType {
+    KELP_FOREST("켈프숲"),
+    SEAGRASS_BED("잘피밭"),
+    URCHIN_BARREN("성게 황폐지"),
+    ROCKY_REEF("암반리프"),
+    SOFT_BOTTOM("연질저서"),
+    ARTIFICIAL_STRUCTURE("인공구조물"),
+    OTHER("기타");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\ProjectStatus.java
+================================================================================
+
+package com.ocean.piuda.dashboard.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ProjectStatus {
+    TRANSPLANT_COMPLETED("이식 완료"),
+    GROWING("성장 중"),
+    STABLE("안정화 구역"),
+    MONITORING("모니터링 중");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\initializer\DashboardDataInitializer.java
+================================================================================
+
+package com.ocean.piuda.dashboard.initializer;
+
+import com.ocean.piuda.dashboard.entity.*;
+import com.ocean.piuda.dashboard.enums.HabitatType;
+import com.ocean.piuda.dashboard.enums.ProjectStatus;
+import com.ocean.piuda.dashboard.repository.ProjectAreaRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("!prod")
+public class DashboardDataInitializer implements CommandLineRunner {
+
+    private final ProjectAreaRepository projectAreaRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) throws Exception {
+        if (projectAreaRepository.count() > 0) {
+            return;
+        }
+
+        log.info("Dashboard 초기 데이터 적재 시작");
+        createPohangData();
+        // createUljinData(); // 필요 시 추가
+    }
+
+    private void createPohangData() {
+        // 기존 pohang-1 데이터
+        ProjectArea area = ProjectArea.builder()
+                .name("작업 영역 1")
+                .startDate(LocalDate.of(2025, 7, 15))
+                .habitat(HabitatType.ROCKY_REEF)
+                .depth(8.0)
+                .areaSize(2100.0)
+                .status(ProjectStatus.TRANSPLANT_COMPLETED)
+                .lat(36.0762)
+                .lon(129.4432)
+                .build();
+
+        // 이식 데이터
+        area.addTransplant(TransplantLog.builder().speciesName("감태").count(2100).areaSize(1100.0).build());
+        area.addTransplant(TransplantLog.builder().speciesName("다시마").count(700).areaSize(650.0).build());
+        area.addTransplant(TransplantLog.builder().speciesName("곰피").count(380).areaSize(350.0).build());
+
+        // 시계열 데이터 생성 유틸
+        LocalDate baseDate = LocalDate.of(2025, 1, 15);
+        List<Double> attach = List.of(60.0, 65.0, 71.0, 77.0, 80.0, 82.0);
+        List<Double> surviv = List.of(92.0, 90.0, 89.0, 88.0, 86.0, 85.0);
+        List<Double> growth = List.of(1.0, 1.2, 1.5, 1.8, 2.0, 2.3);
+
+        List<Double> wTemp = List.of(9.6, 10.0, 11.3, 13.7, 16.1);
+        List<Double> wDo = List.of(8.6, 8.4, 8.2, 8.0, 7.8);
+        List<Double> wNut = List.of(0.29, 0.26, 0.24, 0.22, 0.21);
+
+        for (int i = 0; i < 6; i++) {
+            LocalDate date = baseDate.plusMonths(i);
+            // Growth
+            area.addGrowth(GrowthLog.builder()
+                    .recordDate(date)
+                    .attachmentRate(attach.get(i))
+                    .survivalRate(surviv.get(i))
+                    .growthLength(growth.get(i))
+                    .build());
+
+            // Water (데이터가 5개뿐이라 체크)
+            if (i < 5) {
+                area.addWater(WaterLog.builder()
+                        .recordDate(date)
+                        .temperature(wTemp.get(i))
+                        .dissolvedOxygen(wDo.get(i))
+                        .nutrient(wNut.get(i))
+                        .build());
+            }
+        }
+
+        // 생물다양성
+        area.setBiodiversity(BiodiversitySummary.builder()
+                .fishCountBefore(5).fishCountAfter(11)
+                .invertCountBefore(10).invertCountAfter(18)
+                .shannonIndexBefore(1.12).shannonIndexAfter(1.78)
+                .build());
+
+        // 미디어 (가상 URL)
+        String imgUrl = "/images/underSea.jpg";
+        area.addMedia(MediaLog.builder().recordDate(LocalDate.of(2025, 7, 1)).mediaUrl(imgUrl).caption("2025.07").build());
+        area.addMedia(MediaLog.builder().recordDate(LocalDate.of(2025, 8, 1)).mediaUrl(imgUrl).caption("2025.08").build());
+
+        projectAreaRepository.save(area);
+        log.info("Pohang 데이터 생성 완료 (ID: {})", area.getId());
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\ProjectExporter.java
+================================================================================
+
+package com.ocean.piuda.dashboard;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n" + "=".repeat(80) + "\n");
+            writer.write("File Path: " + file.toString() + "\n");
+            writer.write("=".repeat(80) + "\n\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\ProjectAreaRepository.java
+================================================================================
+
+package com.ocean.piuda.dashboard.repository;
+
+import com.ocean.piuda.dashboard.entity.ProjectArea;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> {
+    // 필요한 데이터는 Service의 DTO 변환 과정에서 Batch Size 설정에 의해 효율적으로 로딩됨 (N+1 문제 방지)
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardQueryService.java
+================================================================================
+
+package com.ocean.piuda.dashboard.service;
+
+import com.ocean.piuda.dashboard.entity.ProjectArea;
+import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
+import com.ocean.piuda.dashboard.repository.ProjectAreaRepository;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DashboardQueryService {
+
+    private final ProjectAreaRepository projectAreaRepository;
+
+    public AreaDetailResponse getAreaDetail(Long id) {
+        ProjectArea area = projectAreaRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        // Entity -> DTO 변환 (Lazy Loading 발생, Transaction 내라 안전)
+        return AreaDetailResponse.fromEntity(area);
+    }
+}
 
 
 ================================================================================

--- a/src/main/java/com/ocean/piuda/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/ocean/piuda/dashboard/controller/DashboardController.java
@@ -1,17 +1,21 @@
 package com.ocean.piuda.dashboard.controller;
 
 import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
+import com.ocean.piuda.dashboard.dto.response.AreaStatResponse;
 import com.ocean.piuda.dashboard.service.DashboardQueryService;
 import com.ocean.piuda.global.api.dto.ApiData;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/api/dashboard")
 @RequiredArgsConstructor
-@Tag(name = "Dashboard API", description = "대시보드 작업 영역 및 통계 데이터 조회")
+@Tag(name = "Dashboard API", description = "대시보드 작업 영역(PostGIS) 및 통계 데이터 조회")
 public class DashboardController {
 
     private final DashboardQueryService dashboardQueryService;
@@ -20,5 +24,38 @@ public class DashboardController {
     @Operation(summary = "작업 영역 상세 조회", description = "ID 기반으로 작업 영역의 상세 데이터(성장률, 수질 등)를 조회합니다.")
     public ApiData<AreaDetailResponse> getAreaDetail(@PathVariable Long id) {
         return ApiData.ok(dashboardQueryService.getAreaDetail(id));
+    }
+
+    @GetMapping("/areas/nearby")
+    @Operation(summary = "반경 기반 검색", description = "중심 좌표와 반경(km)으로 작업 영역을 검색합니다.")
+    public ApiData<List<AreaDetailResponse>> getNearby(
+            @Parameter(description = "위도") @RequestParam Double lat,
+            @Parameter(description = "경도") @RequestParam Double lon,
+            @Parameter(description = "반경(km), 기본값 5.0") @RequestParam(defaultValue = "5.0") Double radius) {
+        return ApiData.ok(dashboardQueryService.getNearbyAreas(lat, lon, radius));
+    }
+
+    @GetMapping("/areas/bbox")
+    @Operation(summary = "뷰포트(BBox) 검색", description = "지도 화면 영역(Min/Max LatLon) 내의 데이터만 조회합니다.")
+    public ApiData<List<AreaDetailResponse>> getBBox(
+            @RequestParam Double minLat, @RequestParam Double minLon,
+            @RequestParam Double maxLat, @RequestParam Double maxLon) {
+        return ApiData.ok(dashboardQueryService.getAreasInBBox(minLat, minLon, maxLat, maxLon));
+    }
+
+    @GetMapping("/areas/nearest")
+    @Operation(summary = "가장 가까운 영역 찾기 (KNN)", description = "내 위치에서 가장 가까운 N개의 작업 영역을 찾습니다.")
+    public ApiData<List<AreaDetailResponse>> getNearest(
+            @RequestParam Double lat, @RequestParam Double lon,
+            @RequestParam(defaultValue = "3") Integer limit) {
+        return ApiData.ok(dashboardQueryService.getNearestAreas(lat, lon, limit));
+    }
+
+    @GetMapping("/stats/nearby")
+    @Operation(summary = "반경 내 통계 요약", description = "반경 내 프로젝트 수, 총 면적, 평균 수심 등을 집계합니다.")
+    public ApiData<AreaStatResponse> getStats(
+            @RequestParam Double lat, @RequestParam Double lon,
+            @RequestParam(defaultValue = "10.0") Double radius) {
+        return ApiData.ok(dashboardQueryService.getNearbyStats(lat, lon, radius));
     }
 }

--- a/src/main/java/com/ocean/piuda/dashboard/dto/response/AreaDetailResponse.java
+++ b/src/main/java/com/ocean/piuda/dashboard/dto/response/AreaDetailResponse.java
@@ -15,14 +15,11 @@ public class AreaDetailResponse {
     private Long id;
     private BasicInfo basic;
 
-    // Row-Oriented Lists (Standard REST)
     private List<TransplantDto> transplants;
     private List<GrowthLogDto> growthLogs;
     private List<WaterLogDto> waterLogs;
     private BiodiversityDto biodiversity;
     private List<MediaDto> mediaLogs;
-
-    // --- Inner DTOs ---
 
     @Builder @Getter
     public static class BasicInfo {
@@ -36,50 +33,13 @@ public class AreaDetailResponse {
         private Double lon;
     }
 
-    @Builder @Getter
-    public static class TransplantDto {
-        private String species;
-        private Integer count;
-        private Double area;
-    }
+    // ... (TransplantDto, GrowthLogDto, WaterLogDto, BiodiversityDto, MediaDto 등 내부 클래스 기존과 동일)
+    @Builder @Getter public static class TransplantDto { String species; Integer count; Double area; }
+    @Builder @Getter public static class GrowthLogDto { LocalDate date; Double attachmentRate; Double survivalRate; Double growthLength; }
+    @Builder @Getter public static class WaterLogDto { LocalDate date; Double temperature; Double dissolvedOxygen; Double nutrient; }
+    @Builder @Getter public static class BiodiversityDto { Stat before; Stat after; @Builder @Getter public static class Stat { Integer fishCount; Integer invertCount; Double shannonIndex; } }
+    @Builder @Getter public static class MediaDto { LocalDate date; String url; String caption; }
 
-    @Builder @Getter
-    public static class GrowthLogDto {
-        private LocalDate date;
-        private Double attachmentRate;
-        private Double survivalRate;
-        private Double growthLength;
-    }
-
-    @Builder @Getter
-    public static class WaterLogDto {
-        private LocalDate date;
-        private Double temperature;
-        private Double dissolvedOxygen;
-        private Double nutrient;
-    }
-
-    @Builder @Getter
-    public static class BiodiversityDto {
-        private Stat before;
-        private Stat after;
-
-        @Builder @Getter
-        public static class Stat {
-            private Integer fishCount;
-            private Integer invertCount;
-            private Double shannonIndex;
-        }
-    }
-
-    @Builder @Getter
-    public static class MediaDto {
-        private LocalDate date;
-        private String url;
-        private String caption;
-    }
-
-    // --- Converter ---
     public static AreaDetailResponse fromEntity(ProjectArea entity) {
         return AreaDetailResponse.builder()
                 .id(entity.getId())
@@ -90,59 +50,26 @@ public class AreaDetailResponse {
                         .depth(entity.getDepth())
                         .areaSize(entity.getAreaSize())
                         .stage(entity.getStatus() != null ? entity.getStatus().getDescription() : null)
+                        // [수정] Entity의 캡슐화된 메서드 사용
                         .lat(entity.getLat())
                         .lon(entity.getLon())
                         .build())
 
                 .transplants(entity.getTransplants().stream()
-                        .map(t -> TransplantDto.builder()
-                                .species(t.getSpeciesName())
-                                .count(t.getCount())
-                                .area(t.getAreaSize())
-                                .build())
-                        .toList())
-
+                        .map(t -> TransplantDto.builder().species(t.getSpeciesName()).count(t.getCount()).area(t.getAreaSize()).build()).toList())
                 .growthLogs(entity.getGrowthLogs().stream()
                         .sorted(Comparator.comparing(GrowthLog::getRecordDate))
-                        .map(g -> GrowthLogDto.builder()
-                                .date(g.getRecordDate())
-                                .attachmentRate(g.getAttachmentRate())
-                                .survivalRate(g.getSurvivalRate())
-                                .growthLength(g.getGrowthLength())
-                                .build())
-                        .toList())
-
+                        .map(g -> GrowthLogDto.builder().date(g.getRecordDate()).attachmentRate(g.getAttachmentRate()).survivalRate(g.getSurvivalRate()).growthLength(g.getGrowthLength()).build()).toList())
                 .waterLogs(entity.getWaterLogs().stream()
                         .sorted(Comparator.comparing(WaterLog::getRecordDate))
-                        .map(w -> WaterLogDto.builder()
-                                .date(w.getRecordDate())
-                                .temperature(w.getTemperature())
-                                .dissolvedOxygen(w.getDissolvedOxygen())
-                                .nutrient(w.getNutrient())
-                                .build())
-                        .toList())
-
+                        .map(w -> WaterLogDto.builder().date(w.getRecordDate()).temperature(w.getTemperature()).dissolvedOxygen(w.getDissolvedOxygen()).nutrient(w.getNutrient()).build()).toList())
                 .biodiversity(entity.getBiodiversity() != null ? BiodiversityDto.builder()
-                        .before(BiodiversityDto.Stat.builder()
-                                .fishCount(entity.getBiodiversity().getFishCountBefore())
-                                .invertCount(entity.getBiodiversity().getInvertCountBefore())
-                                .shannonIndex(entity.getBiodiversity().getShannonIndexBefore())
-                                .build())
-                        .after(BiodiversityDto.Stat.builder()
-                                .fishCount(entity.getBiodiversity().getFishCountAfter())
-                                .invertCount(entity.getBiodiversity().getInvertCountAfter())
-                                .shannonIndex(entity.getBiodiversity().getShannonIndexAfter())
-                                .build())
+                        .before(BiodiversityDto.Stat.builder().fishCount(entity.getBiodiversity().getFishCountBefore()).invertCount(entity.getBiodiversity().getInvertCountBefore()).shannonIndex(entity.getBiodiversity().getShannonIndexBefore()).build())
+                        .after(BiodiversityDto.Stat.builder().fishCount(entity.getBiodiversity().getFishCountAfter()).invertCount(entity.getBiodiversity().getInvertCountAfter()).shannonIndex(entity.getBiodiversity().getShannonIndexAfter()).build())
                         .build() : null)
-
                 .mediaLogs(entity.getMediaLogs().stream()
                         .sorted(Comparator.comparing(MediaLog::getRecordDate))
-                        .map(m -> MediaDto.builder()
-                                .date(m.getRecordDate())
-                                .url(m.getMediaUrl())
-                                .caption(m.getCaption())
-                                .build())
-                        .toList())
+                        .map(m -> MediaDto.builder().date(m.getRecordDate()).url(m.getMediaUrl()).caption(m.getCaption()).build()).toList())
                 .build();
     }
 }

--- a/src/main/java/com/ocean/piuda/dashboard/dto/response/AreaStatResponse.java
+++ b/src/main/java/com/ocean/piuda/dashboard/dto/response/AreaStatResponse.java
@@ -1,0 +1,14 @@
+package com.ocean.piuda.dashboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class AreaStatResponse {
+    private long totalCount;      // 영역 내 프로젝트 수
+    private double totalAreaSize; // 총 복원 면적 합계 (m2)
+    private double avgDepth;      // 평균 수심 (m)
+}

--- a/src/main/java/com/ocean/piuda/dashboard/entity/ProjectArea.java
+++ b/src/main/java/com/ocean/piuda/dashboard/entity/ProjectArea.java
@@ -3,10 +3,13 @@ package com.ocean.piuda.dashboard.entity;
 import com.ocean.piuda.dashboard.enums.HabitatType;
 import com.ocean.piuda.dashboard.enums.ProjectStatus;
 import com.ocean.piuda.global.api.domain.BaseEntity;
+import com.ocean.piuda.global.util.GeometryUtils;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.locationtech.jts.geom.Point;
 
+import java.awt.*;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -66,6 +69,27 @@ public class ProjectArea extends BaseEntity {
     @OneToMany(mappedBy = "projectArea", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<MediaLog> mediaLogs = new ArrayList<>();
+
+
+    @Column(columnDefinition = "geometry(Point, 4326)")
+    private Point location;
+    // DTO용 편의 메서드 (Getter)
+    public Double getLat() {
+        return this.location != null ? this.location.getY() : null;
+    }
+
+    public Double getLon() {
+        return this.location != null ? this.location.getX() : null;
+    }
+
+    // 데이터 세팅 편의 메서드 (Setter)
+    public void setLocation(Double lat, Double lon) {
+        if (lat != null && lon != null) {
+            this.location = GeometryUtils.createPoint(lon, lat);
+        } else {
+            this.location = null;
+        }
+    }
 
     // --- 연관관계 편의 메서드 ---
     public void addTransplant(TransplantLog log) { this.transplants.add(log); log.setProjectArea(this); }

--- a/src/main/java/com/ocean/piuda/dashboard/initializer/DashboardDataInitializer.java
+++ b/src/main/java/com/ocean/piuda/dashboard/initializer/DashboardDataInitializer.java
@@ -4,6 +4,7 @@ import com.ocean.piuda.dashboard.entity.*;
 import com.ocean.piuda.dashboard.enums.HabitatType;
 import com.ocean.piuda.dashboard.enums.ProjectStatus;
 import com.ocean.piuda.dashboard.repository.ProjectAreaRepository;
+import com.ocean.piuda.global.util.GeometryUtils;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -31,11 +32,13 @@ public class DashboardDataInitializer implements CommandLineRunner {
 
         log.info("Dashboard 초기 데이터 적재 시작");
         createPohangData();
-        // createUljinData(); // 필요 시 추가
     }
 
     private void createPohangData() {
-        // 기존 pohang-1 데이터
+        // 좌표 정의
+        double lat = 36.0762;
+        double lon = 129.4432;
+
         ProjectArea area = ProjectArea.builder()
                 .name("작업 영역 1")
                 .startDate(LocalDate.of(2025, 7, 15))
@@ -43,8 +46,8 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .depth(8.0)
                 .areaSize(2100.0)
                 .status(ProjectStatus.TRANSPLANT_COMPLETED)
-                .lat(36.0762)
-                .lon(129.4432)
+                // [수정] Point 객체 생성 및 주입 (Lon, Lat 순서)
+                .location(GeometryUtils.createPoint(lon, lat))
                 .build();
 
         // 이식 데이터
@@ -52,7 +55,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
         area.addTransplant(TransplantLog.builder().speciesName("다시마").count(700).areaSize(650.0).build());
         area.addTransplant(TransplantLog.builder().speciesName("곰피").count(380).areaSize(350.0).build());
 
-        // 시계열 데이터 생성 유틸
+        // 시계열 데이터
         LocalDate baseDate = LocalDate.of(2025, 1, 15);
         List<Double> attach = List.of(60.0, 65.0, 71.0, 77.0, 80.0, 82.0);
         List<Double> surviv = List.of(92.0, 90.0, 89.0, 88.0, 86.0, 85.0);
@@ -64,7 +67,6 @@ public class DashboardDataInitializer implements CommandLineRunner {
 
         for (int i = 0; i < 6; i++) {
             LocalDate date = baseDate.plusMonths(i);
-            // Growth
             area.addGrowth(GrowthLog.builder()
                     .recordDate(date)
                     .attachmentRate(attach.get(i))
@@ -72,7 +74,6 @@ public class DashboardDataInitializer implements CommandLineRunner {
                     .growthLength(growth.get(i))
                     .build());
 
-            // Water (데이터가 5개뿐이라 체크)
             if (i < 5) {
                 area.addWater(WaterLog.builder()
                         .recordDate(date)
@@ -83,14 +84,12 @@ public class DashboardDataInitializer implements CommandLineRunner {
             }
         }
 
-        // 생물다양성
         area.setBiodiversity(BiodiversitySummary.builder()
                 .fishCountBefore(5).fishCountAfter(11)
                 .invertCountBefore(10).invertCountAfter(18)
                 .shannonIndexBefore(1.12).shannonIndexAfter(1.78)
                 .build());
 
-        // 미디어 (가상 URL)
         String imgUrl = "/images/underSea.jpg";
         area.addMedia(MediaLog.builder().recordDate(LocalDate.of(2025, 7, 1)).mediaUrl(imgUrl).caption("2025.07").build());
         area.addMedia(MediaLog.builder().recordDate(LocalDate.of(2025, 8, 1)).mediaUrl(imgUrl).caption("2025.08").build());

--- a/src/main/java/com/ocean/piuda/dashboard/project_context.txt
+++ b/src/main/java/com/ocean/piuda/dashboard/project_context.txt
@@ -743,16 +743,7 @@ import java.util.Optional;
 
 @Repository
 public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> {
-    // 기본 findById는 Lazy Loading 발생
-    // attributePaths에 정의된 필드들은 Eager Loading (Join Fetch) 처리
-    @EntityGraph(attributePaths = {
-            "transplants",
-            "growthLogs",
-            "waterLogs",
-            "biodiversity",
-            "mediaLogs"
-    })
-    Optional<ProjectArea> findById(Long id);
+    // 필요한 데이터는 Service의 DTO 변환 과정에서 Batch Size 설정에 의해 효율적으로 로딩됨 (N+1 문제 방지)
 }
 
 

--- a/src/main/java/com/ocean/piuda/dashboard/repository/ProjectAreaRepository.java
+++ b/src/main/java/com/ocean/piuda/dashboard/repository/ProjectAreaRepository.java
@@ -1,13 +1,70 @@
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.ProjectArea;
-import org.springframework.data.jpa.repository.EntityGraph;
+import com.ocean.piuda.dashboard.repository.projection.AreaStatProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> {
-    // 필요한 데이터는 Service의 DTO 변환 과정에서 Batch Size 설정에 의해 효율적으로 로딩됨 (N+1 문제 방지)
+
+    // 1. 반경 기반 주변 검색 (Nearby)
+    @Query(value = """
+        SELECT * FROM project_areas p
+        WHERE ST_DWithin(
+            CAST(p.location AS geography),
+            CAST(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) AS geography),
+            :radiusInMeters
+        )
+        """, nativeQuery = true)
+    List<ProjectArea> findNearbyAreas(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("radiusInMeters") double radiusInMeters
+    );
+
+    // 2. 뷰포트 영역 조회 (BBox)
+    @Query(value = """
+        SELECT * FROM project_areas p
+        WHERE p.location && ST_MakeEnvelope(:minLon, :minLat, :maxLon, :maxLat, 4326)
+        """, nativeQuery = true)
+    List<ProjectArea> findWithinBBox(
+            @Param("minLat") double minLat, @Param("minLon") double minLon,
+            @Param("maxLat") double maxLat, @Param("maxLon") double maxLon
+    );
+
+    // 3. 가장 가까운 N개 찾기 (Nearest - KNN)
+    @Query(value = """
+        SELECT * FROM project_areas p
+        ORDER BY p.location <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)
+        LIMIT :limitCount
+        """, nativeQuery = true)
+    List<ProjectArea> findNearestAreas(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("limitCount") int limitCount
+    );
+
+    // 4. 반경 내 통계 (Aggregation) -> Interface Projection 반환
+    @Query(value = """
+        SELECT 
+            count(*)                      AS totalCount, 
+            COALESCE(sum(p.area_size), 0) AS totalAreaSize, 
+            COALESCE(avg(p.depth), 0)     AS avgDepth
+        FROM project_areas p
+        WHERE ST_DWithin(
+            CAST(p.location AS geography),
+            CAST(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) AS geography),
+            :radiusInMeters
+        )
+        """, nativeQuery = true)
+    AreaStatProjection getNearbyStatistics(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("radiusInMeters") double radiusInMeters
+    );
 }

--- a/src/main/java/com/ocean/piuda/dashboard/repository/projection/AreaStatProjection.java
+++ b/src/main/java/com/ocean/piuda/dashboard/repository/projection/AreaStatProjection.java
@@ -1,0 +1,7 @@
+package com.ocean.piuda.dashboard.repository.projection;
+
+public interface AreaStatProjection {
+    Long getTotalCount();
+    Double getTotalAreaSize();
+    Double getAvgDepth();
+}

--- a/src/main/java/com/ocean/piuda/dashboard/service/DashboardQueryService.java
+++ b/src/main/java/com/ocean/piuda/dashboard/service/DashboardQueryService.java
@@ -1,13 +1,17 @@
 package com.ocean.piuda.dashboard.service;
 
-import com.ocean.piuda.dashboard.entity.ProjectArea;
 import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
+import com.ocean.piuda.dashboard.dto.response.AreaStatResponse;
+import com.ocean.piuda.dashboard.entity.ProjectArea;
 import com.ocean.piuda.dashboard.repository.ProjectAreaRepository;
+import com.ocean.piuda.dashboard.repository.projection.AreaStatProjection;
 import com.ocean.piuda.global.api.exception.BusinessException;
 import com.ocean.piuda.global.api.exception.ExceptionType;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -19,8 +23,42 @@ public class DashboardQueryService {
     public AreaDetailResponse getAreaDetail(Long id) {
         ProjectArea area = projectAreaRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
-
-        // Entity -> DTO 변환 (Lazy Loading 발생, Transaction 내라 안전)
         return AreaDetailResponse.fromEntity(area);
+    }
+
+    // 1. 반경 검색
+    public List<AreaDetailResponse> getNearbyAreas(Double lat, Double lon, Double radiusKm) {
+        double radiusMeters = (radiusKm != null ? radiusKm : 5.0) * 1000;
+        return projectAreaRepository.findNearbyAreas(lat, lon, radiusMeters).stream()
+                .map(AreaDetailResponse::fromEntity)
+                .toList();
+    }
+
+    // 2. 뷰포트 검색
+    public List<AreaDetailResponse> getAreasInBBox(Double minLat, Double minLon, Double maxLat, Double maxLon) {
+        return projectAreaRepository.findWithinBBox(minLat, minLon, maxLat, maxLon).stream()
+                .map(AreaDetailResponse::fromEntity)
+                .toList();
+    }
+
+    // 3. 가장 가까운 N개
+    public List<AreaDetailResponse> getNearestAreas(Double lat, Double lon, Integer limit) {
+        int limitCount = (limit != null && limit > 0) ? limit : 3;
+        return projectAreaRepository.findNearestAreas(lat, lon, limitCount).stream()
+                .map(AreaDetailResponse::fromEntity)
+                .toList();
+    }
+
+    // 4. 통계 (Projection -> DTO)
+    public AreaStatResponse getNearbyStats(Double lat, Double lon, Double radiusKm) {
+        double radiusMeters = (radiusKm != null ? radiusKm : 10.0) * 1000;
+
+        AreaStatProjection proj = projectAreaRepository.getNearbyStatistics(lat, lon, radiusMeters);
+
+        return AreaStatResponse.builder()
+                .totalCount(proj.getTotalCount() != null ? proj.getTotalCount() : 0L)
+                .totalAreaSize(proj.getTotalAreaSize() != null ? proj.getTotalAreaSize() : 0.0)
+                .avgDepth(proj.getAvgDepth() != null ? proj.getAvgDepth() : 0.0)
+                .build();
     }
 }

--- a/src/main/java/com/ocean/piuda/global/util/GeometryUtils.java
+++ b/src/main/java/com/ocean/piuda/global/util/GeometryUtils.java
@@ -1,0 +1,21 @@
+package com.ocean.piuda.global.util;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+public class GeometryUtils {
+    // SRID 4326 (WGS84)
+    private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    /**
+     * 좌표를 받아 Point 객체 생성
+     * GIS 표준에 따라 (Longitude, Latitude) 순서로 입력받습니다.
+     * @param longitude 경도 (X)
+     * @param latitude  위도 (Y)
+     */
+    public static Point createPoint(double longitude, double latitude) {
+        return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+    }
+}


### PR DESCRIPTION
## 💡 개요 (Summary)
기존 Double 타입(lat, lon)으로 관리되던 ProjectArea의 좌표 데이터를 **PostGIS 기반의 공간 데이터 타입(Geometry(Point))** 으로 전환하고, 이를 활용한 4가지 핵심 공간 검색 API(Nearby, BBox, Nearest, Stats)를 구현했습니다.

이 작업은 전사적 GIS 아키텍처 고도화의 첫 단계로, 대용량 좌표 데이터에 대한 공간 쿼리 성능을 최적화하고 향후 프로젝트 내 모든 위치 기반 데이터의 표준을 수립하는 데 목적이 있습니다.


## 📝 작업 내용 (Key Changes)
### 1. PostGIS 및 의존성 설정
### 2. Entity 리팩토링
- **타입 변경:** `Double lat, lon` → `Point location` (SRID 4326)
- **캡슐화:** 외부(DTO)에서는 기존 API 스펙(Double lat/lon)을 유지하도록 Entity 내부에 변환 로직 캡슐화 (JTS 의존성 격리)
- **좌표 순서 표준화:** GIS 표준인 `(Longitude, Latitude)` 순서로 `GeometryUtils` 유틸리티 통일

### 3. Repository 공간 쿼리 구현 ( JPA Native Query, PostGIS 함수 활용 )
- **반경 검색:** `ST_DWithin` (Meter 단위 정확도 보장)
- **영역 검색(BBox):** `ST_MakeEnvelope` 및 `&&` 연산자 (인덱스 활용)
- **최근접 이웃(KNN):** `<->` 연산자 (거리 정렬 최적화)
- **통계 집계:** Interface Projection(`AreaStatProjection`)을 도입하여 Native Query 결과를 안전하게 매핑

## 🛠️ 기술적 의사결정 (Technical Decisions)
- **공간 쿼리 성능 최적화 (Index-Aware Query):**
    - **반경 검색:** 인덱스를 타지 않는 단순 거리 계산(`ST_Distance < radius`) 대신, 공간 인덱스(GIST)를 효율적으로 활용하는 **`ST_DWithin`** 함수를 사용하여 조회 성능을 최적화했습니다.
    - **KNN(최근접) 검색:** 정렬 부하가 큰 `ORDER BY ST_Distance` 방식 대신, PostGIS 전용 거리 정렬 연산자(**`<->`**)를 도입하여 대용량 데이터에서도 빠르게 근접 이웃을 탐색하도록 구현했습니다.

- **좌표계 및 거리 계산 전략:**
    - DB 저장은 전 세계 표준인 **WGS84 (SRID 4326)** 좌표계를 따르는 `Geometry` 타입을 사용하여 Mapbox 등 외부 지도 API와의 호환성을 확보했습니다.
    - 실제 거리 계산 시에는 `::geography` 캐스팅을 통해 지구 곡률을 반영한 **정확한 미터(m) 단위** 계산이 수행되도록 처리했습니다.

- **JPA 한계 극복 및 DTO 매핑:**
    - PostGIS의 특수 연산자(`<->`) 및 형변환(`CAST`)을 정밀하게 제어하기 위해 JPQL 대신 **Native Query**를 채택했습니다.
    - Native Query의 집계 결과(Count, Sum, Avg) 매핑 시 발생하는 런타임 오버헤드와 에러(`ConverterNotFound`)를 방지하기 위해 **Spring Data JPA Interface Projection**(`AreaStatProjection`) 패턴을 적용했습니다.

- **Entity-DTO 분리 (캡슐화):**
    - `ProjectArea` 엔티티 내부 구현이 변경(Point 타입)되더라도, API 계층(DTO)은 기존의 `Double lat/lon` 포맷을 유지하도록 Entity 내부에 변환 로직을 캡슐화하여 클라이언트 영향도를 0으로 줄였습니다.


## 📅 TODO (Next Steps)
- [ ] **전 도메인 PostGIS 확대 적용:** 현재 `lat`/`lon`으로 운영 중인 `Submission`(활동 제출), `Environment`(해양 환경 관측소), `DivePoint`(다이빙 포인트) 등 모든 도메인을 `Geometry` 타입으로 리팩토링.
- [ ] **대용량 집계 최적화 (DuckDB 도입):** 향후 데이터 증가에 대비하여, 단순 조회는 PostGIS가 담당하고 복잡한 공간 통계 및 분석 쿼리(OLAP)는 **DuckDB**를 도입하여 처리 성능 최적화 예정.

## 🔗 Related Issue
- #24 
