### PR TITLE
feat : 관리자 리포트 초안 생성 API 추가 Closes #27

### DIFF
--- a/project_context.txt
+++ b/project_context.txt
@@ -6323,6 +6323,7 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\controller\DashboardControl
 package com.ocean.piuda.dashboard.controller;
 
 import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
+import com.ocean.piuda.dashboard.dto.response.AreaMarkerResponse;
 import com.ocean.piuda.dashboard.dto.response.AreaStatResponse;
 import com.ocean.piuda.dashboard.service.DashboardQueryService;
 import com.ocean.piuda.global.api.dto.ApiData;
@@ -6342,14 +6343,32 @@ public class DashboardController {
 
     private final DashboardQueryService dashboardQueryService;
 
+    // 1. 상세 데이터 API
     @GetMapping("/areas/{id}")
     @Operation(summary = "작업 영역 상세 조회", description = "ID 기반으로 작업 영역의 상세 데이터(성장률, 수질 등)를 조회합니다.")
     public ApiData<AreaDetailResponse> getAreaDetail(@PathVariable Long id) {
         return ApiData.ok(dashboardQueryService.getAreaDetail(id));
     }
 
+    /**
+     * @deprecated
+     *   - 실제 화면 구현에서는 마커 클릭 시 ID 기반 단건 상세 조회만 사용하고 있어, 반경 기준 상세 리스트는 필요하지 않아 미사용 상태입니다.
+     *   - 설계 의도: 특정 좌표/반경 기준으로 여러 작업 영역의 '상세 데이터'를 한 번에 조회하는 분석/리포트 용도.
+     *   - 향후 관리자용 리포트/분석 화면 등에서 재활용 가능성을 고려해 일단 보존합니다.
+     */
+    @Deprecated
     @GetMapping("/areas/nearby")
-    @Operation(summary = "반경 기반 검색", description = "중심 좌표와 반경(km)으로 작업 영역을 검색합니다.")
+    @Operation(
+            summary = "[Deprecated] 반경 기반 작업 영역 상세 검색",
+            description = """
+                설계 의도: 중심 좌표와 반경(km) 기준으로 여러 작업 영역의 '상세 데이터'를 한 번에 조회
+                                
+                실제 구현에서는 영역별 상세는 ID 기반 단건 조회로 충분하여, 
+                상세 데이터는 마커 클릭 시 /areas/{id}로 개별 조회하면 충분하다고 판단되어 미사용 상태입니다.
+                향후 다른 분석/관리 도메인에서 재활용 가능성을 고려해 보존합니다.                
+                """,
+            deprecated = true
+    )
     public ApiData<List<AreaDetailResponse>> getNearby(
             @Parameter(description = "위도") @RequestParam Double lat,
             @Parameter(description = "경도") @RequestParam Double lon,
@@ -6357,16 +6376,49 @@ public class DashboardController {
         return ApiData.ok(dashboardQueryService.getNearbyAreas(lat, lon, radius));
     }
 
+    /**
+     * @deprecated
+     *   - 실제 구현에서는 뷰포트 기준으론 마커용 경량 데이터만 필요하고, 상세 데이터는 마커 클릭 시 /areas/{id}로 개별 조회하면 충분하다고 판단되어 미사용 상태입니다.
+     *   - 설계 의도 : 지도 뷰포트(BBox)에 포함된 모든 작업 영역의 '상세 데이터'를 한 번에 조회.
+     *   - 향후 다른 분석/관리 도메인에서 재활용 가능성을 고려해 보존합니다.
+     */
+    @Deprecated
     @GetMapping("/areas/bbox")
-    @Operation(summary = "뷰포트(BBox) 검색", description = "지도 화면 영역(Min/Max LatLon) 내의 데이터만 조회합니다.")
+    @Operation(
+            summary = "[Deprecated] 뷰포트(BBox) 내 작업 영역 상세 검색",
+            description = """
+                설계 의도 : 지도 뷰포트(BBox)에 포함된 모든 작업 영역의 '상세 데이터'를 한 번에 조회.
+                
+                실제 구현에서는 뷰포트 기준으론 마커용 경량 데이터만 필요하고, 
+                상세 데이터는 마커 클릭 시 /areas/{id}로 개별 조회하면 충분하다고 판단되어 미사용 상태입니다.
+                향후 다른 분석/관리 도메인에서 재활용 가능성을 고려해 보존합니다.                
+                """,
+            deprecated = true
+    )
     public ApiData<List<AreaDetailResponse>> getBBox(
             @RequestParam Double minLat, @RequestParam Double minLon,
             @RequestParam Double maxLat, @RequestParam Double maxLon) {
         return ApiData.ok(dashboardQueryService.getAreasInBBox(minLat, minLon, maxLat, maxLon));
     }
 
+    /**
+     * @deprecated
+     *   - 실제 UX에서는 리스트/지도에는 요약 정보만 보여주고, 상세는 클릭 시 단건 조회하는 방식으로 충분해 이 API는 사용하지 않게 되었습니다.
+     *   - 초기 설계 의도: "내 위치에서 가장 가까운 N개 작업 영역의 상세 데이터"를 한 번에 조회하는 기능.
+     *   - 다만 KNN 기반 상세 리스트가 필요한 별도 화면(예: 관리자 분석 페이지 등)이 생길 수 있어 보존합니다.
+     */
+    @Deprecated
     @GetMapping("/areas/nearest")
-    @Operation(summary = "가장 가까운 영역 찾기 (KNN)", description = "내 위치에서 가장 가까운 N개의 작업 영역을 찾습니다.")
+    @Operation(
+            summary = "[Deprecated] 가장 가까운 작업 영역 상세 검색",
+            description = """
+                설계 의도: "내 위치에서 가장 가까운 N개 작업 영역의 상세 데이터"를 한 번에 조회하는 기능.
+               
+                실제 UX에서는 상세는 클릭 시 단건 조회하는 방식으로 충분해 이 API는 사용하지 않습니다.
+                잠재적 재활용(예: 관리자/분석 화면)을 위해 보존합니다.
+                """,
+            deprecated = true
+    )
     public ApiData<List<AreaDetailResponse>> getNearest(
             @RequestParam Double lat, @RequestParam Double lon,
             @RequestParam(defaultValue = "3") Integer limit) {
@@ -6380,6 +6432,67 @@ public class DashboardController {
             @RequestParam(defaultValue = "10.0") Double radius) {
         return ApiData.ok(dashboardQueryService.getNearbyStats(lat, lon, radius));
     }
+
+    // 2. 지도 마커 전용 API
+
+    @GetMapping("/markers/bbox")
+    @Operation(
+            summary = "지도 뷰포트 내 마커 목록",
+            description = """
+                현재 지도 화면(BBox)에 포함된 작업 영역의 '마커용 요약 정보'를 조회합니다.
+                - 상세 데이터(시계열, 수질, 생물다양성 등)는 포함하지 않습니다.
+                - 마커 클릭 시에는 /api/dashboard/areas/{id} API로 상세 정보를 조회하는 패턴을 권장합니다.
+                """
+    )
+    public ApiData<List<AreaMarkerResponse>> getMarkersInBBox(
+            @Parameter(description = "최소 위도 (south)") @RequestParam Double minLat,
+            @Parameter(description = "최소 경도 (west)") @RequestParam Double minLon,
+            @Parameter(description = "최대 위도 (north)") @RequestParam Double maxLat,
+            @Parameter(description = "최대 경도 (east)") @RequestParam Double maxLon
+    ) {
+        return ApiData.ok(
+                dashboardQueryService.getMarkersInBBox(minLat, minLon, maxLat, maxLon)
+        );
+    }
+
+    @GetMapping("/markers/nearby")
+    @Operation(
+            summary = "반경 내 마커 목록",
+            description = """
+                중심 좌표와 반경(km)으로 주변 작업 영역의 '마커용 요약 정보'를 조회합니다.
+                - 지도/리스트 표시용으로 설계된 경량 응답입니다.
+                - 상세 데이터가 필요하면 /api/dashboard/areas/{id} API를 함께 사용하세요.
+                """
+    )
+    public ApiData<List<AreaMarkerResponse>> getNearbyMarkers(
+            @Parameter(description = "위도") @RequestParam Double lat,
+            @Parameter(description = "경도") @RequestParam Double lon,
+            @Parameter(description = "반경(km), 기본값 5.0") @RequestParam(defaultValue = "5.0") Double radius
+    ) {
+        return ApiData.ok(
+                dashboardQueryService.getNearbyMarkers(lat, lon, radius)
+        );
+    }
+
+    @GetMapping("/markers/nearest")
+    @Operation(
+            summary = "가장 가까운 마커 목록 (KNN)",
+            description = """
+                내 위치에서 가장 가까운 N개의 작업 영역을 KNN(Nearest Neighbor) 순으로 조회합니다.
+                - 응답은 지도/리스트 표시용 '마커 요약 데이터'만 포함합니다.
+                - 마커 클릭 시 /api/dashboard/areas/{id}로 상세 정보를 조회하는 패턴을 권장합니다.
+                """
+    )
+    public ApiData<List<AreaMarkerResponse>> getNearestMarkers(
+            @Parameter(description = "위도") @RequestParam Double lat,
+            @Parameter(description = "경도") @RequestParam Double lon,
+            @Parameter(description = "가져올 마커 개수, 기본값 3") @RequestParam(defaultValue = "3") Integer limit
+    ) {
+        return ApiData.ok(
+                dashboardQueryService.getNearestMarkers(lat, lon, limit)
+        );
+    }
+
 }
 
 
@@ -6461,6 +6574,45 @@ public class AreaDetailResponse {
                         .map(m -> MediaDto.builder().date(m.getRecordDate()).url(m.getMediaUrl()).caption(m.getCaption()).build()).toList())
                 .build();
     }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaMarkerResponse.java
+================================================================================
+
+package com.ocean.piuda.dashboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+/**
+ * 지도 마커용 요약 DTO
+ * - 상세 데이터 없이, 지도/리스트에 필요한 필드만 포함
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+public class AreaMarkerResponse {
+
+    private Long id;
+    private String name;
+
+    private Double lat;
+    private Double lon;
+
+    private LocalDate startDate;
+    private Double depth;
+    private Double areaSize;
+
+    /** 서식지 한글 설명 (예: "암반리프") */
+    private String habitat;
+
+    /** 프로젝트 단계 한글 설명 (예: "이식 완료") */
+    private String stage;
 }
 
 
@@ -7059,6 +7211,7 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\ProjectAreaRepos
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.ProjectArea;
+import com.ocean.piuda.dashboard.repository.projection.AreaMarkerProjection;
 import com.ocean.piuda.dashboard.repository.projection.AreaStatProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -7070,7 +7223,13 @@ import java.util.List;
 @Repository
 public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> {
 
-    // 1. 반경 기반 주변 검색 (Nearby)
+    // 1. 상세 엔티티 조회용 공간쿼리 (Deprecated / 현재 미사용)
+    /**
+     * @deprecated
+     *   - 현재 서비스 플로우에서는 사용하지 않습니다.
+     *   - 잠재적 재활용(예: 관리자/분석 화면)을 위해 보존합니다.
+     */
+    @Deprecated
     @Query(value = """
         SELECT * FROM project_areas p
         WHERE ST_DWithin(
@@ -7085,7 +7244,12 @@ public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> 
             @Param("radiusInMeters") double radiusInMeters
     );
 
-    // 2. 뷰포트 영역 조회 (BBox)
+    /**
+     * @deprecated
+     *   - 현재 서비스 플로우에서는 사용하지 않습니다.
+     *   - 잠재적 재활용을 위해 보존합니다.
+     */
+    @Deprecated
     @Query(value = """
         SELECT * FROM project_areas p
         WHERE p.location && ST_MakeEnvelope(:minLon, :minLat, :maxLon, :maxLat, 4326)
@@ -7095,7 +7259,12 @@ public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> 
             @Param("maxLat") double maxLat, @Param("maxLon") double maxLon
     );
 
-    // 3. 가장 가까운 N개 찾기 (Nearest - KNN)
+    /**
+     * @deprecated
+     *   - 현재 서비스 플로우에서는 사용하지 않습니다.
+     *   - 잠재적 재활용을 위해 보존합니다.
+     */
+    @Deprecated
     @Query(value = """
         SELECT * FROM project_areas p
         ORDER BY p.location <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)
@@ -7125,6 +7294,115 @@ public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> 
             @Param("lon") double lon,
             @Param("radiusInMeters") double radiusInMeters
     );
+
+    // 5. 지도 마커용 경량 쿼리들
+
+    /**
+     * 지도 뷰포트(BBox) 내 마커 목록
+     * - 상세 데이터 없이, 마커/리스트 표시용 핵심 필드만 조회
+     */
+    @Query(value = """
+        SELECT 
+            p.area_id        AS id,
+            p.name           AS name,
+            ST_Y(p.location) AS lat,
+            ST_X(p.location) AS lon,
+            p.start_date     AS startDate,
+            p.depth          AS depth,
+            p.area_size      AS areaSize,
+            p.habitat        AS habitat,
+            p.status         AS status
+        FROM project_areas p
+        WHERE p.location && ST_MakeEnvelope(:minLon, :minLat, :maxLon, :maxLat, 4326)
+        """, nativeQuery = true)
+    List<AreaMarkerProjection> findMarkersWithinBBox(
+            @Param("minLat") double minLat,
+            @Param("minLon") double minLon,
+            @Param("maxLat") double maxLat,
+            @Param("maxLon") double maxLon
+    );
+
+    /**
+     * 중심 좌표와 반경(미터) 기준 마커 목록
+     * - 지도/리스트에서 주변 마커를 표시할 때 사용
+     */
+    @Query(value = """
+        SELECT 
+            p.area_id        AS id,
+            p.name           AS name,
+            ST_Y(p.location) AS lat,
+            ST_X(p.location) AS lon,
+            p.start_date     AS startDate,
+            p.depth          AS depth,
+            p.area_size      AS areaSize,
+            p.habitat        AS habitat,
+            p.status         AS status
+        FROM project_areas p
+        WHERE ST_DWithin(
+            CAST(p.location AS geography),
+            CAST(ST_SetSRID(ST_MakePoint(:lon, :lat), 4326) AS geography),
+            :radiusInMeters
+        )
+        """, nativeQuery = true)
+    List<AreaMarkerProjection> findMarkersNearby(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("radiusInMeters") double radiusInMeters
+    );
+
+
+    /**
+     * KNN 기반 가장 가까운 N개 마커 목록
+     * - 거리순(가까운 순)으로 정렬된 마커 요약 데이터를 반환합니다.
+     */
+    @Query(value = """
+        SELECT 
+            p.area_id        AS id,
+            p.name           AS name,
+            ST_Y(p.location) AS lat,
+            ST_X(p.location) AS lon,
+            p.start_date     AS startDate,
+            p.depth          AS depth,
+            p.area_size      AS areaSize,
+            p.habitat        AS habitat,
+            p.status         AS status
+        FROM project_areas p
+        ORDER BY p.location <-> ST_SetSRID(ST_MakePoint(:lon, :lat), 4326)
+        LIMIT :limitCount
+        """, nativeQuery = true)
+    List<AreaMarkerProjection> findNearestMarkers(
+            @Param("lat") double lat,
+            @Param("lon") double lon,
+            @Param("limitCount") int limitCount
+    );
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AreaMarkerProjection.java
+================================================================================
+
+package com.ocean.piuda.dashboard.repository.projection;
+
+import java.time.LocalDate;
+
+/**
+ * 지도 마커 쿼리용 Projection
+ * - 네이티브 쿼리 SELECT 컬럼 alias 와 이름을 맞춰야 함
+ */
+public interface AreaMarkerProjection {
+    Long getId();
+    String getName();
+
+    Double getLat();
+    Double getLon();
+
+    LocalDate getStartDate();
+    Double getDepth();
+    Double getAreaSize();
+
+    String getHabitat(); // DB에 저장된 Enum String (예: "ROCKY_REEF")
+    String getStatus();  // DB에 저장된 Enum String (예: "TRANSPLANT_COMPLETED")
 }
 
 
@@ -7148,9 +7426,13 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardQueryServi
 package com.ocean.piuda.dashboard.service;
 
 import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
+import com.ocean.piuda.dashboard.dto.response.AreaMarkerResponse;
 import com.ocean.piuda.dashboard.dto.response.AreaStatResponse;
 import com.ocean.piuda.dashboard.entity.ProjectArea;
+import com.ocean.piuda.dashboard.enums.HabitatType;
+import com.ocean.piuda.dashboard.enums.ProjectStatus;
 import com.ocean.piuda.dashboard.repository.ProjectAreaRepository;
+import com.ocean.piuda.dashboard.repository.projection.AreaMarkerProjection;
 import com.ocean.piuda.dashboard.repository.projection.AreaStatProjection;
 import com.ocean.piuda.global.api.exception.BusinessException;
 import com.ocean.piuda.global.api.exception.ExceptionType;
@@ -7167,13 +7449,19 @@ public class DashboardQueryService {
 
     private final ProjectAreaRepository projectAreaRepository;
 
+    // 1. 상세 조회
     public AreaDetailResponse getAreaDetail(Long id) {
         ProjectArea area = projectAreaRepository.findById(id)
                 .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
         return AreaDetailResponse.fromEntity(area);
     }
 
-    // 1. 반경 검색
+    /**
+     * @deprecated
+     *   - 여러 작업 영역의 '상세 데이터'를 반경 기준으로 한 번에 조회하기 위한 메서드입니다.
+     *   - 현재 서비스 플로우에서는 사용하지 않으며,잠재적 재활용을 위해 보존합니다.
+     */
+    @Deprecated
     public List<AreaDetailResponse> getNearbyAreas(Double lat, Double lon, Double radiusKm) {
         double radiusMeters = (radiusKm != null ? radiusKm : 5.0) * 1000;
         return projectAreaRepository.findNearbyAreas(lat, lon, radiusMeters).stream()
@@ -7181,14 +7469,24 @@ public class DashboardQueryService {
                 .toList();
     }
 
-    // 2. 뷰포트 검색
+    /**
+     * @deprecated
+     *   - 뷰포트 기준으로 여러 작업 영역의 '상세 데이터'를 모두 내려주는 메서드입니다.
+     *   - 현재 서비스 플로우에서는 사용하지 않으며,잠재적 재활용을 위해 보존합니다.
+     */
+    @Deprecated
     public List<AreaDetailResponse> getAreasInBBox(Double minLat, Double minLon, Double maxLat, Double maxLon) {
         return projectAreaRepository.findWithinBBox(minLat, minLon, maxLat, maxLon).stream()
                 .map(AreaDetailResponse::fromEntity)
                 .toList();
     }
 
-    // 3. 가장 가까운 N개
+    /**
+     * @deprecated
+     *   - "가장 가까운 작업 영역 목록의 상세 데이터"를 조회하기 위한 메서드입니다.
+     *   - 현재 서비스 플로우에서는 사용하지 않으며,잠재적 재활용을 위해 보존합니다.
+     */
+    @Deprecated
     public List<AreaDetailResponse> getNearestAreas(Double lat, Double lon, Integer limit) {
         int limitCount = (limit != null && limit > 0) ? limit : 3;
         return projectAreaRepository.findNearestAreas(lat, lon, limitCount).stream()
@@ -7196,7 +7494,7 @@ public class DashboardQueryService {
                 .toList();
     }
 
-    // 4. 통계 (Projection -> DTO)
+    // 1-4. 통계 (Projection -> DTO)
     public AreaStatResponse getNearbyStats(Double lat, Double lon, Double radiusKm) {
         double radiusMeters = (radiusKm != null ? radiusKm : 10.0) * 1000;
 
@@ -7208,6 +7506,99 @@ public class DashboardQueryService {
                 .avgDepth(proj.getAvgDepth() != null ? proj.getAvgDepth() : 0.0)
                 .build();
     }
+
+    // 2. 지도 마커용 경량 조회
+
+    /**
+     * 뷰포트(BBox) 내 마커 목록
+     * - 지도 뷰포트에 보이는 마커들만 요약 정보로 반환합니다.
+     * - 상세 데이터는 /areas/{id}로 별도 조회하는 패턴을 사용합니다.
+     */
+    public List<AreaMarkerResponse> getMarkersInBBox(
+            Double minLat, Double minLon,
+            Double maxLat, Double maxLon
+    ) {
+        List<AreaMarkerProjection> rows =
+                projectAreaRepository.findMarkersWithinBBox(minLat, minLon, maxLat, maxLon);
+
+        return rows.stream()
+                .map(this::toMarkerResponse)
+                .toList();
+    }
+
+    /**
+     * 반경 기반 마커 목록
+     * - 중심 좌표 + 반경 기준으로 주변 마커를 조회합니다.
+     * - 상세 데이터가 필요할 때는 getAreaDetail(id)와 조합해서 사용하세요.
+     */
+    public List<AreaMarkerResponse> getNearbyMarkers(
+            Double lat, Double lon,
+            Double radiusKm
+    ) {
+        double radiusMeters = (radiusKm != null ? radiusKm : 5.0) * 1000;
+
+        List<AreaMarkerProjection> rows =
+                projectAreaRepository.findMarkersNearby(lat, lon, radiusMeters);
+
+        return rows.stream()
+                .map(this::toMarkerResponse)
+                .toList();
+    }
+
+    /**
+     * KNN 기반 가장 가까운 N개 마커 목록
+     * - 주어진 좌표에서 가장 가까운 작업 영역들을 거리순으로 반환합니다.
+     * - 지도에서 "내 주변" 리스트/마커를 보여줄 때 유용합니다.
+     */
+    public List<AreaMarkerResponse> getNearestMarkers(
+            Double lat, Double lon,
+            Integer limit
+    ) {
+        int limitCount = (limit != null && limit > 0) ? limit : 3;
+
+        List<AreaMarkerProjection> rows =
+                projectAreaRepository.findNearestMarkers(lat, lon, limitCount);
+
+        return rows.stream()
+                .map(this::toMarkerResponse)
+                .toList();
+    }
+
+    // 내부 변환 로직
+    private AreaMarkerResponse toMarkerResponse(AreaMarkerProjection p) {
+        String habitatDesc = null;
+        if (p.getHabitat() != null) {
+            try {
+                habitatDesc = HabitatType.valueOf(p.getHabitat()).getDescription();
+            } catch (IllegalArgumentException e) {
+                // enum 매칭 실패 시, 원본 값을 그대로 사용
+                habitatDesc = p.getHabitat();
+            }
+        }
+
+        String stageDesc = null;
+        if (p.getStatus() != null) {
+            try {
+                stageDesc = ProjectStatus.valueOf(p.getStatus()).getDescription();
+            } catch (IllegalArgumentException e) {
+                stageDesc = p.getStatus();
+            }
+        }
+
+        return AreaMarkerResponse.builder()
+                .id(p.getId())
+                .name(p.getName())
+                .lat(p.getLat())
+                .lon(p.getLon())
+                .startDate(p.getStartDate())
+                .depth(p.getDepth())
+                .areaSize(p.getAreaSize())
+                .habitat(habitatDesc)
+                .stage(stageDesc)
+                .build();
+    }
+
+
 }
 
 

--- a/src/main/java/com/ocean/piuda/admin/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/admin/ProjectExporter.java
@@ -1,0 +1,140 @@
+package com.ocean.piuda.admin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n" + "=".repeat(80) + "\n");
+            writer.write("File Path: " + file.toString() + "\n");
+            writer.write("=".repeat(80) + "\n\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ocean/piuda/admin/project_context.txt
+++ b/src/main/java/com/ocean/piuda/admin/project_context.txt
@@ -1,0 +1,3665 @@
+
+================================================================================
+File Path: .\common\enums\ActivityType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum ActivityType {
+    TRANSPLANT,          // 이식
+    TRASH_COLLECTION,    // 폐기물수거
+    RESEARCH,            // 연구
+    MONITORING,          // 모니터링
+    URCHIN_REMOVAL,
+    OTHER                // 기타
+}
+
+
+================================================================================
+File Path: .\common\enums\AuditAction.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum AuditAction {
+    SUBMITTED,  // 제출됨
+    APPROVED,   // 승인
+    REJECTED,   // 반려
+    DELETED,    // 삭제
+    COMMENT     // 코멘트
+}
+
+
+================================================================================
+File Path: .\common\enums\CurrentState.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum CurrentState {
+    LOW,     // 약
+    MEDIUM,  // 중
+    HIGH     // 강
+}
+
+
+================================================================================
+File Path: .\common\enums\ExportFormat.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum ExportFormat {
+    CSV,   // CSV 형식
+    XLSX   // Excel 형식
+}
+
+
+================================================================================
+File Path: .\common\enums\ExportStatus.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum ExportStatus {
+    PROCESSING,  // 처리 중
+    READY,       // 완료
+    FAILED       // 실패
+}
+
+
+================================================================================
+File Path: .\common\enums\HealthGrade.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum HealthGrade {
+    A, B, C, D
+}
+
+
+================================================================================
+File Path: .\common\enums\ParticipantRole.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum ParticipantRole {
+    CITIZEN_DIVER,    // 시민다이버
+    RESEARCHER,       // 연구자
+    LOCAL_MANAGER,    // 관계자
+    OTHER             // 기타
+}
+
+
+================================================================================
+File Path: .\common\enums\SubmissionStatus.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum SubmissionStatus {
+    PENDING,    // 검수 대기
+    APPROVED,   // 승인
+    REJECTED,   // 반려
+    DELETED     // 삭제
+}
+
+
+================================================================================
+File Path: .\common\enums\Weather.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+public enum Weather {
+    SUNNY,   // 맑음
+    CLOUDY,  // 흐림
+    RAINY,   // 비
+    WINDY,   // 바람
+    OTHER    // 기타
+}
+
+
+================================================================================
+File Path: .\dashboard\controller\AdminDashboardController.java
+================================================================================
+
+package com.ocean.piuda.admin.dashboard.controller;
+
+import com.ocean.piuda.admin.dashboard.dto.AdminDashboardSummaryResponse;
+import com.ocean.piuda.admin.dashboard.service.AdminDashboardService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/admin/dashboard")
+@RequiredArgsConstructor
+@Tag(
+        name = "Admin Dashboard",
+        description = "관리자 대시보드 통계 API입니다. 전체 제출 현황 통계를 조회할 수 있습니다."
+)
+public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+    /**
+     * 대시보드 통계 조회
+     */
+    @GetMapping("/summary")
+    @Operation(summary = "대시보드 통계 조회", description = "전체 제출 현황 통계를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<AdminDashboardSummaryResponse> getDashboardSummary() {
+        AdminDashboardSummaryResponse summary = adminDashboardService.getDashboardSummary();
+        return ApiData.ok(summary);
+    }
+}
+
+
+================================================================================
+File Path: .\dashboard\dto\AdminDashboardSummaryResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.dashboard.dto;
+
+public record AdminDashboardSummaryResponse(
+        Long totalSubmissions,
+        Long pending,
+        Long approved,
+        Long rejected,
+        Long deleted
+) {
+    public static AdminDashboardSummaryResponse of(
+            long total,
+            long pending,
+            long approved,
+            long rejected,
+            long deleted
+    ) {
+        return new AdminDashboardSummaryResponse(total, pending, approved, rejected, deleted);
+    }
+}
+
+
+================================================================================
+File Path: .\dashboard\service\AdminDashboardService.java
+================================================================================
+
+package com.ocean.piuda.admin.dashboard.service;
+
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.dashboard.dto.AdminDashboardSummaryResponse;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class AdminDashboardService {
+
+    private final SubmissionRepository submissionRepository;
+
+    /**
+     * 대시보드 통계 조회
+     */
+    public AdminDashboardSummaryResponse getDashboardSummary() {
+        long total = submissionRepository.count();
+        long pending = submissionRepository.countByStatus(SubmissionStatus.PENDING);
+        long approved = submissionRepository.countByStatus(SubmissionStatus.APPROVED);
+        long rejected = submissionRepository.countByStatus(SubmissionStatus.REJECTED);
+        long deleted = submissionRepository.countByStatus(SubmissionStatus.DELETED);
+
+        return AdminDashboardSummaryResponse.of(total, pending, approved, rejected, deleted);
+    }
+}
+
+
+================================================================================
+File Path: .\export\controller\ExportController.java
+================================================================================
+
+package com.ocean.piuda.admin.export.controller;
+
+import com.ocean.piuda.admin.export.dto.request.ExportByIdsRequest;
+import com.ocean.piuda.admin.export.dto.request.ExportRequest;
+import com.ocean.piuda.admin.export.dto.response.ExportJobResponse;
+import com.ocean.piuda.admin.export.service.ExportService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import com.ocean.piuda.security.jwt.service.TokenUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/exports")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(
+        name = "Admin Export",
+        description = "제출 데이터 내보내기 API입니다. 승인된 데이터를 CSV 형식으로 내보내고 이력을 조회할 수 있습니다."
+)
+public class ExportController {
+
+    private final ExportService exportService;
+    private final TokenUserService tokenUserService;
+
+    @PostMapping("/download")
+    @Operation(summary = "데이터 내보내기 (CSV 다운로드)", description = "승인된 제출 데이터를 CSV 파일로 내보냅니다. 파일이 바로 다운로드됩니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "CSV 파일 다운로드 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 형식 오류 (format 누락 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ResponseEntity<byte[]> downloadExport(
+            @Valid @RequestBody ExportRequest request
+    ) {
+        byte[] csvBytes = exportService.generateExportFile(request);
+        String fileName = exportService.generateFileName(request.getFormat());
+        
+        try {
+            String requestedBy = tokenUserService.getCurrentUser().getEmail() != null 
+                    ? tokenUserService.getCurrentUser().getEmail() 
+                    : tokenUserService.getCurrentUser().getUsername();
+            exportService.saveExportHistory(request, requestedBy);
+        } catch (Exception e) {
+            log.warn("Export 이력 저장 실패: {}", e.getMessage());
+        }
+        
+        // Content-Type 설정 (CSV의 경우)
+        MediaType contentType = request.getFormat() == com.ocean.piuda.admin.common.enums.ExportFormat.CSV 
+                ? new MediaType("text", "csv", StandardCharsets.UTF_8)
+                : MediaType.APPLICATION_OCTET_STREAM;
+        
+        // Content-Disposition 헤더 설정 (한글 파일명 지원)
+        ContentDisposition contentDisposition = ContentDisposition.attachment()
+                .filename(fileName, StandardCharsets.UTF_8)
+                .build();
+        
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(contentType);
+        headers.setContentDisposition(contentDisposition);
+        headers.setContentLength(csvBytes.length);
+        headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
+        headers.add("Pragma", "no-cache");
+        headers.add("Expires", "0");
+        
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(csvBytes);
+    }
+
+    @GetMapping
+    @Operation(summary = "내보내기 이력 조회", description = "내보내기 작업 이력을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<List<ExportJobResponse>> getExportHistory() {
+        List<ExportJobResponse> history = exportService.getExportHistory();
+        return ApiData.ok(history);
+    }
+
+    @PostMapping("/download/by-ids")
+    @Operation(
+            summary = "데이터 내보내기 (IDs 기반 CSV 다운로드)",
+            description = "지정한 submission ids 목록을 CSV 파일로 내보냅니다. 승인된 데이터만 포함됩니다."
+    )
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "CSV 파일 다운로드 성공"),
+            @ApiResponse(responseCode = "400", description = "요청 형식 오류 (format/ids 누락 등)"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ResponseEntity<byte[]> downloadExportByIds(
+            @Valid @RequestBody ExportByIdsRequest request
+    ) {
+        byte[] csvBytes = exportService.generateExportFileByIds(request);
+        String fileName = exportService.generateFileName(request.getFormat());
+
+        try {
+            String requestedBy = tokenUserService.getCurrentUser().getEmail() != null
+                    ? tokenUserService.getCurrentUser().getEmail()
+                    : tokenUserService.getCurrentUser().getUsername();
+            exportService.saveExportHistory(request, requestedBy);
+        } catch (Exception e) {
+            log.warn("Export(IDs) 이력 저장 실패: {}", e.getMessage());
+        }
+
+        MediaType contentType = request.getFormat() == com.ocean.piuda.admin.common.enums.ExportFormat.CSV
+                ? new MediaType("text", "csv", StandardCharsets.UTF_8)
+                : MediaType.APPLICATION_OCTET_STREAM;
+
+        ContentDisposition contentDisposition = ContentDisposition.attachment()
+                .filename(fileName, StandardCharsets.UTF_8)
+                .build();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(contentType);
+        headers.setContentDisposition(contentDisposition);
+        headers.setContentLength(csvBytes.length);
+        headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
+        headers.add("Pragma", "no-cache");
+        headers.add("Expires", "0");
+
+        return ResponseEntity.ok()
+                .headers(headers)
+                .body(csvBytes);
+    }
+
+}
+
+
+================================================================================
+File Path: .\export\dto\request\ExportByIdsRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.export.dto.request;
+
+import com.ocean.piuda.admin.common.enums.ExportFormat;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExportByIdsRequest {
+
+    @NotNull(message = "포맷은 필수입니다")
+    private ExportFormat format;
+
+    @NotEmpty(message = "ids는 1개 이상이어야 합니다")
+    private List<Long> ids;
+
+}
+
+
+================================================================================
+File Path: .\export\dto\request\ExportRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.export.dto.request;
+
+import com.ocean.piuda.admin.common.enums.ExportFormat;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExportRequest {
+    
+    @NotNull(message = "포맷은 필수입니다")
+    private ExportFormat format;
+    
+    private ExportFilters filters;
+    
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ExportFilters {
+        private LocalDate dateFrom;
+        private LocalDate dateTo;
+    }
+}
+
+
+================================================================================
+File Path: .\export\dto\response\ExportJobResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.export.dto.response;
+
+import com.ocean.piuda.admin.common.enums.ExportFormat;
+import com.ocean.piuda.admin.common.enums.ExportStatus;
+import com.ocean.piuda.admin.export.entity.ExportJob;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExportJobResponse {
+    private Long jobId;
+    private String requestedBy;
+    private ExportFormat format;
+    private ExportStatus status;
+    private String downloadUrl;
+    private LocalDateTime createdAt;
+    private LocalDateTime completedAt;
+    private String filtersJson;
+
+    public static ExportJobResponse from(ExportJob exportJob) {
+        return ExportJobResponse.builder()
+                .jobId(exportJob.getJobId())
+                .requestedBy(exportJob.getRequestedBy())
+                .format(exportJob.getFormat())
+                .status(exportJob.getStatus())
+                .downloadUrl(exportJob.getDownloadUrl())
+                .createdAt(exportJob.getCreatedAt())
+                .completedAt(exportJob.getCompletedAt())
+                .filtersJson(exportJob.getFiltersJson())
+                .build();
+    }
+}
+
+
+================================================================================
+File Path: .\export\entity\ExportJob.java
+================================================================================
+
+package com.ocean.piuda.admin.export.entity;
+
+import com.ocean.piuda.admin.common.enums.ExportFormat;
+import com.ocean.piuda.admin.common.enums.ExportStatus;
+import com.ocean.piuda.global.api.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "export_job")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ExportJob extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "job_id")
+    private Long jobId;
+
+    @Column(name = "requested_by", nullable = false, length = 100)
+    private String requestedBy;
+
+    @Column(name = "filters_json", columnDefinition = "TEXT")
+    private String filtersJson;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private ExportFormat format = ExportFormat.CSV;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private ExportStatus status = ExportStatus.PROCESSING;
+
+    @Column(name = "download_url", length = 500)
+    private String downloadUrl;
+
+    @Column(name = "completed_at")
+    private LocalDateTime completedAt;
+}
+
+
+================================================================================
+File Path: .\export\repository\ExportJobRepository.java
+================================================================================
+
+package com.ocean.piuda.admin.export.repository;
+
+import com.ocean.piuda.admin.export.entity.ExportJob;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface ExportJobRepository extends JpaRepository<ExportJob, Long> {
+    List<ExportJob> findAllByOrderByCreatedAtDesc();
+
+}
+
+
+================================================================================
+File Path: .\export\service\ExportService.java
+================================================================================
+
+package com.ocean.piuda.admin.export.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocean.piuda.admin.common.enums.ExportFormat;
+import com.ocean.piuda.admin.common.enums.ExportStatus;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.export.dto.request.ExportByIdsRequest;
+import com.ocean.piuda.admin.export.dto.request.ExportRequest;
+import com.ocean.piuda.admin.export.dto.response.ExportJobResponse;
+import com.ocean.piuda.admin.export.entity.ExportJob;
+import com.ocean.piuda.admin.export.repository.ExportJobRepository;
+import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExportService {
+
+    private final ExportJobRepository exportJobRepository;
+    private final SubmissionRepository submissionRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Transactional(readOnly = true)
+    public byte[] generateExportFile(ExportRequest request) {
+        try {
+            List<Submission> submissions = getSubmissionsForExport(request);
+            return generateCSV(submissions);
+        } catch (Exception e) {
+            log.error("Export 파일 생성 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ExceptionType.EXPORT_FAILED);
+        }
+    }
+
+    @Transactional
+    public ExportJobResponse saveExportHistory(ExportRequest request, String requestedBy) {
+        try {
+            String filtersJson = request.getFilters() != null 
+                    ? objectMapper.writeValueAsString(request.getFilters())
+                    : "{}";
+
+            ExportJob exportJob = ExportJob.builder()
+                    .requestedBy(requestedBy)
+                    .format(request.getFormat())
+                    .status(ExportStatus.READY)
+                    .filtersJson(filtersJson)
+                    .completedAt(LocalDateTime.now())
+                    .build();
+
+            ExportJob saved = exportJobRepository.save(exportJob);
+            return ExportJobResponse.from(saved);
+        } catch (Exception e) {
+            log.error("Export 이력 저장 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ExceptionType.EXPORT_FAILED);
+        }
+    }
+
+    private List<Submission> getSubmissionsForExport(ExportRequest request) {
+        try {
+            ExportRequest.ExportFilters filters = request.getFilters();
+
+            LocalDateTime startDate = filters != null && filters.getDateFrom() != null 
+                    ? filters.getDateFrom().atStartOfDay() 
+                    : null;
+            LocalDateTime endDate = filters != null && filters.getDateTo() != null 
+                    ? filters.getDateTo().atTime(23, 59, 59) 
+                    : null;
+
+            return submissionRepository.findWithFilters(
+                    null,
+                    SubmissionStatus.APPROVED,
+                    null,
+                    startDate,
+                    endDate,
+                    org.springframework.data.domain.Pageable.unpaged()
+            ).getContent();
+
+        } catch (Exception e) {
+            log.error("제출 데이터 조회 실패: {}", e.getMessage(), e);
+            return submissionRepository.findAll().stream()
+                    .filter(s -> s.getStatus() == SubmissionStatus.APPROVED)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    private byte[] generateCSV(List<Submission> submissions) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        // 1) UTF-8 BOM은 가장 먼저
+        baos.write(0xEF); baos.write(0xBB); baos.write(0xBF);
+
+        try (OutputStreamWriter writer = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
+            // 2) Excel 힌트 + CRLF
+            writer.write("sep=,\r\n");
+
+            // 3) 헤더 (CRLF)
+            writer.write("제출ID,현장명,활동유형,제출일,작성자,이메일,위도,경도,수심(m),수온(°C),시야(m),날씨,조류상태,참여인원,대표자명,역할,세부내용,수거량,활동후기,첨부파일수\r\n");
+
+            DateTimeFormatter dtf = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+            for (Submission submission : submissions) {
+                writer.write(submission.getSubmissionId() + ",");
+                writer.write(escapeCsv(submission.getSiteName()) + ",");
+                writer.write((submission.getActivityType() != null ? submission.getActivityType().name() : "") + ",");
+                writer.write((submission.getSubmittedAt() != null ? submission.getSubmittedAt().format(dtf) : "") + ",");
+                writer.write(escapeCsv(submission.getAuthorName()) + ",");
+                writer.write(escapeCsv(submission.getAuthorEmail() != null ? submission.getAuthorEmail() : "") + ",");
+
+                // 4) (핵심) 콤마를 항상 붙이도록 괄호 위치 수정
+                writer.write((submission.getLatitude()  != null ? submission.getLatitude().toString()  : "") + ",");
+                writer.write((submission.getLongitude() != null ? submission.getLongitude().toString() : "") + ",");
+
+                if (submission.getBasicEnv() != null) {
+                    writer.write((submission.getBasicEnv().getDepthM()      != null ? submission.getBasicEnv().getDepthM().toString()      : "") + ",");
+                    writer.write((submission.getBasicEnv().getWaterTempC()  != null ? submission.getBasicEnv().getWaterTempC().toString()  : "") + ",");
+                    writer.write((submission.getBasicEnv().getVisibilityM() != null ? submission.getBasicEnv().getVisibilityM().toString() : "") + ",");
+                    writer.write((submission.getBasicEnv().getWeather()     != null ? submission.getBasicEnv().getWeather().name()         : "") + ",");
+                    writer.write((submission.getBasicEnv().getCurrentState()!= null ? submission.getBasicEnv().getCurrentState().name()    : "") + ",");
+                } else {
+                    writer.write(",,,,,");
+                }
+
+                if (submission.getParticipants() != null) {
+                    writer.write((submission.getParticipants().getParticipantCount() != null ? submission.getParticipants().getParticipantCount().toString() : "") + ",");
+                    writer.write(escapeCsv(submission.getParticipants().getLeaderName() != null ? submission.getParticipants().getLeaderName() : "") + ",");
+                    writer.write((submission.getParticipants().getRole() != null ? submission.getParticipants().getRole().name() : "") + ",");
+                } else {
+                    writer.write(",,,");
+                }
+
+                if (submission.getActivity() != null) {
+                    writer.write(escapeCsv(submission.getActivity().getDetails() != null ? submission.getActivity().getDetails() : "") + ",");
+                    writer.write((submission.getActivity().getCollectionAmount() != null ? submission.getActivity().getCollectionAmount().toString() : "") + ",");
+                } else {
+                    writer.write(",,");
+                }
+
+                writer.write(escapeCsv(submission.getFeedbackText() != null ? submission.getFeedbackText() : "") + ",");
+                writer.write((submission.getAttachmentCount() != null ? submission.getAttachmentCount().toString() : ""));
+                writer.write("\r\n"); // 5) 각 행 끝은 CRLF
+            }
+
+            writer.flush();
+        }
+
+        return baos.toByteArray();
+    }
+
+    private String escapeCsv(String value) {
+        if (value == null) return "";
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    public String generateFileName(ExportFormat format) {
+        String extension = format == ExportFormat.CSV ? ".csv" : ".xlsx";
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        return String.format("submissions_export_%s%s", timestamp, extension);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ExportJobResponse> getExportHistory() {
+        return exportJobRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(ExportJobResponse::from)
+                .collect(Collectors.toList());
+    }
+
+
+    @Transactional(readOnly = true)
+    public byte[] generateExportFileByIds(ExportByIdsRequest request) {
+        try {
+            List<Submission> submissions = getSubmissionsForExportByIds(request.getIds());
+
+            // 요청한 ids 순서대로 정렬
+            Map<Long, Integer> order = new HashMap<>();
+            for (int i = 0; i < request.getIds().size(); i++) {
+                order.put(request.getIds().get(i), i);
+            }
+            submissions.sort(Comparator.comparingInt(s -> order.getOrDefault(s.getSubmissionId(), Integer.MAX_VALUE)));
+
+            return generateCSV(submissions);
+        } catch (Exception e) {
+            log.error("Export(IDs) 파일 생성 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ExceptionType.EXPORT_FAILED);
+        }
+    }
+
+    @Transactional
+    public ExportJobResponse saveExportHistory(ExportByIdsRequest request, String requestedBy) {
+        try {
+            String filtersJson = objectMapper.writeValueAsString(
+                    Map.of("ids", request.getIds())
+            );
+
+            ExportJob exportJob = ExportJob.builder()
+                    .requestedBy(requestedBy)
+                    .format(request.getFormat())
+                    .status(ExportStatus.READY)
+                    .filtersJson(filtersJson)
+                    .completedAt(LocalDateTime.now())
+                    .build();
+
+            ExportJob saved = exportJobRepository.save(exportJob);
+            return ExportJobResponse.from(saved);
+        } catch (Exception e) {
+            log.error("Export(IDs) 이력 저장 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ExceptionType.EXPORT_FAILED);
+        }
+    }
+
+    private List<Submission> getSubmissionsForExportByIds(List<Long> ids) {
+        if (ids == null || ids.isEmpty()) return List.of();
+        return submissionRepository.findAllByIdsAndStatusWithDetails(ids, SubmissionStatus.APPROVED);
+    }
+}
+
+
+================================================================================
+File Path: .\initializer\AdminUserInitializer.java
+================================================================================
+
+package com.ocean.piuda.admin.initializer;
+
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.user.entity.User;
+import com.ocean.piuda.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("!prod") // 프로덕션 환경에서는 실행되지 않음
+@Order(0) // SubmissionDataInitializer보다 먼저 실행
+public class AdminUserInitializer implements CommandLineRunner {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    private static final String ADMIN_USERNAME = "admin@admin.com";
+    private static final String ADMIN_PASSWORD = "password";
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        // 이미 Admin 계정이 있으면 생성하지 않음
+        if (userRepository.findByUsername(ADMIN_USERNAME).isPresent()) {
+            log.info("Admin 계정이 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        log.info("Admin 계정 초기화 시작...");
+
+        // Admin 계정 생성
+        User adminUser = User.builder()
+                .username(ADMIN_USERNAME)
+                .password(passwordEncoder.encode(ADMIN_PASSWORD))
+                .role(Role.ADMIN)
+                .email(ADMIN_USERNAME)
+                .nickname("관리자")
+                .build();
+
+        userRepository.save(adminUser);
+        log.info("Admin 계정 생성 완료 - Username: {}, Role: {}", ADMIN_USERNAME, Role.ADMIN);
+    }
+}
+
+
+================================================================================
+File Path: .\ProjectExporter.java
+================================================================================
+
+package com.ocean.piuda.admin;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n" + "=".repeat(80) + "\n");
+            writer.write("File Path: " + file.toString() + "\n");
+            writer.write("=".repeat(80) + "\n\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+================================================================================
+File Path: .\report\controller\ReportDraftController.java
+================================================================================
+
+package com.ocean.piuda.admin.report.controller;
+
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByIdsRequest;
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByPeriodRequest;
+import com.ocean.piuda.admin.report.dto.response.ReportDraftResponse;
+import com.ocean.piuda.admin.report.service.ReportDraftService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/reports/drafts")
+@RequiredArgsConstructor
+@Tag(name = "Admin Report Draft", description = "선택한 해양 활동 제출물로 리포트 초안을 Gemini로 생성합니다.")
+public class ReportDraftController {
+
+    private final ReportDraftService reportDraftService;
+
+    @PostMapping("/by-ids")
+    @Operation(
+            summary = "리포트 초안 생성 (IDs 기반)",
+            description = "선택한 submission ids(기본: APPROVED)를 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
+    )
+    public ApiData<ReportDraftResponse> byIds(@RequestBody @Valid ReportDraftByIdsRequest request) {
+        return ApiData.ok(reportDraftService.generateByIds(request));
+    }
+
+    @PostMapping("/by-period")
+    @Operation(
+            summary = "리포트 초안 생성 (기간 기반)",
+            description = "dateFrom~dateTo 기간(기본: APPROVED)을 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
+    )
+    public ApiData<ReportDraftResponse> byPeriod(@RequestBody @Valid ReportDraftByPeriodRequest request) {
+        return ApiData.ok(reportDraftService.generateByPeriod(request));
+    }
+}
+
+
+================================================================================
+File Path: .\report\dto\request\ReportDraftByIdsRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.report.dto.request;
+
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReportDraftByIdsRequest(
+        @NotEmpty(message = "ids는 1개 이상이어야 합니다")
+        List<Long> ids,
+
+        @NotNull(message = "reportType은 필수입니다")
+        ReportDraftType reportType,
+
+        String prompt
+) {}
+
+
+================================================================================
+File Path: .\report\dto\request\ReportDraftByPeriodRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.report.dto.request;
+
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record ReportDraftByPeriodRequest(
+        @NotNull(message = "dateFrom는 필수입니다")
+        LocalDate dateFrom,
+
+        @NotNull(message = "dateTo는 필수입니다")
+        LocalDate dateTo,
+
+        @NotNull(message = "reportType은 필수입니다")
+        ReportDraftType reportType,
+
+        String prompt
+) {}
+
+
+================================================================================
+File Path: .\report\dto\response\ReportDraftResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.report.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import lombok.Builder;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public record ReportDraftResponse(
+        List<Long> submissionIds,
+        List<Long> missingIds,
+
+        ReportDraftType reportType,
+
+        String internalDraft,
+        String externalNewsletter,
+        String externalInstagram,
+        String externalPublication,
+
+        GeminiMeta meta
+) {}
+
+
+================================================================================
+File Path: .\report\enums\ReportDraftType.java
+================================================================================
+
+package com.ocean.piuda.admin.report.enums;
+
+public enum ReportDraftType {
+    INTERNAL_DRAFT("internalDraft"),
+    EXTERNAL_NEWSLETTER("externalNewsletter"),
+    EXTERNAL_INSTAGRAM("externalInstagram"),
+    EXTERNAL_PUBLICATION("externalPublication");
+
+    private final String jsonKey;
+
+    ReportDraftType(String jsonKey) {
+        this.jsonKey = jsonKey;
+    }
+
+    public String jsonKey() {
+        return jsonKey;
+    }
+}
+
+
+================================================================================
+File Path: .\report\service\ReportDraftService.java
+================================================================================
+
+package com.ocean.piuda.admin.report.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByIdsRequest;
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByPeriodRequest;
+import com.ocean.piuda.admin.report.dto.response.ReportDraftResponse;
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import com.ocean.piuda.admin.report.util.ReportPromptBuilder;
+import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
+import com.ocean.piuda.ai.gemini.service.GeminiTextService;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReportDraftService {
+
+    private final GeminiTextService geminiTextService;
+    private final SubmissionRepository submissionRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${gemini.model.report:${gemini.model.text}}")
+    private String reportModel;
+
+    public ReportDraftResponse generateByIds(ReportDraftByIdsRequest request) {
+        List<Long> ids = distinctPreserveOrder(request.ids());
+        List<Submission> found =
+                submissionRepository.findAllByIdsAndStatusWithDetails(ids, SubmissionStatus.APPROVED);
+
+        // 요청 순서 보존 정렬
+        Map<Long, Integer> order = new HashMap<>();
+        for (int i = 0; i < ids.size(); i++) order.put(ids.get(i), i);
+        found.sort(Comparator.comparingInt(s -> order.getOrDefault(s.getSubmissionId(), Integer.MAX_VALUE)));
+
+        List<Long> foundIds = found.stream().map(Submission::getSubmissionId).toList();
+        List<Long> missing = ids.stream().filter(id -> !foundIds.contains(id)).toList();
+
+        return generate(found, ids, missing, request.prompt(), request.reportType());
+    }
+
+    public ReportDraftResponse generateByPeriod(ReportDraftByPeriodRequest request) {
+        LocalDateTime start = request.dateFrom().atStartOfDay();
+        LocalDateTime end = request.dateTo().atTime(23, 59, 59);
+
+        List<Submission> found =
+                submissionRepository.findAllByStatusAndSubmittedAtBetweenWithDetails(
+                        SubmissionStatus.APPROVED, start, end
+                );
+
+        List<Long> foundIds = found.stream().map(Submission::getSubmissionId).toList();
+        return generate(found, foundIds, List.of(), request.prompt(), request.reportType());
+    }
+
+    private ReportDraftResponse generate(
+            List<Submission> submissions,
+            List<Long> submissionIds,
+            List<Long> missingIds,
+            String extraPrompt,
+            ReportDraftType reportType
+    ) {
+        if (submissions == null || submissions.isEmpty()) {
+            throw new BusinessException(
+                    ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR,
+                    Map.of(
+                            "reason", "선택된 기간/IDs에 해당하는 APPROVED submission이 없습니다.",
+                            "missingIds", missingIds
+                    )
+            );
+        }
+        if (reportType == null) {
+            throw new BusinessException(
+                    ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR,
+                    Map.of("reason", "reportType은 필수입니다.")
+            );
+        }
+
+        // 너무 많으면 프롬프트 폭증 방지 (필요시 조정)
+        List<Submission> trimmed = submissions.size() > 50 ? submissions.subList(0, 50) : submissions;
+
+        String submissionsJson = toCompactJson(trimmed);
+
+        // ✅ 타입 1개만 출력하도록 프롬프트 구성
+        String prompt = ReportPromptBuilder.build(submissionsJson, extraPrompt, reportType);
+
+        GeminiResponse gemResp = geminiTextService.generateReportDraft(prompt);
+        String raw = gemResp.content();
+        GeminiMeta meta = gemResp.meta();
+        String cleaned = cleanupJson(raw);
+
+        // ✅ JSON에서 요청한 키 1개만 파싱
+        String content = "";
+        try {
+            JsonNode root = objectMapper.readTree(cleaned);
+            content = root.path(reportType.jsonKey()).asText("");
+        } catch (Exception e) {
+            log.warn("Gemini report JSON parse failed. raw={}", raw, e);
+            // 파싱 실패 시 raw를 그대로 반환(운영상 디버깅)
+            content = raw == null ? "" : raw;
+        }
+
+        // 실제 사용된 ids (trimmed 기준)
+        List<Long> usedIds = trimmed.stream().map(Submission::getSubmissionId).toList();
+
+        // ✅ 선택 타입에 맞는 필드만 채워서 반환
+        ReportDraftResponse.ReportDraftResponseBuilder builder = ReportDraftResponse.builder()
+                .submissionIds(usedIds)
+                .missingIds(missingIds)
+                .reportType(reportType)
+                .meta(meta);
+
+        switch (reportType) {
+            case INTERNAL_DRAFT -> builder.internalDraft(content);
+            case EXTERNAL_NEWSLETTER -> builder.externalNewsletter(content);
+            case EXTERNAL_INSTAGRAM -> builder.externalInstagram(content);
+            case EXTERNAL_PUBLICATION -> builder.externalPublication(content);
+        }
+
+        return builder.build();
+    }
+
+    private String toCompactJson(List<Submission> submissions) {
+        try {
+            List<Map<String, Object>> rows = submissions.stream()
+                    .map(this::toPromptRow)
+                    .collect(Collectors.toList());
+            return objectMapper.writeValueAsString(rows);
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ExceptionType.UNEXPECTED_SERVER_ERROR,
+                    Map.of("reason", "submissions JSON 변환 실패", "message", e.getMessage())
+            );
+        }
+    }
+
+    private Map<String, Object> toPromptRow(Submission s) {
+        Map<String, Object> m = new LinkedHashMap<>();
+
+        // ✅ 식별: 현장명 + 제출일시만 사용 (submissionId 제거)
+        m.put("siteName", s.getSiteName());
+        m.put("submittedAt", s.getSubmittedAt() != null ? s.getSubmittedAt().toString() : null);
+        m.put("activityType", s.getActivityType() != null ? s.getActivityType().name() : null);
+
+        // ✅ basicEnv: recordDate/startTime/endTime 제외, 환경 수치만 유지
+        if (s.getBasicEnv() != null) {
+            Map<String, Object> env = new LinkedHashMap<>();
+            env.put("waterTempC", s.getBasicEnv().getWaterTempC());
+            env.put("visibilityM", s.getBasicEnv().getVisibilityM());
+            env.put("depthM", s.getBasicEnv().getDepthM());
+            env.put("currentState", s.getBasicEnv().getCurrentState() != null ? s.getBasicEnv().getCurrentState().name() : null);
+            env.put("weather", s.getBasicEnv().getWeather() != null ? s.getBasicEnv().getWeather().name() : null);
+            m.put("basicEnv", env);
+        }
+
+        // ✅ participants 완전 제외
+
+        // ✅ activity: naturalReproduction / survival 포함
+        if (s.getActivity() != null) {
+            Map<String, Object> a = new LinkedHashMap<>();
+            a.put("type", s.getActivity().getType() != null ? s.getActivity().getType().name() : null);
+            a.put("details", truncate(s.getActivity().getDetails(), 600));
+            a.put("collectionAmount", s.getActivity().getCollectionAmount());
+            a.put("durationHours", s.getActivity().getDurationHours());
+            a.put("healthGrade", s.getActivity().getHealthGrade() != null ? s.getActivity().getHealthGrade().name() : null);
+            a.put("growthCm", s.getActivity().getGrowthCm());
+
+            if (s.getActivity().getNaturalReproduction() != null) {
+                Map<String, Object> nat = new LinkedHashMap<>();
+                nat.put("radiusM", s.getActivity().getNaturalReproduction().getRadiusM());
+                nat.put("numerator", s.getActivity().getNaturalReproduction().getNumerator());
+                nat.put("denominator", s.getActivity().getNaturalReproduction().getDenominator());
+                a.put("naturalReproduction", nat);
+            }
+
+            if (s.getActivity().getSurvival() != null) {
+                Map<String, Object> surv = new LinkedHashMap<>();
+                surv.put("dieCount", s.getActivity().getSurvival().getDieCount());
+                surv.put("totalCount", s.getActivity().getSurvival().getTotalCount());
+                a.put("survival", surv);
+            }
+
+            m.put("activity", a);
+        }
+
+        m.put("feedbackText", truncate(s.getFeedbackText(), 600));
+        return m;
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return null;
+        String t = s.trim();
+        if (t.length() <= max) return t;
+        return t.substring(0, max) + "…";
+    }
+
+    private static String cleanupJson(String raw) {
+        if (raw == null) return "";
+        String t = raw.trim();
+        // 혹시 모델이 코드펜스를 붙였을 때 제거
+        t = t.replaceAll("^```json\\s*", "").replaceAll("^```\\s*", "");
+        t = t.replaceAll("\\s*```$", "");
+        return t.trim();
+    }
+
+    private static List<Long> distinctPreserveOrder(List<Long> ids) {
+        if (ids == null) return List.of();
+        LinkedHashSet<Long> set = new LinkedHashSet<>(ids);
+        return new ArrayList<>(set);
+    }
+}
+
+
+================================================================================
+File Path: .\report\util\ReportPromptBuilder.java
+================================================================================
+
+package com.ocean.piuda.admin.report.util;
+
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+
+public class ReportPromptBuilder {
+
+    private ReportPromptBuilder() {}
+
+    public static String build(String submissionsJson, String extraPromptOrNull, ReportDraftType type) {
+        String extra = (extraPromptOrNull == null) ? "" : extraPromptOrNull.trim();
+        String key = type.jsonKey();
+
+        String guide = switch (type) {
+            case INTERNAL_DRAFT -> "- internalDraft: 기간/범위, 활동유형별 요약, 정량(수거량/이식수 등), 운영/이슈 중심.\n";
+            case EXTERNAL_NEWSLETTER -> "- externalNewsletter: 짧은 제목 + 2~4문단 + 하이라이트 bullet + CTA.\n";
+            case EXTERNAL_INSTAGRAM -> "- externalInstagram: 4~10줄 스토리텔링 + 핵심 bullet 2~4개 + 해시태그 8~15개.\n";
+            case EXTERNAL_PUBLICATION -> "- externalPublication: 제목/리드문/본문(소제목 가능) + 성과 요약.\n";
+        };
+
+        return """
+너는 해양 활동 기록 제출물(Submission)을 바탕으로 리포트 초안을 작성하는 전문 에디터다.
+
+[중요 원칙]
+- 아래에 제공된 JSON 데이터에 포함된 사실만 사용한다. 추측/날조 금지.
+- 데이터가 부족하면 "확인 필요" 또는 "기록 없음"으로 명시한다.
+- 외부홍보용(external*)에는 개인정보/민감정보를 포함하지 말 것:
+  - 이메일/연락처 금지
+  - 위도/경도 등 정확 좌표 금지(지역명 수준으로만)
+- 문서는 모두 한국어로 작성한다.
+- 결과는 반드시 "JSON만" 출력한다. 코드펜스( ``` ) 금지.
+- 아래에서 지정한 키 1개만 출력한다. 다른 키/설명/문장 절대 추가 금지.
+
+[데이터]
+%s
+
+[출력 JSON 스키마] (반드시 이 키 하나만)
+{ "%s": "요청된 유형의 마크다운 초안" }
+
+[작성 가이드]
+%s
+
+[추가 지시사항(있으면 반영)]
+%s
+""".formatted(submissionsJson, key, guide, extra.isBlank() ? "(없음)" : extra);
+    }
+}
+
+
+================================================================================
+File Path: .\submission\controller\SubmissionController.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.controller;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.submission.dto.request.*;
+import com.ocean.piuda.admin.submission.dto.response.*;
+import com.ocean.piuda.admin.submission.service.SubmissionCommandService;
+import com.ocean.piuda.admin.submission.service.SubmissionQueryService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import com.ocean.piuda.global.api.dto.PageResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/submissions")
+@RequiredArgsConstructor
+@Tag(
+        name = "Admin Submission",
+        description = "해양 활동 제출 데이터 관리 API입니다. 제출 데이터의 조회, 생성, 승인, 반려, 삭제 기능을 제공합니다."
+)
+public class SubmissionController {
+
+    private final SubmissionQueryService submissionQueryService;
+    private final SubmissionCommandService submissionCommandService;
+
+    /**
+     * 제출 데이터 생성
+     */
+    @PostMapping
+    @Operation(summary = "제출 데이터 생성", description = "Admin이 직접 제출 데이터를 생성합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "생성 성공"),
+            @ApiResponse(responseCode = "400", description = "필수 필드 누락 또는 형식 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<SubmissionDetailResponse> createSubmission(
+            @RequestBody @Valid CreateSubmissionRequest request
+    ) {
+        SubmissionDetailResponse response = submissionCommandService.createSubmission(request);
+        return ApiData.ok(response);
+    }
+
+    /**
+     * 제출 목록 조회
+     */
+    @GetMapping
+    @Operation(summary = "제출 목록 조회", description = "제출 목록을 페이지네이션과 함께 조회합니다. 검색, 필터링, 정렬을 지원합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<PageResponse<SubmissionListResponse>> getSubmissions(
+            @Parameter(description = "검색 키워드 (현장명, 작성자)") @RequestParam(required = false) String keyword,
+            @Parameter(description = "상태 필터 (PENDING, APPROVED, REJECTED, DELETED)") @RequestParam(required = false) SubmissionStatus status,
+            @Parameter(description = "활동 유형 필터 (TRANSPLANT, TRASH_COLLECTION, RESEARCH, MONITORING, OTHER)") @RequestParam(required = false) ActivityType activityType,
+            @Parameter(description = "시작 날짜 (ISO 8601 형식)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(description = "종료 날짜 (ISO 8601 형식)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기 (기본값: 20)") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "정렬 필드 (기본값: submittedAt)") @RequestParam(defaultValue = "submittedAt") String sortBy,
+            @Parameter(description = "정렬 방향 (ASC, DESC, 기본값: DESC)") @RequestParam(defaultValue = "DESC") String sortDir
+    ) {
+        Sort sort = Sort.by(Sort.Direction.fromString(sortDir), sortBy);
+        Pageable pageable = PageRequest.of(page, size, sort);
+        
+        PageResponse<SubmissionListResponse> result = submissionQueryService.getSubmissions(
+                keyword, status, activityType, startDate, endDate, pageable
+        );
+        
+        return ApiData.ok(result);
+    }
+
+    /**
+     * 제출 상세 조회
+     */
+    @GetMapping("/{submissionId}")
+    @Operation(summary = "제출 상세 조회", description = "특정 제출 데이터의 상세 정보를 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<SubmissionDetailResponse> getSubmissionDetail(
+            @Parameter(description = "제출 ID", required = true) @PathVariable Long submissionId) {
+        SubmissionDetailResponse response = submissionQueryService.getSubmissionDetail(submissionId);
+        return ApiData.ok(response);
+    }
+
+    /**
+     * 검수 로그 조회
+     */
+    @GetMapping("/{submissionId}/logs")
+    @Operation(summary = "검수 로그 조회", description = "특정 제출 데이터의 검수 이력을 조회합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "조회 성공"),
+            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<List<AuditLogResponse>> getSubmissionLogs(
+            @Parameter(description = "제출 ID", required = true) @PathVariable Long submissionId) {
+        List<AuditLogResponse> logs = submissionQueryService.getSubmissionLogs(submissionId);
+        return ApiData.ok(logs);
+    }
+
+    /**
+     * 단건 승인
+     */
+    @PostMapping("/{submissionId}/approve")
+    @Operation(summary = "단건 승인", description = "특정 제출 데이터를 승인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "승인 성공"),
+            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 승인/반려/삭제된 제출"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<SubmissionDetailResponse> approveSubmission(
+            @Parameter(description = "제출 ID", required = true) @PathVariable Long submissionId) {
+        SubmissionDetailResponse response = submissionCommandService.approveSubmission(submissionId);
+        return ApiData.ok(response);
+    }
+
+    /**
+     * 단건 반려
+     */
+    @PostMapping("/{submissionId}/reject")
+    @Operation(summary = "단건 반려", description = "특정 제출 데이터를 반려합니다. 반려 사유를 필수로 입력해야 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "반려 성공"),
+            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 승인/반려/삭제된 제출"),
+            @ApiResponse(responseCode = "422", description = "반려 사유가 공란"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<SubmissionDetailResponse> rejectSubmission(
+            @Parameter(description = "제출 ID", required = true) @PathVariable Long submissionId,
+            @RequestBody @Valid SingleRejectRequest request
+    ) {
+        SubmissionDetailResponse response = submissionCommandService.rejectSubmission(submissionId, request);
+        return ApiData.ok(response);
+    }
+
+    /**
+     * 단건 삭제
+     */
+    @DeleteMapping("/{submissionId}")
+    @Operation(summary = "단건 삭제", description = "특정 제출 데이터를 영구 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ResponseEntity<Void> deleteSubmission(
+            @Parameter(description = "제출 ID", required = true) @PathVariable Long submissionId,
+            @RequestBody(required = false) SingleDeleteRequest request
+    ) {
+        if (request == null) {
+            request = new SingleDeleteRequest(null);
+        }
+        submissionCommandService.deleteSubmission(submissionId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * 일괄 승인
+     */
+    @PostMapping("/bulk/approve")
+    @Operation(summary = "일괄 승인", description = "여러 제출 데이터를 한 번에 승인합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일괄 승인 완료"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<BulkApproveResponse> bulkApprove(
+            @RequestBody @Valid BulkApproveRequest request
+    ) {
+        BulkApproveResponse response = submissionCommandService.bulkApprove(request);
+        return ApiData.ok(response);
+    }
+
+    /**
+     * 일괄 반려
+     */
+    @PostMapping("/bulk/reject")
+    @Operation(summary = "일괄 반려", description = "여러 제출 데이터를 한 번에 반려합니다. 반려 사유를 필수로 입력해야 합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일괄 반려 완료"),
+            @ApiResponse(responseCode = "422", description = "반려 사유가 공란"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<BulkRejectResponse> bulkReject(
+            @RequestBody @Valid BulkRejectRequest request
+    ) {
+        BulkRejectResponse response = submissionCommandService.bulkReject(request);
+        return ApiData.ok(response);
+    }
+
+    /**
+     * 일괄 삭제
+     */
+    @DeleteMapping("/bulk")
+    @Operation(summary = "일괄 삭제", description = "여러 제출 데이터를 한 번에 영구 삭제합니다.")
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "일괄 삭제 완료"),
+            @ApiResponse(responseCode = "401", description = "인증 실패"),
+            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+    })
+    public ApiData<BulkDeleteResponse> bulkDelete(
+            @RequestBody @Valid BulkDeleteRequest request
+    ) {
+        BulkDeleteResponse response = submissionCommandService.bulkDelete(request);
+        return ApiData.ok(response);
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\BulkApproveRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record BulkApproveRequest(
+        @NotEmpty(message = "승인할 제출 ID 목록은 필수입니다.")
+        List<Long> ids
+) {
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\BulkDeleteRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+import jakarta.validation.constraints.NotEmpty;
+
+import java.util.List;
+
+public record BulkDeleteRequest(
+        @NotEmpty(message = "삭제할 제출 ID 목록은 필수입니다.")
+        List<Long> ids,
+        
+        String reason
+) {
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\BulkRejectRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.List;
+
+public record BulkRejectRequest(
+        @NotEmpty(message = "반려할 제출 ID 목록은 필수입니다.")
+        List<Long> ids,
+        
+        @NotNull(message = "반려 사유는 필수입니다.")
+        @Valid
+        RejectReasonDto reason
+) {
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\CreateSubmissionRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.CurrentState;
+import com.ocean.piuda.admin.common.enums.HealthGrade;
+import com.ocean.piuda.admin.common.enums.ParticipantRole;
+import com.ocean.piuda.admin.common.enums.Weather;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateSubmissionRequest {
+
+    @NotBlank(message = "현장명은 필수입니다")
+    private String siteName;
+
+    @NotNull(message = "활동유형은 필수입니다")
+    private ActivityType activityType;
+
+    private LocalDateTime submittedAt; // null이면 현재 시간 사용
+
+    @NotBlank(message = "작성자명은 필수입니다")
+    private String authorName;
+
+    private String authorEmail;
+
+    private String feedbackText;
+
+    private BigDecimal latitude;
+    private BigDecimal longitude;
+
+    @Valid
+    private BasicEnvDto basicEnv;
+
+    @Valid
+    private ParticipantsDto participants;
+
+    @Valid
+    @NotNull(message = "활동 정보는 필수입니다")
+    private ActivityDto activity;
+
+    @Valid
+    private List<AttachmentDto> attachments;
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BasicEnvDto {
+        private LocalDate recordDate;
+        private LocalTime startTime;
+        private LocalTime endTime;
+        private Float waterTempC;
+        private Float visibilityM;
+        private Float depthM;
+        private CurrentState currentState;
+        private Weather weather;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ParticipantsDto {
+        private String leaderName;
+        private Integer participantCount;
+        private ParticipantRole role;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ActivityDto {
+        @NotNull(message = "활동유형은 필수입니다")
+        private ActivityType type;
+        private String details;
+        private Float collectionAmount;
+        private Float durationHours;
+
+        // --- 추가된 필드 ---
+        private HealthGrade healthGrade;
+        private Float growthCm;
+        private NaturalReproductionDto naturalReproduction;
+        private SurvivalDto survival;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class NaturalReproductionDto {
+        private Float radiusM;
+        private Float numerator;
+        private Float denominator;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SurvivalDto {
+        private Float dieCount;
+        private Float totalCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AttachmentDto {
+        private String fileName;
+        private String fileUrl;
+        private String mimeType;
+        private Integer fileSize;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\RejectReasonDto.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+public record RejectReasonDto(
+        String templateCode,
+        String message
+) {
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\SingleDeleteRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+public record SingleDeleteRequest(
+        String reason
+) {
+}
+
+
+================================================================================
+File Path: .\submission\dto\request\SingleRejectRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+public record SingleRejectRequest(
+        @NotNull(message = "반려 사유는 필수입니다.")
+        @Valid
+        RejectReasonDto reason
+) {
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\ActivityResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.HealthGrade;
+import com.ocean.piuda.admin.submission.entity.Activity;
+import com.ocean.piuda.admin.submission.entity.embeded.NaturalReproduction;
+import com.ocean.piuda.admin.submission.entity.embeded.Survival;
+
+public record ActivityResponse(
+        ActivityType type,
+        String details,
+        Float collectionAmount,
+        Float durationHours,
+
+        // --- 추가된 필드 ---
+        HealthGrade healthGrade,
+        Float growthCm,
+        NaturalReproductionResponse naturalReproduction,
+        SurvivalResponse survival
+) {
+    public static ActivityResponse from(Activity activity) {
+        if (activity == null) return null;
+        return new ActivityResponse(
+                activity.getType(),
+                activity.getDetails(),
+                activity.getCollectionAmount(),
+                activity.getDurationHours(),
+
+                // 매핑 로직
+                activity.getHealthGrade(),
+                activity.getGrowthCm(),
+                NaturalReproductionResponse.from(activity.getNaturalReproduction()),
+                SurvivalResponse.from(activity.getSurvival())
+        );
+    }
+
+    // --- 내부 레코드 정의 ---
+    public record NaturalReproductionResponse(
+            Float radiusM,
+            Float numerator,
+            Float denominator
+    ) {
+        public static NaturalReproductionResponse from(NaturalReproduction vo) {
+            if (vo == null) return null;
+            return new NaturalReproductionResponse(vo.getRadiusM(), vo.getNumerator(), vo.getDenominator());
+        }
+    }
+
+    public record SurvivalResponse(
+            Float dieCount,
+            Float totalCount
+    ) {
+        public static SurvivalResponse from(Survival vo) {
+            if (vo == null) return null;
+            return new SurvivalResponse(vo.getDieCount(), vo.getTotalCount());
+        }
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\AttachmentResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.submission.entity.Attachment;
+
+import java.time.LocalDateTime;
+
+public record AttachmentResponse(
+        Long attachmentId,
+        String fileName,
+        String fileUrl,
+        String mimeType,
+        Integer fileSize,
+        LocalDateTime uploadedAt
+) {
+    public static AttachmentResponse from(Attachment attachment) {
+        if (attachment == null) return null;
+        return new AttachmentResponse(
+                attachment.getAttachmentId(),
+                attachment.getFileName(),
+                attachment.getFileUrl(),
+                attachment.getMimeType(),
+                attachment.getFileSize(),
+                attachment.getUploadedAt()
+        );
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\AuditLogResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.common.enums.AuditAction;
+import com.ocean.piuda.admin.submission.entity.AuditLog;
+
+import java.time.LocalDateTime;
+
+public record AuditLogResponse(
+        Long logId,
+        AuditAction action,
+        String performedBy,
+        String comment,
+        LocalDateTime createdAt
+) {
+    public static AuditLogResponse from(AuditLog auditLog) {
+        if (auditLog == null) return null;
+        return new AuditLogResponse(
+                auditLog.getLogId(),
+                auditLog.getAction(),
+                auditLog.getPerformedBy(),
+                auditLog.getComment(),
+                auditLog.getCreatedAt()
+        );
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\BasicEnvResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.common.enums.CurrentState;
+import com.ocean.piuda.admin.common.enums.Weather;
+import com.ocean.piuda.admin.submission.entity.BasicEnv;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record BasicEnvResponse(
+        LocalDate recordDate,
+        LocalTime startTime,
+        LocalTime endTime,
+        Float waterTempC,
+        Float visibilityM,
+        Float depthM,
+        CurrentState currentState,
+        Weather weather
+) {
+    public static BasicEnvResponse from(BasicEnv basicEnv) {
+        if (basicEnv == null) return null;
+        return new BasicEnvResponse(
+                basicEnv.getRecordDate(),
+                basicEnv.getStartTime(),
+                basicEnv.getEndTime(),
+                basicEnv.getWaterTempC(),
+                basicEnv.getVisibilityM(),
+                basicEnv.getDepthM(),
+                basicEnv.getCurrentState(),
+                basicEnv.getWeather()
+        );
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\BulkApproveResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import java.util.List;
+
+public record BulkApproveResponse(
+        List<Long> approved,
+        List<Long> skipped
+) {}
+
+
+================================================================================
+File Path: .\submission\dto\response\BulkDeleteResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import java.util.List;
+
+public record BulkDeleteResponse(
+        List<Long> deleted,
+        List<Long> failed
+) {}
+
+
+================================================================================
+File Path: .\submission\dto\response\BulkRejectResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import java.util.List;
+
+public record BulkRejectResponse(
+        List<Long> rejected,
+        List<Long> conflicts
+) {}
+
+
+================================================================================
+File Path: .\submission\dto\response\ParticipantsResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.common.enums.ParticipantRole;
+import com.ocean.piuda.admin.submission.entity.Participants;
+
+public record ParticipantsResponse(
+        String leaderName,
+        Integer participantCount,
+        ParticipantRole role
+) {
+    public static ParticipantsResponse from(Participants participants) {
+        if (participants == null) return null;
+        return new ParticipantsResponse(
+                participants.getLeaderName(),
+                participants.getParticipantCount(),
+                participants.getRole()
+        );
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\SubmissionDetailResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.submission.entity.Submission;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record SubmissionDetailResponse(
+        Long submissionId,
+        String siteName,
+        ActivityType activityType,
+        LocalDateTime submittedAt,
+        SubmissionStatus status,
+        String authorName,
+        String authorEmail,
+        Integer attachmentCount,
+        String feedbackText,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        BasicEnvResponse basicEnv,
+        ParticipantsResponse participants,
+        ActivityResponse activity,
+        List<AttachmentResponse> attachments,
+        String rejectReason,
+        List<AuditLogResponse> auditLogs,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+    public static SubmissionDetailResponse from(Submission submission) {
+        List<AttachmentResponse> attachments = null;
+        if (submission.getAttachments() != null) {
+            attachments = submission.getAttachments().stream()
+                    .map(AttachmentResponse::from)
+                    .collect(Collectors.toList());
+        }
+
+        List<AuditLogResponse> auditLogs = null;
+        if (submission.getAuditLogs() != null) {
+            auditLogs = submission.getAuditLogs().stream()
+                    .map(AuditLogResponse::from)
+                    .collect(Collectors.toList());
+        }
+
+        String rejectReason = null;
+        if (submission.getRejectReason() != null) {
+            rejectReason = submission.getRejectReason().getMessage();
+        }
+
+        return new SubmissionDetailResponse(
+                submission.getSubmissionId(),
+                submission.getSiteName(),
+                submission.getActivityType(),
+                submission.getSubmittedAt(),
+                submission.getStatus(),
+                submission.getAuthorName(),
+                submission.getAuthorEmail(),
+                submission.getAttachmentCount(),
+                submission.getFeedbackText(),
+                submission.getLatitude(),
+                submission.getLongitude(),
+                BasicEnvResponse.from(submission.getBasicEnv()),
+                ParticipantsResponse.from(submission.getParticipants()),
+                ActivityResponse.from(submission.getActivity()),
+                attachments,
+                rejectReason,
+                auditLogs,
+                submission.getCreatedAt(),
+                submission.getModifiedAt()
+        );
+    }
+}
+
+
+================================================================================
+File Path: .\submission\dto\response\SubmissionListResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.dto.response;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.submission.entity.Submission;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record SubmissionListResponse(
+        Long submissionId,
+        String siteName,
+        ActivityType activityType,
+        LocalDateTime submittedAt,
+        SubmissionStatus status,
+        String authorName,
+        String authorEmail,
+        Integer attachmentCount
+) {
+    public static SubmissionListResponse from(Submission submission) {
+        return new SubmissionListResponse(
+                submission.getSubmissionId(),
+                submission.getSiteName(),
+                submission.getActivityType(),
+                submission.getSubmittedAt(),
+                submission.getStatus(),
+                submission.getAuthorName(),
+                submission.getAuthorEmail(),
+                submission.getAttachmentCount()
+        );
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\Activity.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.HealthGrade;
+import com.ocean.piuda.admin.submission.entity.embeded.NaturalReproduction;
+import com.ocean.piuda.admin.submission.entity.embeded.Survival;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "activity")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class Activity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false)
+    private Submission submission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ActivityType type;
+
+    @Column(columnDefinition = "TEXT")
+    private String details;
+
+    @Column(name = "collection_amount")
+    @Builder.Default
+    private Float collectionAmount = 0f;
+
+    @Column(name = "duration_hours")
+    @Builder.Default
+    private Float durationHours = 0f;
+
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "health_grade")
+    private HealthGrade healthGrade;
+
+    @Column(name = "growth_cm")
+    @Builder.Default
+    private Float growthCm = 0f;
+
+    @Embedded
+    private NaturalReproduction naturalReproduction;
+
+    @Embedded
+    private Survival survival;
+
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\Attachment.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "attachment")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class Attachment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "attachment_id")
+    private Long attachmentId;
+
+    @ManyToOne
+    @JoinColumn(name = "submission_id", nullable = false)
+    private Submission submission;
+
+    @Column(name = "file_name", length = 255)
+    private String fileName;
+
+    @Column(name = "file_url", nullable = false, length = 500)
+    private String fileUrl;
+
+    @Column(name = "mime_type", length = 50)
+    private String mimeType;
+
+    @Column(name = "file_size")
+    private Integer fileSize;
+
+    @Column(name = "uploaded_at")
+    @Builder.Default
+    private LocalDateTime uploadedAt = LocalDateTime.now();
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\AuditLog.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.AuditAction;
+import com.ocean.piuda.global.api.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "audit_log")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class AuditLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "log_id")
+    private Long logId;
+
+    @ManyToOne
+    @JoinColumn(name = "submission_id", nullable = false)
+    private Submission submission;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AuditAction action;
+
+    @Column(name = "performed_by", nullable = false, length = 100)
+    private String performedBy;
+
+    @Column(length = 500)
+    private String comment;
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\BasicEnv.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.CurrentState;
+import com.ocean.piuda.admin.common.enums.Weather;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "basic_env")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class BasicEnv {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "env_id")
+    private Long envId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false)
+    private Submission submission;
+
+    @Column(name = "record_date", nullable = false)
+    private LocalDate recordDate;
+
+    @Column(name = "start_time")
+    private LocalTime startTime;
+
+    @Column(name = "end_time")
+    private LocalTime endTime;
+
+    @Column(name = "water_temp_c")
+    private Float waterTempC;
+
+    @Column(name = "visibility_m")
+    private Float visibilityM;
+
+    @Column(name = "depth_m")
+    private Float depthM;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_state")
+    private CurrentState currentState;
+
+    @Enumerated(EnumType.STRING)
+    private Weather weather;
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\embeded\NaturalReproduction.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity.embeded;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class NaturalReproduction {
+
+    @Column(name = "nat_radius_m")
+    private Float radiusM;      // 관측 반경
+
+    @Column(name = "nat_numerator")
+    private Float numerator;    // 자연번식 개체수
+
+    @Column(name = "nat_denominator")
+    private Float denominator;  // 기준 개체수
+}
+
+
+================================================================================
+File Path: .\submission\entity\embeded\Survival.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity.embeded;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Embeddable
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Survival {
+
+    @Column(name = "surv_die_count")
+    private Float dieCount;     // 죽은 개체수
+
+    @Column(name = "surv_total_count")
+    private Float totalCount;   // 총 개체수
+}
+
+
+================================================================================
+File Path: .\submission\entity\Participants.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.ParticipantRole;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "participants")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class Participants {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "participant_id")
+    private Long participantId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false)
+    private Submission submission;
+
+    @Column(name = "leader_name", length = 100)
+    private String leaderName;
+
+    @Column(name = "participant_count")
+    @Builder.Default
+    private Integer participantCount = 1;
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private ParticipantRole role = ParticipantRole.CITIZEN_DIVER;
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\RejectReason.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reject_reason")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class RejectReason {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "reason_id")
+    private Long reasonId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false)
+    private Submission submission;
+
+    @Column(name = "template_code", length = 100)
+    private String templateCode;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(name = "rejected_by", nullable = false, length = 100)
+    private String rejectedBy;
+
+    @Column(name = "rejected_at")
+    @Builder.Default
+    private LocalDateTime rejectedAt = LocalDateTime.now();
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\entity\Submission.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.global.api.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Entity
+@Table(name = "submission")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class Submission extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "submission_id")
+    private Long submissionId;
+
+    @Column(name = "site_name", nullable = false, length = 200)
+    private String siteName;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "activity_type", nullable = false)
+    private ActivityType activityType;
+
+    @Column(name = "submitted_at", nullable = false)
+    private java.time.LocalDateTime submittedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private SubmissionStatus status = SubmissionStatus.PENDING;
+
+    @Column(name = "author_name", nullable = false, length = 100)
+    private String authorName;
+
+    @Column(name = "author_email", length = 200)
+    private String authorEmail;
+
+    @Column(name = "attachment_count")
+    @Builder.Default
+    private Integer attachmentCount = 0;
+
+    @Column(name = "feedback_text", columnDefinition = "TEXT")
+    private String feedbackText;
+
+    @Column(precision = 9, scale = 6)
+    private BigDecimal latitude;
+
+    @Column(precision = 9, scale = 6)
+    private BigDecimal longitude;
+
+    // 관계 매핑
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private BasicEnv basicEnv;
+
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Participants participants;
+
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Activity activity;
+
+    @OneToMany(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Attachment> attachments = new ArrayList<>();
+
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private RejectReason rejectReason;
+
+    @OneToMany(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<AuditLog> auditLogs = new ArrayList<>();
+
+    // 비즈니스 메서드
+    public void updateStatus(SubmissionStatus status) {
+        this.status = status;
+    }
+
+    public void addAttachment(Attachment attachment) {
+        attachments.add(attachment);
+        attachment.updateSubmission(this);
+        this.attachmentCount = attachments.size();
+    }
+
+    public void addAuditLog(AuditLog auditLog) {
+        auditLogs.add(auditLog);
+        auditLog.updateSubmission(this);
+    }
+
+    public void setBasicEnv(BasicEnv basicEnv) {
+        this.basicEnv = basicEnv;
+        if (basicEnv != null) {
+            basicEnv.updateSubmission(this);
+        }
+    }
+
+    public void setParticipants(Participants participants) {
+        this.participants = participants;
+        if (participants != null) {
+            participants.updateSubmission(this);
+        }
+    }
+
+    public void setActivity(Activity activity) {
+        this.activity = activity;
+        if (activity != null) {
+            activity.updateSubmission(this);
+        }
+    }
+
+    public void setRejectReason(RejectReason rejectReason) {
+        this.rejectReason = rejectReason;
+        if (rejectReason != null) {
+            rejectReason.updateSubmission(this);
+        }
+    }
+}
+
+
+================================================================================
+File Path: .\submission\initializer\SubmissionDataInitializer.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.initializer;
+
+import com.ocean.piuda.admin.common.enums.*;
+import com.ocean.piuda.admin.submission.entity.*;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+@Profile("!prod") // 프로덕션 환경에서는 실행되지 않음
+@Order(1)
+public class SubmissionDataInitializer implements CommandLineRunner {
+
+    private final SubmissionRepository submissionRepository;
+
+    @Override
+    @Transactional
+    public void run(String... args) {
+        if (submissionRepository.count() > 0) {
+            log.info("Submission 데이터가 이미 존재합니다. 초기화를 건너뜁니다.");
+            return;
+        }
+
+        log.info("Admin Submission 테스트 데이터 초기화 시작...");
+
+        List<Submission> submissions = new ArrayList<>();
+
+        // 1. 검수 대기 중인 제출 (PENDING)
+        submissions.add(createSubmission(
+                1L,
+                "포항 해안가",
+                ActivityType.TRANSPLANT,
+                SubmissionStatus.PENDING,
+                "홍길동",
+                "hong@example.com",
+                3,
+                "깨끗해진 바다가 뿌듯합니다",
+                new BigDecimal("36.0322"),
+                new BigDecimal("129.3650"),
+                LocalDate.now().minusDays(2),
+                LocalTime.of(9, 0),
+                LocalTime.of(12, 30),
+                18.5f,
+                15.0f,
+                10.5f,
+                CurrentState.MEDIUM,
+                Weather.SUNNY,
+                "홍길동",
+                5,
+                ParticipantRole.CITIZEN_DIVER,
+                "이식 작업을 수행했습니다. 총 50개를 이식했습니다.",
+                50.0f,
+                3.5f,
+                "public/user_objects/2025-01-15/photo1.jpg"
+        ));
+
+        // 2. 승인된 제출 (APPROVED)
+        submissions.add(createSubmission(
+                2L,
+                "부산 송도해수욕장",
+                ActivityType.TRASH_COLLECTION,
+                SubmissionStatus.APPROVED,
+                "김철수",
+                "kim@example.com",
+                2,
+                "해변 청소 활동에 참여했습니다",
+                new BigDecimal("35.0784"),
+                new BigDecimal("129.0756"),
+                LocalDate.now().minusDays(5),
+                LocalTime.of(10, 0),
+                LocalTime.of(14, 0),
+                20.0f,
+                20.0f,
+                5.0f,
+                CurrentState.LOW,
+                Weather.SUNNY,
+                "김철수",
+                3,
+                ParticipantRole.CITIZEN_DIVER,
+                "플라스틱 병 30개, 캔 15개를 수거했습니다.",
+                45.0f,
+                4.0f,
+                "public/user_objects/2025-01-10/photo2.jpg"
+        ));
+
+        // 3. 반려된 제출 (REJECTED)
+        Submission rejectedSubmission = createSubmission(
+                3L,
+                "제주도 성산일출봉",
+                ActivityType.OTHER,
+                SubmissionStatus.REJECTED,
+                "이영희",
+                "lee@example.com",
+                1,
+                "제주도 바다 정화 활동",
+                new BigDecimal("33.4584"),
+                new BigDecimal("126.9426"),
+                LocalDate.now().minusDays(7),
+                LocalTime.of(8, 0),
+                LocalTime.of(11, 0),
+                22.0f,
+                25.0f,
+                8.0f,
+                CurrentState.LOW,
+                Weather.CLOUDY,
+                "이영희",
+                2,
+                ParticipantRole.RESEARCHER,
+                "해양 생물 관찰 및 정화 활동",
+                10.0f,
+                3.0f,
+                "public/user_objects/2025-01-08/photo3.jpg"
+        );
+        RejectReason rejectReason = RejectReason.builder()
+                .submission(rejectedSubmission)
+                .templateCode("PHOTO_INSUFFICIENT")
+                .message("사진이 부족합니다. 최소 3장 이상의 사진을 첨부해주세요.")
+                .rejectedBy("admin@oceancampus.kr")
+                .rejectedAt(LocalDateTime.now().minusDays(6))
+                .build();
+        rejectedSubmission.setRejectReason(rejectReason);
+        submissions.add(rejectedSubmission);
+
+        // 4. 검수 대기 중인 제출 (PENDING) - 추가
+        submissions.add(createSubmission(
+                4L,
+                "강원도 속초 해변",
+                ActivityType.TRANSPLANT,
+                SubmissionStatus.PENDING,
+                "박민수",
+                "park@example.com",
+                4,
+                "속초 바다 정화 활동에 참여했습니다",
+                new BigDecimal("38.2070"),
+                new BigDecimal("128.5918"),
+                LocalDate.now().minusDays(1),
+                LocalTime.of(13, 0),
+                LocalTime.of(17, 0),
+                16.0f,
+                12.0f,
+                15.0f,
+                CurrentState.HIGH,
+                Weather.WINDY,
+                "박민수",
+                4,
+                ParticipantRole.LOCAL_MANAGER,
+                "이식 80개 완료",
+                80.0f,
+                4.0f,
+                "public/user_objects/2025-01-16/photo4.jpg"
+        ));
+
+        // 5. 승인된 제출 (APPROVED) - 추가
+        submissions.add(createSubmission(
+                5L,
+                "전라남도 여수 해수욕장",
+                ActivityType.TRASH_COLLECTION,
+                SubmissionStatus.APPROVED,
+                "최지영",
+                "choi@example.com",
+                5,
+                "여수 바다가 아름답습니다",
+                new BigDecimal("34.7604"),
+                new BigDecimal("127.6622"),
+                LocalDate.now().minusDays(10),
+                LocalTime.of(9, 30),
+                LocalTime.of(13, 30),
+                19.0f,
+                18.0f,
+                7.0f,
+                CurrentState.MEDIUM,
+                Weather.SUNNY,
+                "최지영",
+                6,
+                ParticipantRole.CITIZEN_DIVER,
+                "쓰레기 100개 수거 완료",
+                100.0f,
+                4.0f,
+                "public/user_objects/2025-01-07/photo5.jpg"
+        ));
+
+        submissionRepository.saveAll(submissions);
+        log.info("{}개의 Submission 테스트 데이터 생성 완료", submissions.size());
+    }
+
+    private Submission createSubmission(
+            Long id,
+            String siteName,
+            ActivityType activityType,
+            SubmissionStatus status,
+            String authorName,
+            String authorEmail,
+            int attachmentCount,
+            String feedbackText,
+            BigDecimal latitude,
+            BigDecimal longitude,
+            LocalDate recordDate,
+            LocalTime startTime,
+            LocalTime endTime,
+            Float waterTempC,
+            Float visibilityM,
+            Float depthM,
+            CurrentState currentState,
+            Weather weather,
+            String leaderName,
+            int participantCount,
+            ParticipantRole role,
+            String activityDetails,
+            Float collectionAmount,
+            Float durationHours,
+            String fileUrl
+    ) {
+        LocalDateTime submittedAt = LocalDateTime.of(recordDate, startTime);
+
+        // BasicEnv 생성
+        BasicEnv basicEnv = BasicEnv.builder()
+                .recordDate(recordDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .waterTempC(waterTempC)
+                .visibilityM(visibilityM)
+                .depthM(depthM)
+                .currentState(currentState)
+                .weather(weather)
+                .build();
+
+        // Participants 생성
+        Participants participants = Participants.builder()
+                .leaderName(leaderName)
+                .participantCount(participantCount)
+                .role(role)
+                .build();
+
+        // Activity 생성
+        Activity activity = Activity.builder()
+                .type(activityType)
+                .details(activityDetails)
+                .collectionAmount(collectionAmount)
+                .durationHours(durationHours)
+                .build();
+
+        // Attachments 생성
+        List<Attachment> attachments = new ArrayList<>();
+        String baseUrl = fileUrl.substring(0, fileUrl.lastIndexOf("/") + 1);
+        for (int i = 1; i <= attachmentCount; i++) {
+            Attachment attachment = Attachment.builder()
+                    .fileName("photo" + i + ".jpg")
+                    .fileUrl(baseUrl + "photo" + i + ".jpg")
+                    .mimeType("image/jpeg")
+                    .fileSize(1024 * 500 * i) // 500KB * i
+                    .uploadedAt(submittedAt)
+                    .build();
+            attachments.add(attachment);
+        }
+
+        // Submission 생성
+        Submission submission = Submission.builder()
+                .siteName(siteName)
+                .activityType(activityType)
+                .submittedAt(submittedAt)
+                .status(status)
+                .authorName(authorName)
+                .authorEmail(authorEmail)
+                .attachmentCount(attachmentCount)
+                .feedbackText(feedbackText)
+                .latitude(latitude)
+                .longitude(longitude)
+                .build();
+
+        // 관계 설정
+        submission.setBasicEnv(basicEnv);
+        submission.setParticipants(participants);
+        submission.setActivity(activity);
+        attachments.forEach(submission::addAttachment);
+
+        // AuditLog 생성 (제출됨)
+        AuditLog submitLog = AuditLog.builder()
+                .submission(submission)
+                .action(AuditAction.SUBMITTED)
+                .performedBy("system")
+                .comment(null)
+                .createdAt(submittedAt)
+                .build();
+        submission.addAuditLog(submitLog);
+
+        // 승인/반려된 경우 AuditLog 추가
+        if (status == SubmissionStatus.APPROVED) {
+            AuditLog approveLog = AuditLog.builder()
+                    .submission(submission)
+                    .action(AuditAction.APPROVED)
+                    .performedBy("admin@oceancampus.kr")
+                    .comment(null)
+                    .createdAt(submittedAt.plusDays(1))
+                    .build();
+            submission.addAuditLog(approveLog);
+        } else if (status == SubmissionStatus.REJECTED) {
+            AuditLog rejectLog = AuditLog.builder()
+                    .submission(submission)
+                    .action(AuditAction.REJECTED)
+                    .performedBy("admin@oceancampus.kr")
+                    .comment("사진이 부족합니다. 최소 3장 이상의 사진을 첨부해주세요.")
+                    .createdAt(submittedAt.plusDays(1))
+                    .build();
+            submission.addAuditLog(rejectLog);
+        }
+
+        return submission;
+    }
+}
+
+
+================================================================================
+File Path: .\submission\repository\AuditLogRepository.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.repository;
+
+import com.ocean.piuda.admin.submission.entity.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+    List<AuditLog> findBySubmissionSubmissionIdOrderByCreatedAtDesc(Long submissionId);
+}
+
+
+================================================================================
+File Path: .\submission\repository\SubmissionRepository.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.repository;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.submission.entity.Submission;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SubmissionRepository extends JpaRepository<Submission, Long> {
+
+    long countByStatus(SubmissionStatus status);
+
+    @Query("""
+        SELECT DISTINCT s FROM Submission s
+        LEFT JOIN FETCH s.basicEnv
+        LEFT JOIN FETCH s.participants
+        LEFT JOIN FETCH s.activity
+        LEFT JOIN FETCH s.attachments
+        LEFT JOIN FETCH s.rejectReason
+        WHERE s.submissionId = :id
+        """)
+    Optional<Submission> findByIdWithDetails(@Param("id") Long id);
+    
+    @Query("""
+        SELECT DISTINCT s FROM Submission s
+        LEFT JOIN FETCH s.auditLogs
+        WHERE s.submissionId = :id
+        """)
+    Optional<Submission> findByIdWithAuditLogs(@Param("id") Long id);
+
+    @Query("""
+    SELECT DISTINCT s FROM Submission s
+    LEFT JOIN FETCH s.basicEnv
+    LEFT JOIN FETCH s.participants
+    LEFT JOIN FETCH s.activity
+    WHERE (:keyword IS NULL OR :keyword = '' OR 
+           s.siteName LIKE %:keyword% OR 
+           s.authorName LIKE %:keyword%)
+      AND (:status IS NULL OR s.status = :status)
+      AND (:activityType IS NULL OR s.activityType = :activityType)
+      AND (cast(:startDate as timestamp) IS NULL OR s.submittedAt >= :startDate)
+      AND (cast(:endDate as timestamp) IS NULL OR s.submittedAt <= :endDate)
+    """)
+    Page<Submission> findWithFilters(
+            @Param("keyword") String keyword,
+            @Param("status") SubmissionStatus status,
+            @Param("activityType") ActivityType activityType,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            Pageable pageable
+    );
+
+    @Query("""
+        SELECT DISTINCT s FROM Submission s
+        LEFT JOIN FETCH s.basicEnv
+        LEFT JOIN FETCH s.participants
+        LEFT JOIN FETCH s.activity
+        LEFT JOIN FETCH s.attachments
+        WHERE s.status = :status
+          AND s.submissionId IN :ids
+        """)
+    List<Submission> findAllByIdsAndStatusWithDetails(
+            @Param("ids") List<Long> ids,
+            @Param("status") SubmissionStatus status
+    );
+
+    @Query("""
+    SELECT DISTINCT s FROM Submission s
+    LEFT JOIN FETCH s.basicEnv
+    LEFT JOIN FETCH s.participants
+    LEFT JOIN FETCH s.activity
+    LEFT JOIN FETCH s.attachments
+    WHERE s.status = :status
+      AND s.submittedAt BETWEEN :start AND :end
+    ORDER BY s.submittedAt DESC
+    """)
+    List<Submission> findAllByStatusAndSubmittedAtBetweenWithDetails(
+            @Param("status") SubmissionStatus status,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+
+}
+
+
+
+================================================================================
+File Path: .\submission\service\SubmissionCommandService.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.service;
+
+import com.ocean.piuda.admin.submission.dto.response.*;
+import com.ocean.piuda.admin.common.enums.AuditAction;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.submission.dto.request.*;
+import com.ocean.piuda.admin.submission.dto.response.SubmissionDetailResponse;
+import com.ocean.piuda.admin.submission.entity.Activity;
+import com.ocean.piuda.admin.submission.entity.Attachment;
+import com.ocean.piuda.admin.submission.entity.AuditLog;
+import com.ocean.piuda.admin.submission.entity.BasicEnv;
+import com.ocean.piuda.admin.submission.entity.Participants;
+import com.ocean.piuda.admin.submission.entity.RejectReason;
+import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.submission.entity.embeded.NaturalReproduction;
+import com.ocean.piuda.admin.submission.entity.embeded.Survival;
+import com.ocean.piuda.admin.submission.repository.AuditLogRepository;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class SubmissionCommandService {
+
+    private final SubmissionRepository submissionRepository;
+    private final AuditLogRepository auditLogRepository;
+    private final SubmissionQueryService submissionQueryService;
+
+    /**
+     * 제출 데이터 생성
+     */
+    public SubmissionDetailResponse createSubmission(CreateSubmissionRequest request) {
+        // 기본값 설정
+        LocalDateTime submittedAt = request.getSubmittedAt() != null
+                ? request.getSubmittedAt()
+                : LocalDateTime.now();
+
+        // Submission 생성
+        Submission submission = Submission.builder()
+                .siteName(request.getSiteName())
+                .activityType(request.getActivityType())
+                .submittedAt(submittedAt)
+                .status(SubmissionStatus.PENDING)
+                .authorName(request.getAuthorName())
+                .authorEmail(request.getAuthorEmail())
+                .feedbackText(request.getFeedbackText())
+                .latitude(request.getLatitude())
+                .longitude(request.getLongitude())
+                .attachmentCount(0)
+                .build();
+
+        // BasicEnv 생성
+        if (request.getBasicEnv() != null) {
+            CreateSubmissionRequest.BasicEnvDto envDto = request.getBasicEnv();
+            BasicEnv basicEnv = BasicEnv.builder()
+                    .recordDate(envDto.getRecordDate())
+                    .startTime(envDto.getStartTime())
+                    .endTime(envDto.getEndTime())
+                    .waterTempC(envDto.getWaterTempC())
+                    .visibilityM(envDto.getVisibilityM())
+                    .depthM(envDto.getDepthM())
+                    .currentState(envDto.getCurrentState())
+                    .weather(envDto.getWeather())
+                    .build();
+            submission.setBasicEnv(basicEnv);
+        }
+
+        // Participants 생성
+        if (request.getParticipants() != null) {
+            CreateSubmissionRequest.ParticipantsDto participantsDto = request.getParticipants();
+            Participants participants = Participants.builder()
+                    .leaderName(participantsDto.getLeaderName())
+                    .participantCount(participantsDto.getParticipantCount() != null
+                            ? participantsDto.getParticipantCount()
+                            : 1)
+                    .role(participantsDto.getRole() != null
+                            ? participantsDto.getRole()
+                            : com.ocean.piuda.admin.common.enums.ParticipantRole.CITIZEN_DIVER)
+                    .build();
+            submission.setParticipants(participants);
+        }
+
+        // Activity 생성 및 신규 필드 매핑
+        CreateSubmissionRequest.ActivityDto activityDto = request.getActivity();
+
+        // NaturalReproduction VO 빌드
+        NaturalReproduction naturalReproduction = null;
+        if (activityDto.getNaturalReproduction() != null) {
+            naturalReproduction = NaturalReproduction.builder()
+                    .radiusM(activityDto.getNaturalReproduction().getRadiusM() != null ? activityDto.getNaturalReproduction().getRadiusM() : 0f)
+                    .numerator(activityDto.getNaturalReproduction().getNumerator() != null ? activityDto.getNaturalReproduction().getNumerator() : 0f)
+                    .denominator(activityDto.getNaturalReproduction().getDenominator() != null ? activityDto.getNaturalReproduction().getDenominator() : 0f)
+                    .build();
+        }
+
+        // Survival VO 빌드
+        Survival survival = null;
+        if (activityDto.getSurvival() != null) {
+            survival = Survival.builder()
+                    .dieCount(activityDto.getSurvival().getDieCount() != null ? activityDto.getSurvival().getDieCount() : 0f)
+                    .totalCount(activityDto.getSurvival().getTotalCount() != null ? activityDto.getSurvival().getTotalCount() : 0f)
+                    .build();
+        }
+
+        Activity activity = Activity.builder()
+                .type(activityDto.getType())
+                .details(activityDto.getDetails())
+                .collectionAmount(activityDto.getCollectionAmount() != null
+                        ? activityDto.getCollectionAmount()
+                        : 0f)
+                .durationHours(activityDto.getDurationHours() != null
+                        ? activityDto.getDurationHours()
+                        : 0f)
+                // 추가된 필드 매핑
+                .healthGrade(activityDto.getHealthGrade())
+                .growthCm(activityDto.getGrowthCm() != null ? activityDto.getGrowthCm() : 0f)
+                .naturalReproduction(naturalReproduction)
+                .survival(survival)
+                .build();
+
+        submission.setActivity(activity);
+
+        // Attachments 생성
+        if (request.getAttachments() != null && !request.getAttachments().isEmpty()) {
+            for (CreateSubmissionRequest.AttachmentDto attachmentDto : request.getAttachments()) {
+                Attachment attachment = Attachment.builder()
+                        .fileName(attachmentDto.getFileName())
+                        .fileUrl(attachmentDto.getFileUrl())
+                        .mimeType(attachmentDto.getMimeType())
+                        .fileSize(attachmentDto.getFileSize())
+                        .uploadedAt(submittedAt)
+                        .build();
+                submission.addAttachment(attachment);
+            }
+        }
+
+        // 저장
+        Submission saved = submissionRepository.save(submission);
+
+        // AuditLog 생성 (제출됨)
+        createAuditLog(saved, AuditAction.SUBMITTED, null);
+
+        return SubmissionDetailResponse.from(saved);
+    }
+
+    /**
+     * 단건 승인
+     */
+    public SubmissionDetailResponse approveSubmission(Long submissionId) {
+        Submission submission = submissionQueryService.getSubmissionById(submissionId);
+
+        if (submission.getStatus() == SubmissionStatus.APPROVED) {
+            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_APPROVED);
+        }
+        if (submission.getStatus() == SubmissionStatus.DELETED) {
+            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_DELETED);
+        }
+
+        submission.updateStatus(SubmissionStatus.APPROVED);
+        createAuditLog(submission, AuditAction.APPROVED, null);
+
+        return SubmissionDetailResponse.from(submission);
+    }
+
+    /**
+     * 단건 반려
+     */
+    public SubmissionDetailResponse rejectSubmission(Long submissionId, SingleRejectRequest request) {
+        Submission submission = submissionQueryService.getSubmissionById(submissionId);
+
+        if (submission.getStatus() == SubmissionStatus.REJECTED) {
+            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_REJECTED);
+        }
+        if (submission.getStatus() == SubmissionStatus.DELETED) {
+            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_DELETED);
+        }
+
+        if (request.reason() == null || request.reason().message() == null || request.reason().message().isBlank()) {
+            throw new BusinessException(ExceptionType.REJECT_REASON_REQUIRED);
+        }
+
+        submission.updateStatus(SubmissionStatus.REJECTED);
+
+        RejectReason rejectReason = RejectReason.builder()
+                .submission(submission)
+                .templateCode(request.reason().templateCode())
+                .message(request.reason().message())
+                .rejectedBy(getCurrentUsername())
+                .rejectedAt(LocalDateTime.now())
+                .build();
+        submission.setRejectReason(rejectReason);
+
+        createAuditLog(submission, AuditAction.REJECTED, request.reason().message());
+
+        return SubmissionDetailResponse.from(submission);
+    }
+
+    /**
+     * 단건 삭제
+     */
+    public void deleteSubmission(Long submissionId, SingleDeleteRequest request) {
+        Submission submission = submissionQueryService.getSubmissionById(submissionId);
+
+        if (submission.getStatus() == SubmissionStatus.DELETED) {
+            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_DELETED);
+        }
+
+        createAuditLog(submission, AuditAction.DELETED, request.reason());
+        submissionRepository.delete(submission);
+    }
+
+    /**
+     * 일괄 승인
+     */
+    public BulkApproveResponse bulkApprove(BulkApproveRequest request) {
+        List<Long> approved = new ArrayList<>();
+        List<Long> skipped = new ArrayList<>();
+
+        for (Long id : request.ids()) {
+            try {
+                Submission submission = submissionRepository.findById(id).orElse(null);
+                if (submission == null || submission.getStatus() == SubmissionStatus.DELETED) {
+                    skipped.add(id);
+                    continue;
+                }
+                if (submission.getStatus() == SubmissionStatus.APPROVED) {
+                    skipped.add(id);
+                    continue;
+                }
+
+                submission.updateStatus(SubmissionStatus.APPROVED);
+                createAuditLog(submission, AuditAction.APPROVED, null);
+                approved.add(id);
+            } catch (Exception e) {
+                skipped.add(id);
+            }
+        }
+
+        return new BulkApproveResponse(approved, skipped);
+    }
+
+    /**
+     * 일괄 반려
+     */
+    public BulkRejectResponse bulkReject(BulkRejectRequest request) {
+        if (request.reason() == null || request.reason().message() == null || request.reason().message().isBlank()) {
+            throw new BusinessException(ExceptionType.REJECT_REASON_REQUIRED);
+        }
+
+        List<Long> rejected = new ArrayList<>();
+        List<Long> conflicts = new ArrayList<>();
+
+        for (Long id : request.ids()) {
+            try {
+                Submission submission = submissionRepository.findById(id).orElse(null);
+                if (submission == null || submission.getStatus() == SubmissionStatus.DELETED) {
+                    conflicts.add(id);
+                    continue;
+                }
+                if (submission.getStatus() == SubmissionStatus.REJECTED) {
+                    conflicts.add(id);
+                    continue;
+                }
+
+                submission.updateStatus(SubmissionStatus.REJECTED);
+
+                RejectReason rejectReason = RejectReason.builder()
+                        .submission(submission)
+                        .templateCode(request.reason().templateCode())
+                        .message(request.reason().message())
+                        .rejectedBy(getCurrentUsername())
+                        .rejectedAt(LocalDateTime.now())
+                        .build();
+                submission.setRejectReason(rejectReason);
+
+                createAuditLog(submission, AuditAction.REJECTED, request.reason().message());
+                rejected.add(id);
+            } catch (Exception e) {
+                conflicts.add(id);
+            }
+        }
+
+        return new BulkRejectResponse(rejected, conflicts);
+    }
+
+    /**
+     * 일괄 삭제
+     */
+    public BulkDeleteResponse bulkDelete(BulkDeleteRequest request) {
+        List<Long> deleted = new ArrayList<>();
+        List<Long> failed = new ArrayList<>();
+
+        for (Long id : request.ids()) {
+            try {
+                Submission submission = submissionRepository.findById(id).orElse(null);
+                if (submission == null || submission.getStatus() == SubmissionStatus.DELETED) {
+                    failed.add(id);
+                    continue;
+                }
+
+                createAuditLog(submission, AuditAction.DELETED, request.reason());
+                submissionRepository.delete(submission);
+                deleted.add(id);
+            } catch (Exception e) {
+                failed.add(id);
+            }
+        }
+
+        return new BulkDeleteResponse(deleted, failed);
+    }
+
+    private void createAuditLog(Submission submission, AuditAction action, String comment) {
+        AuditLog auditLog = AuditLog.builder()
+                .submission(submission)
+                .action(action)
+                .performedBy(getCurrentUsername())
+                .comment(comment)
+                .build();
+        auditLog.updateSubmission(submission);
+        auditLogRepository.save(auditLog);
+    }
+
+    private String getCurrentUsername() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null && authentication.isAuthenticated()) {
+            return authentication.getName();
+        }
+        return "SYSTEM";
+    }
+
+}
+
+
+================================================================================
+File Path: .\submission\service\SubmissionQueryService.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.service;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.submission.dto.response.AuditLogResponse;
+import com.ocean.piuda.admin.submission.dto.response.SubmissionDetailResponse;
+import com.ocean.piuda.admin.submission.dto.response.SubmissionListResponse;
+import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.submission.repository.AuditLogRepository;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import com.ocean.piuda.global.api.dto.PageResponse;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Transactional(readOnly = true)
+@Service
+@RequiredArgsConstructor
+public class SubmissionQueryService {
+
+    private final SubmissionRepository submissionRepository;
+    private final AuditLogRepository auditLogRepository;
+
+    /**
+     * 제출 목록 조회 (필터링, 검색, 정렬 포함)
+     */
+    public PageResponse<SubmissionListResponse> getSubmissions(
+            String keyword,
+            SubmissionStatus status,
+            ActivityType activityType,
+            LocalDateTime startDate,
+            LocalDateTime endDate,
+            Pageable pageable
+    ) {
+        Page<Submission> page = submissionRepository.findWithFilters(
+                keyword, status, activityType, startDate, endDate, pageable
+        );
+
+        Page<SubmissionListResponse> mapped = page.map(SubmissionListResponse::from);
+        return PageResponse.of(mapped);
+    }
+
+    /**
+     * 제출 상세 조회
+     */
+    public SubmissionDetailResponse getSubmissionDetail(Long submissionId) {
+        // attachments는 fetch join으로 조회 (auditLogs는 제외하여 MultipleBagFetchException 방지)
+        Submission submission = submissionRepository.findByIdWithDetails(submissionId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.SUBMISSION_NOT_FOUND));
+        
+        // auditLogs는 별도 Repository로 조회하여 초기화
+        List<com.ocean.piuda.admin.submission.entity.AuditLog> auditLogs = 
+                auditLogRepository.findBySubmissionSubmissionIdOrderByCreatedAtDesc(submissionId);
+        
+        // submission의 auditLogs 컬렉션 초기화
+        submission.getAuditLogs().clear();
+        submission.getAuditLogs().addAll(auditLogs);
+
+        return SubmissionDetailResponse.from(submission);
+    }
+
+    /**
+     * 검수 로그 조회
+     */
+    public List<AuditLogResponse> getSubmissionLogs(Long submissionId) {
+        return auditLogRepository.findBySubmissionSubmissionIdOrderByCreatedAtDesc(submissionId)
+                .stream()
+                .map(AuditLogResponse::from)
+                .toList();
+    }
+
+    /**
+     * Submission 엔티티 조회 (내부용)
+     */
+    public Submission getSubmissionById(Long submissionId) {
+        return submissionRepository.findById(submissionId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.SUBMISSION_NOT_FOUND));
+    }
+}
+

--- a/src/main/java/com/ocean/piuda/admin/report/controller/ReportDraftController.java
+++ b/src/main/java/com/ocean/piuda/admin/report/controller/ReportDraftController.java
@@ -1,0 +1,39 @@
+package com.ocean.piuda.admin.report.controller;
+
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByIdsRequest;
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByPeriodRequest;
+import com.ocean.piuda.admin.report.dto.response.ReportDraftResponse;
+import com.ocean.piuda.admin.report.service.ReportDraftService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/admin/reports/drafts")
+@RequiredArgsConstructor
+@Tag(name = "Admin Report Draft", description = "선택한 해양 활동 제출물로 리포트 초안을 Gemini로 생성합니다.")
+public class ReportDraftController {
+
+    private final ReportDraftService reportDraftService;
+
+    @PostMapping("/by-ids")
+    @Operation(
+            summary = "리포트 초안 생성 (IDs 기반)",
+            description = "선택한 submission ids(기본: APPROVED)를 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
+    )
+    public ApiData<ReportDraftResponse> byIds(@RequestBody @Valid ReportDraftByIdsRequest request) {
+        return ApiData.ok(reportDraftService.generateByIds(request));
+    }
+
+    @PostMapping("/by-period")
+    @Operation(
+            summary = "리포트 초안 생성 (기간 기반)",
+            description = "dateFrom~dateTo 기간(기본: APPROVED)을 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
+    )
+    public ApiData<ReportDraftResponse> byPeriod(@RequestBody @Valid ReportDraftByPeriodRequest request) {
+        return ApiData.ok(reportDraftService.generateByPeriod(request));
+    }
+}

--- a/src/main/java/com/ocean/piuda/admin/report/dto/request/ReportDraftByIdsRequest.java
+++ b/src/main/java/com/ocean/piuda/admin/report/dto/request/ReportDraftByIdsRequest.java
@@ -1,0 +1,19 @@
+package com.ocean.piuda.admin.report.dto.request;
+
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ReportDraftByIdsRequest(
+        @NotEmpty(message = "ids는 1개 이상이어야 합니다")
+        List<Long> ids,
+
+        @NotNull(message = "reportType은 필수입니다")
+        ReportDraftType reportType,
+
+        String prompt
+) {}

--- a/src/main/java/com/ocean/piuda/admin/report/dto/request/ReportDraftByPeriodRequest.java
+++ b/src/main/java/com/ocean/piuda/admin/report/dto/request/ReportDraftByPeriodRequest.java
@@ -1,0 +1,21 @@
+package com.ocean.piuda.admin.report.dto.request;
+
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record ReportDraftByPeriodRequest(
+        @NotNull(message = "dateFrom는 필수입니다")
+        LocalDate dateFrom,
+
+        @NotNull(message = "dateTo는 필수입니다")
+        LocalDate dateTo,
+
+        @NotNull(message = "reportType은 필수입니다")
+        ReportDraftType reportType,
+
+        String prompt
+) {}

--- a/src/main/java/com/ocean/piuda/admin/report/dto/response/ReportDraftResponse.java
+++ b/src/main/java/com/ocean/piuda/admin/report/dto/response/ReportDraftResponse.java
@@ -1,0 +1,24 @@
+package com.ocean.piuda.admin.report.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import lombok.Builder;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+public record ReportDraftResponse(
+        List<Long> submissionIds,
+        List<Long> missingIds,
+
+        ReportDraftType reportType,
+
+        String internalDraft,
+        String externalNewsletter,
+        String externalInstagram,
+        String externalPublication,
+
+        GeminiMeta meta
+) {}

--- a/src/main/java/com/ocean/piuda/admin/report/enums/ReportDraftType.java
+++ b/src/main/java/com/ocean/piuda/admin/report/enums/ReportDraftType.java
@@ -1,0 +1,18 @@
+package com.ocean.piuda.admin.report.enums;
+
+public enum ReportDraftType {
+    INTERNAL_DRAFT("internalDraft"),
+    EXTERNAL_NEWSLETTER("externalNewsletter"),
+    EXTERNAL_INSTAGRAM("externalInstagram"),
+    EXTERNAL_PUBLICATION("externalPublication");
+
+    private final String jsonKey;
+
+    ReportDraftType(String jsonKey) {
+        this.jsonKey = jsonKey;
+    }
+
+    public String jsonKey() {
+        return jsonKey;
+    }
+}

--- a/src/main/java/com/ocean/piuda/admin/report/service/ReportDraftService.java
+++ b/src/main/java/com/ocean/piuda/admin/report/service/ReportDraftService.java
@@ -1,0 +1,262 @@
+package com.ocean.piuda.admin.report.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByIdsRequest;
+import com.ocean.piuda.admin.report.dto.request.ReportDraftByPeriodRequest;
+import com.ocean.piuda.admin.report.dto.response.ReportDraftResponse;
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+import com.ocean.piuda.admin.report.util.ReportPromptBuilder;
+import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
+import com.ocean.piuda.ai.gemini.service.GeminiTextService;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ReportDraftService {
+
+    private final GeminiTextService geminiTextService;
+    private final SubmissionRepository submissionRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${gemini.model.report:${gemini.model.text}}")
+    private String reportModel;
+
+    public ReportDraftResponse generateByIds(ReportDraftByIdsRequest request) {
+        List<Long> ids = distinctPreserveOrder(request.ids());
+        List<Submission> found =
+                submissionRepository.findAllByIdsAndStatusWithDetails(ids, SubmissionStatus.APPROVED);
+
+        // 요청 순서 보존 정렬
+        Map<Long, Integer> order = new HashMap<>();
+        for (int i = 0; i < ids.size(); i++) order.put(ids.get(i), i);
+        found.sort(Comparator.comparingInt(s -> order.getOrDefault(s.getSubmissionId(), Integer.MAX_VALUE)));
+
+        List<Long> foundIds = found.stream().map(Submission::getSubmissionId).toList();
+        List<Long> missing = ids.stream().filter(id -> !foundIds.contains(id)).toList();
+
+        return generate(found, ids, missing, request.prompt(), request.reportType());
+    }
+
+    public ReportDraftResponse generateByPeriod(ReportDraftByPeriodRequest request) {
+        LocalDateTime start = request.dateFrom().atStartOfDay();
+        LocalDateTime end = request.dateTo().atTime(23, 59, 59);
+
+        List<Submission> found =
+                submissionRepository.findAllByStatusAndSubmittedAtBetweenWithDetails(
+                        SubmissionStatus.APPROVED, start, end
+                );
+
+        List<Long> foundIds = found.stream().map(Submission::getSubmissionId).toList();
+        return generate(found, foundIds, List.of(), request.prompt(), request.reportType());
+    }
+
+    private ReportDraftResponse generate(
+            List<Submission> submissions,
+            List<Long> submissionIds,
+            List<Long> missingIds,
+            String extraPrompt,
+            ReportDraftType reportType
+    ) {
+        if (submissions == null || submissions.isEmpty()) {
+            throw new BusinessException(
+                    ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR,
+                    Map.of(
+                            "reason", "선택된 기간/IDs에 해당하는 APPROVED submission이 없습니다.",
+                            "missingIds", missingIds
+                    )
+            );
+        }
+        if (reportType == null) {
+            throw new BusinessException(
+                    ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR,
+                    Map.of("reason", "reportType은 필수입니다.")
+            );
+        }
+
+        // 너무 많으면 프롬프트 폭증 방지 (필요시 조정)
+        List<Submission> trimmed = submissions.size() > 50 ? submissions.subList(0, 50) : submissions;
+
+        String submissionsJson = toCompactJson(trimmed);
+
+        // ✅ 타입 1개만 출력하도록 프롬프트 구성
+        String prompt = ReportPromptBuilder.build(submissionsJson, extraPrompt, reportType);
+
+        GeminiResponse gemResp = geminiTextService.generateReportDraft(prompt);
+        String raw = gemResp.content();
+        GeminiMeta meta = gemResp.meta();
+        String cleaned = cleanupJson(raw);
+
+        // ✅ JSON에서 요청한 키 1개만 파싱
+        String content;
+        try {
+            JsonNode root = objectMapper.readTree(cleaned);
+            content = root.path(reportType.jsonKey()).asText("");
+        } catch (Exception e) {
+            log.warn("Gemini report JSON parse failed. raw={}", raw, e);
+            // 파싱 실패 시 raw를 그대로 반환(운영상 디버깅)
+            content = raw == null ? "" : raw;
+        }
+
+        // 실제 사용된 ids (trimmed 기준)
+        List<Long> usedIds = trimmed.stream().map(Submission::getSubmissionId).toList();
+
+        // ✅ 선택 타입에 맞는 필드만 채워서 반환
+        ReportDraftResponse.ReportDraftResponseBuilder builder = ReportDraftResponse.builder()
+                .submissionIds(usedIds)
+                .missingIds(missingIds)
+                .reportType(reportType)
+                .meta(meta);
+
+        switch (reportType) {
+            case INTERNAL_DRAFT -> builder.internalDraft(content);
+            case EXTERNAL_NEWSLETTER -> builder.externalNewsletter(content);
+            case EXTERNAL_INSTAGRAM -> builder.externalInstagram(content);
+            case EXTERNAL_PUBLICATION -> builder.externalPublication(content);
+        }
+
+        return builder.build();
+    }
+
+    private String toCompactJson(List<Submission> submissions) {
+        try {
+            List<Map<String, Object>> rows = submissions.stream()
+                    .map(this::toPromptRow)
+                    .collect(Collectors.toList());
+            return objectMapper.writeValueAsString(rows);
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ExceptionType.UNEXPECTED_SERVER_ERROR,
+                    Map.of("reason", "submissions JSON 변환 실패", "message", e.getMessage())
+            );
+        }
+    }
+
+    /**
+     * ✅ 리포트 프롬프트용 Row 구성 정책
+     * - null 값은 "키 자체를 넣지 않음"(omit null)
+     * - 활동유형에 비적용인 지표(예: TRASH_COLLECTION의 healthGrade/growthCm 등)는 아예 제외
+     */
+    private Map<String, Object> toPromptRow(Submission s) {
+        Map<String, Object> m = new LinkedHashMap<>();
+
+        // ✅ 식별: 현장명 + 제출일시만 사용 (submissionId 제거)
+        putIfNotBlank(m, "siteName", s.getSiteName());
+        putIfNotNull(m, "submittedAt", s.getSubmittedAt() != null ? s.getSubmittedAt().toString() : null);
+        putIfNotNull(m, "activityType", s.getActivityType() != null ? s.getActivityType().name() : null);
+
+        // ✅ basicEnv: recordDate/startTime/endTime 제외, 환경 수치만 유지 (null 키 제거)
+        if (s.getBasicEnv() != null) {
+            Map<String, Object> env = new LinkedHashMap<>();
+            putIfNotNull(env, "waterTempC", s.getBasicEnv().getWaterTempC());
+            putIfNotNull(env, "visibilityM", s.getBasicEnv().getVisibilityM());
+            putIfNotNull(env, "depthM", s.getBasicEnv().getDepthM());
+            putIfNotNull(env, "currentState", s.getBasicEnv().getCurrentState() != null ? s.getBasicEnv().getCurrentState().name() : null);
+            putIfNotNull(env, "weather", s.getBasicEnv().getWeather() != null ? s.getBasicEnv().getWeather().name() : null);
+
+            removeNullsDeep(env);
+            if (!env.isEmpty()) m.put("basicEnv", env);
+        }
+
+        // ✅ participants 완전 제외
+
+        // ✅ activity: 공통 필드 + (활동유형에 따라) 의미 있는 필드만 포함
+        if (s.getActivity() != null) {
+            Map<String, Object> a = new LinkedHashMap<>();
+            putIfNotNull(a, "type", s.getActivity().getType() != null ? s.getActivity().getType().name() : null);
+            putIfNotBlank(a, "details", truncate(s.getActivity().getDetails(), 600));
+            putIfNotNull(a, "collectionAmount", s.getActivity().getCollectionAmount());
+            putIfNotNull(a, "durationHours", s.getActivity().getDurationHours());
+
+            // ✅ healthGrade/growth/naturalReproduction/survival 등은
+            //    이식/연구/모니터링 계열에서만 의미가 있으므로 그때만 포함
+            ActivityType type = s.getActivity().getType();
+            if (type == ActivityType.TRANSPLANT || type == ActivityType.MONITORING || type == ActivityType.RESEARCH) {
+                putIfNotNull(a, "healthGrade", s.getActivity().getHealthGrade() != null ? s.getActivity().getHealthGrade().name() : null);
+                putIfNotNull(a, "growthCm", s.getActivity().getGrowthCm());
+
+                if (s.getActivity().getNaturalReproduction() != null) {
+                    Map<String, Object> nat = new LinkedHashMap<>();
+                    putIfNotNull(nat, "radiusM", s.getActivity().getNaturalReproduction().getRadiusM());
+                    putIfNotNull(nat, "numerator", s.getActivity().getNaturalReproduction().getNumerator());
+                    putIfNotNull(nat, "denominator", s.getActivity().getNaturalReproduction().getDenominator());
+                    removeNullsDeep(nat);
+                    if (!nat.isEmpty()) a.put("naturalReproduction", nat);
+                }
+
+                if (s.getActivity().getSurvival() != null) {
+                    Map<String, Object> surv = new LinkedHashMap<>();
+                    putIfNotNull(surv, "dieCount", s.getActivity().getSurvival().getDieCount());
+                    putIfNotNull(surv, "totalCount", s.getActivity().getSurvival().getTotalCount());
+                    removeNullsDeep(surv);
+                    if (!surv.isEmpty()) a.put("survival", surv);
+                }
+            }
+
+            removeNullsDeep(a);
+            if (!a.isEmpty()) m.put("activity", a);
+        }
+
+        putIfNotBlank(m, "feedbackText", truncate(s.getFeedbackText(), 600));
+
+        removeNullsDeep(m);
+        return m;
+    }
+
+    private static void putIfNotNull(Map<String, Object> m, String key, Object value) {
+        if (value != null) m.put(key, value);
+    }
+
+    private static void putIfNotBlank(Map<String, Object> m, String key, String value) {
+        if (value != null && !value.isBlank()) m.put(key, value);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void removeNullsDeep(Map<String, Object> m) {
+        if (m == null) return;
+        m.entrySet().removeIf(e -> e.getValue() == null);
+
+        for (Object v : m.values()) {
+            if (v instanceof Map<?, ?> mm) {
+                removeNullsDeep((Map<String, Object>) mm);
+            }
+        }
+    }
+
+    private static String truncate(String s, int max) {
+        if (s == null) return null;
+        String t = s.trim();
+        if (t.length() <= max) return t;
+        return t.substring(0, max) + "…";
+    }
+
+    private static String cleanupJson(String raw) {
+        if (raw == null) return "";
+        String t = raw.trim();
+        // 혹시 모델이 코드펜스를 붙였을 때 제거
+        t = t.replaceAll("^```json\\s*", "").replaceAll("^```\\s*", "");
+        t = t.replaceAll("\\s*```$", "");
+        return t.trim();
+    }
+
+    private static List<Long> distinctPreserveOrder(List<Long> ids) {
+        if (ids == null) return List.of();
+        LinkedHashSet<Long> set = new LinkedHashSet<>(ids);
+        return new ArrayList<>(set);
+    }
+}

--- a/src/main/java/com/ocean/piuda/admin/report/util/ReportPromptBuilder.java
+++ b/src/main/java/com/ocean/piuda/admin/report/util/ReportPromptBuilder.java
@@ -1,0 +1,56 @@
+package com.ocean.piuda.admin.report.util;
+
+import com.ocean.piuda.admin.report.enums.ReportDraftType;
+
+public class ReportPromptBuilder {
+
+    private ReportPromptBuilder() {}
+
+    public static String build(String submissionsJson, String extraPromptOrNull, ReportDraftType type) {
+        String extra = (extraPromptOrNull == null) ? "" : extraPromptOrNull.trim();
+        String key = type.jsonKey();
+
+        String guide = switch (type) {
+            case INTERNAL_DRAFT -> """
+- internalDraft: 기간/범위, 활동유형별 요약, 정량(수거량/이식수 등), 운영/이슈 중심.
+- (중요) 데이터에 없거나 활동유형에 비적용인 지표는 "기록 없음"으로 쓰지 말고 항목 자체를 생략한다.
+- 누락이 운영상 문제로 보이는 경우에만 "확인 필요"로 짧게 표시한다.
+""";
+            case EXTERNAL_NEWSLETTER -> """
+- externalNewsletter: 짧은 제목 + 2~4문단 + 하이라이트 bullet + CTA.
+""";
+            case EXTERNAL_INSTAGRAM -> """
+- externalInstagram: 4~10줄 스토리텔링 + 핵심 bullet 2~4개 + 해시태그 8~15개.
+""";
+            case EXTERNAL_PUBLICATION -> """
+- externalPublication: 제목/리드문/본문(소제목 가능) + 성과 요약.
+""";
+        };
+
+        return """
+너는 해양 활동 기록 제출물(Submission)을 바탕으로 리포트 초안을 작성하는 전문 에디터다.
+
+[중요 원칙]
+- 아래에 제공된 JSON 데이터에 포함된 사실만 사용한다. 추측/날조 금지.
+- 데이터가 부족하면 INTERNAL_DRAFT는 필요한 경우에만 "확인 필요"로 표시하고, 그 외 유형은 "확인 필요" 또는 "기록 없음"으로 명시한다.
+- 외부홍보용(external*)에는 개인정보/민감정보를 포함하지 말 것:
+  - 이메일/연락처 금지
+  - 위도/경도 등 정확 좌표 금지(지역명 수준으로만)
+- 문서는 모두 한국어로 작성한다.
+- 결과는 반드시 "JSON만" 출력한다. 코드펜스( ``` ) 금지.
+- 아래에서 지정한 키 1개만 출력한다. 다른 키/설명/문장 절대 추가 금지.
+
+[데이터]
+%s
+
+[출력 JSON 스키마] (반드시 이 키 하나만)
+{ "%s": "요청된 유형의 마크다운 초안" }
+
+[작성 가이드]
+%s
+
+[추가 지시사항(있으면 반영)]
+%s
+""".formatted(submissionsJson, key, guide, extra.isBlank() ? "(없음)" : extra);
+    }
+}

--- a/src/main/java/com/ocean/piuda/admin/submission/repository/SubmissionRepository.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/repository/SubmissionRepository.java
@@ -72,5 +72,23 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
             @Param("ids") List<Long> ids,
             @Param("status") SubmissionStatus status
     );
+
+    @Query("""
+    SELECT DISTINCT s FROM Submission s
+    LEFT JOIN FETCH s.basicEnv
+    LEFT JOIN FETCH s.participants
+    LEFT JOIN FETCH s.activity
+    LEFT JOIN FETCH s.attachments
+    WHERE s.status = :status
+      AND s.submittedAt BETWEEN :start AND :end
+    ORDER BY s.submittedAt DESC
+    """)
+    List<Submission> findAllByStatusAndSubmittedAtBetweenWithDetails(
+            @Param("status") SubmissionStatus status,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
+    );
+
+
 }
 

--- a/src/main/java/com/ocean/piuda/ai/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/ai/ProjectExporter.java
@@ -1,0 +1,139 @@
+package com.ocean.piuda.ai;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n" + "=".repeat(80) + "\n");
+            writer.write("File Path: " + file.toString() + "\n");
+            writer.write("=".repeat(80) + "\n\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ocean/piuda/ai/gemini/service/GeminiTextService.java
+++ b/src/main/java/com/ocean/piuda/ai/gemini/service/GeminiTextService.java
@@ -5,6 +5,7 @@ import com.google.genai.Client;
 import com.google.genai.types.Content;
 import com.google.genai.types.GenerateContentConfig;
 import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
 import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
 import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
 import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
@@ -16,9 +17,9 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class GeminiTextService {
 
     private final Client client;
@@ -26,14 +27,48 @@ public class GeminiTextService {
     @Value("${gemini.model.text}")
     private String defaultTextModel;
 
+    @Value("${gemini.model.report:${gemini.model.text}}")
+    private String reportModel;
 
     private static final String SYS_TEXT =
             "너는 신뢰할 수 있는 AI 어시스턴트다. 사실과 논리를 중시하고, 모르는 것은 모른다고 말하라.";
 
+    private static final String SYS_REPORT =
+            "너는 해양 활동 기록 제출물 기반 리포트 초안 작성 AI다. " +
+                    "주어진 데이터에 없는 사실을 만들지 말고, 개인정보(이메일/연락처)/정확 좌표는 대외용에 절대 포함하지 말라. " +
+                    "반드시 지정된 JSON 스키마만 출력하라.";
 
     public GeminiResponse complete(GeminiRequest req) {
-        String model = defaultTextModel;
-        GenerateContentResponse resp = client.models.generateContent(model, req.prompt(), null);
+        return generate(defaultTextModel, SYS_TEXT, req.prompt());
+    }
+
+    public GeminiResponse generateReportDraft(String prompt) {
+        return generate(reportModel, SYS_REPORT, prompt);
+    }
+
+    private GeminiResponse generate(String model, String systemInstruction, String userPrompt) {
+
+        // role은 user/model만 허용 → user로만 content 구성
+        List<Content> contents = List.of(
+                Content.builder()
+                        .role("user")
+                        .parts(Part.fromText(userPrompt == null ? "" : userPrompt))
+                        .build()
+        );
+
+        // system은 config.systemInstruction으로
+        GenerateContentConfig config = GenerateContentConfig.builder()
+                .systemInstruction(
+                        Content.builder()
+                                .role("user") // (여기도 user/model만 허용이라 user로 넣습니다)
+                                .parts(Part.fromText(systemInstruction))
+                                .build()
+                )
+                .temperature(0.2f)
+                .build();
+
+        // 재시도는 원하면 여기서 감싸면 됨(5xx만)
+        GenerateContentResponse resp = client.models.generateContent(model, contents, config);
 
         String text = GeminiSdkUtil.extractText(resp);
         GeminiMeta meta = GeminiSdkUtil.toMeta(model, resp);

--- a/src/main/java/com/ocean/piuda/ai/project_context.txt
+++ b/src/main/java/com/ocean/piuda/ai/project_context.txt
@@ -1,0 +1,1280 @@
+
+================================================================================
+File Path: .\gemini\config\GeminiConfig.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.config;
+
+
+import com.google.genai.Client;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class GeminiConfig {
+
+    @Bean
+    public Client geminiClient(
+            @Value("${gemini.api.key}") String apiKey
+    ) {
+        return Client.builder()
+                .apiKey(apiKey)   // Developer API 키
+                .build();
+    }
+}
+
+
+================================================================================
+File Path: .\gemini\controller\GeminiTextController.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.controller;
+
+import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
+import com.ocean.piuda.ai.gemini.service.GeminiTextService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ai/gemini")
+@RequiredArgsConstructor
+@Tag(name = "Gemini Text API", description = "Gemini 기반 자연어 처리 AI API")
+public class GeminiTextController {
+
+    private final GeminiTextService service;
+
+    @PostMapping("/text/complete")
+    @Operation(
+            summary = "프롬프트 처리",
+            description = """
+                    텍스트 프롬프트를 Gemini 모델로 보냅니다.
+                    """
+    )
+    public ApiData<GeminiResponse> complete(
+            @RequestBody @Valid GeminiRequest request
+    ) {
+        return ApiData.ok(service.complete(request));
+    }
+}
+
+
+================================================================================
+File Path: .\gemini\controller\GeminiVisionController.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.controller;
+
+import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
+import com.ocean.piuda.ai.gemini.service.GeminiVisionService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/ai/gemini")
+@RequiredArgsConstructor
+@Tag(name = "Gemini Vision API", description = "Gemini 기반 단일 이미지 설명/분석 API")
+public class GeminiVisionController {
+
+    private final GeminiVisionService service;
+
+    @PostMapping(
+            value = "/vision/describe",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    @Operation(
+            summary = "이미지 설명/분석",
+            description = """
+                    단일 이미지를 업로드하고, 프롬프트를 JSON 파트로 함께 전달하세요.
+                    - Multipart 파트: image(파일), request(JSON)
+                    - 20MB 초과 파일은 Files API 사용을 권장합니다.
+                    """
+    )
+    public ApiData<GeminiResponse> describe(
+            @Parameter(name = "image", required = true,
+                    content = @Content(mediaType = "image/*",
+                            schema = @Schema(type = "string", format = "binary")))
+            @RequestPart("image") MultipartFile image,
+            @Parameter(name = "request", required = false,
+                    content = @Content(mediaType = "application/json",
+                            schema = @Schema(implementation = GeminiRequest.class)))
+            @RequestPart(name = "request", required = false) @Valid GeminiRequest request
+    ) {
+        GeminiRequest req = request == null ? GeminiRequest.builder().build() : request;
+        return ApiData.ok(service.describe(image, req));
+    }
+}
+
+
+================================================================================
+File Path: .\gemini\dto\request\GeminiRequest.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.dto.request;
+
+
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+/**
+ * 단일 이미지 + 프롬프트로 설명/분석 요청
+ */
+@Builder
+public record GeminiRequest(
+        @Size(max = 2000, message = "prompt는 2000자 이하여야 합니다.")
+        String prompt
+) { }
+
+
+================================================================================
+File Path: .\gemini\dto\response\GeminiMeta.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GeminiMeta(
+        String model,
+        Integer promptTokens,
+        Integer candidatesTokens,
+        Integer totalTokens
+) { }
+
+
+================================================================================
+File Path: .\gemini\dto\response\GeminiResponse.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.dto.response;
+
+
+import lombok.Builder;
+
+@Builder
+public record GeminiResponse(
+        String content,
+        GeminiMeta meta
+) { }
+
+
+================================================================================
+File Path: .\gemini\service\GeminiTextService.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.service;
+
+
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentConfig;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
+import com.ocean.piuda.ai.gemini.util.GeminiSdkUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GeminiTextService {
+
+    private final Client client;
+
+    @Value("${gemini.model.text}")
+    private String defaultTextModel;
+
+    @Value("${gemini.model.report:${gemini.model.text}}")
+    private String reportModel;
+
+    private static final String SYS_TEXT =
+            "너는 신뢰할 수 있는 AI 어시스턴트다. 사실과 논리를 중시하고, 모르는 것은 모른다고 말하라.";
+
+    private static final String SYS_REPORT =
+            "너는 해양 활동 기록 제출물 기반 리포트 초안 작성 AI다. " +
+                    "주어진 데이터에 없는 사실을 만들지 말고, 개인정보(이메일/연락처)/정확 좌표는 대외용에 절대 포함하지 말라. " +
+                    "반드시 지정된 JSON 스키마만 출력하라.";
+
+    public GeminiResponse complete(GeminiRequest req) {
+        return generate(defaultTextModel, SYS_TEXT, req.prompt());
+    }
+
+    public GeminiResponse generateReportDraft(String prompt) {
+        return generate(reportModel, SYS_REPORT, prompt);
+    }
+
+    private GeminiResponse generate(String model, String systemInstruction, String userPrompt) {
+
+        // role은 user/model만 허용 → user로만 content 구성
+        List<Content> contents = List.of(
+                Content.builder()
+                        .role("user")
+                        .parts(Part.fromText(userPrompt == null ? "" : userPrompt))
+                        .build()
+        );
+
+        // system은 config.systemInstruction으로
+        GenerateContentConfig config = GenerateContentConfig.builder()
+                .systemInstruction(
+                        Content.builder()
+                                .role("user") // (여기도 user/model만 허용이라 user로 넣습니다)
+                                .parts(Part.fromText(systemInstruction))
+                                .build()
+                )
+                .temperature(0.2f)
+                .build();
+
+        // 재시도는 원하면 여기서 감싸면 됨(5xx만)
+        GenerateContentResponse resp = client.models.generateContent(model, contents, config);
+
+        String text = GeminiSdkUtil.extractText(resp);
+        GeminiMeta meta = GeminiSdkUtil.toMeta(model, resp);
+        return GeminiResponse.builder().content(text).meta(meta).build();
+    }
+}
+
+
+================================================================================
+File Path: .\gemini\service\GeminiVisionService.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.service;
+
+import com.google.genai.Client;
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentResponse;
+import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiResponse;
+import com.ocean.piuda.ai.gemini.util.GeminiSdkUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GeminiVisionService {
+
+    private final Client client;
+
+    @Value("${gemini.model.vision}")
+    private String defaultVisionModel;
+
+    private static final long MAX_INLINE_BYTES = 20L * 1024 * 1024;
+
+    public GeminiResponse describe(MultipartFile image, GeminiRequest req) {
+
+        byte[] bytes = readBytesWithLimit(image);
+        String mime = safeMime(image);
+
+        List<Content> contents =
+                GeminiSdkUtil.buildUserContents(bytes, mime, req.prompt());
+
+
+
+        GenerateContentResponse resp = client.models.generateContent(defaultVisionModel, contents, null);
+
+        String text = GeminiSdkUtil.extractText(resp);
+        GeminiMeta meta = GeminiSdkUtil.toMeta(defaultVisionModel, resp);
+        return GeminiResponse.builder().content(text).meta(meta).build();
+    }
+
+    private static byte[] readBytesWithLimit(MultipartFile image) {
+        if (image == null || image.isEmpty()) throw new IllegalArgumentException("image 파일이 필요합니다.");
+        if (image.getSize() > MAX_INLINE_BYTES) {
+            throw new IllegalArgumentException("이미지 용량이 너무 큽니다(<=20MB). Files API 사용 권장");
+        }
+        try { return image.getBytes(); }
+        catch (IOException e) { throw new IllegalStateException("이미지 바이트를 읽을 수 없습니다.", e); }
+    }
+
+    private static String safeMime(MultipartFile file) {
+        String c = file.getContentType();
+        return (c == null || c.isBlank()) ? MediaType.IMAGE_JPEG_VALUE : c;
+    }
+}
+
+
+================================================================================
+File Path: .\gemini\util\GeminiSdkUtil.java
+================================================================================
+
+package com.ocean.piuda.ai.gemini.util;
+
+
+import com.google.genai.types.Content;
+import com.google.genai.types.GenerateContentResponse;
+import com.google.genai.types.Part;
+import com.ocean.piuda.ai.gemini.dto.response.GeminiMeta;
+
+import java.util.List;
+import java.util.Objects;
+
+public class GeminiSdkUtil {
+
+    // 이미지 + 프롬프트
+    public static List<Content> buildUserContents(byte[] imageBytes, String mimeType, String promptOrNull) {
+        Part image = Part.fromBytes(imageBytes, mimeType);
+        if (promptOrNull == null || promptOrNull.isBlank()) {
+            return List.of(Content.fromParts(image));
+        }
+         return List.of(
+             Content.builder()
+                    .role("user")
+                    .parts(image, Part.fromText(promptOrNull))
+                    .build()
+         );
+    }
+
+
+
+    public static String extractText(GenerateContentResponse resp) {
+        try { return Objects.toString(resp.text(), ""); }
+        catch (Exception e) { return ""; }
+    }
+
+    public static GeminiMeta toMeta(String model, GenerateContentResponse resp) {
+        var usageOpt = resp.usageMetadata();
+        Integer pt = null, ct = null, tt = null;
+        if (usageOpt.isPresent()) {
+            var u = usageOpt.get();
+            pt = u.promptTokenCount().orElse(null);
+            ct = u.candidatesTokenCount().orElse(null);
+            tt = u.totalTokenCount().orElse(null);
+        }
+        return GeminiMeta.builder()
+                .model(model)
+                .promptTokens(pt)
+                .candidatesTokens(ct)
+                .totalTokens(tt)
+                .build();
+    }
+}
+
+
+================================================================================
+File Path: .\groq\controller\GroqApiController.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.controller;
+
+import com.ocean.piuda.ai.groq.dto.request.EvaluateHarmfulnessRequest;
+import com.ocean.piuda.ai.groq.dto.request.GroqPromptRequest;
+import com.ocean.piuda.ai.groq.dto.response.EvaluateHarmfulnessResponse;
+import com.ocean.piuda.ai.groq.dto.response.GroqPromptResponse;
+import com.ocean.piuda.ai.groq.service.GroqApiService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ai/groq")
+@RequiredArgsConstructor
+@Tag(name = "Groq AI API", description = "Groq 기반 자연어 처리 AI API")
+public class GroqApiController {
+
+    private final GroqApiService groqApiService;
+
+    @PostMapping("/complete")
+    @Operation(
+            summary = "프롬프트 처리",
+            description = """
+                    사용자 프롬프트를 Groq 모델에 전달해 응답을 생성합니다.
+                    - `useRealtime=true`면 실시간 웹 검색을 통한 최신 정보가 반영된 응답을 생성하며, 해당 응답의 출처는 `meta.executedTools`에만 담겨 반환됩니다.
+                    - 최신정보 반영이 필요 없는 처리는 `useRealtime` 을 명시하지 않으면 됩니다.
+                    """
+    )
+    public ApiData<GroqPromptResponse> complete(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "프롬프트/옵션(useRealtime)",
+                    required = true
+            )
+            @RequestBody @Valid GroqPromptRequest request
+    ) {
+        return ApiData.ok(groqApiService.complete(request));
+    }
+
+    @PostMapping("/harmfulness")
+    @Operation(
+            summary = "문장 유해성 평가",
+            description = """
+                    입력 문장의 유해성 정도를 0~10 사이 정수로 평가합니다.
+                    - 실시간 검색은 사용하지 않으며, 도구 호출을 차단합니다.
+                    """
+    )
+    public ApiData<EvaluateHarmfulnessResponse> evaluateHarmfulness(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "유해성 평가할 문장",
+                    required = true
+            )
+            @RequestBody @Valid EvaluateHarmfulnessRequest request
+    ) {
+        return ApiData.ok(groqApiService.evaluateHarmfulness(request));
+    }
+}
+
+
+================================================================================
+File Path: .\groq\dto\request\EvaluateHarmfulnessRequest.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+
+@Builder
+public record EvaluateHarmfulnessRequest (
+        @NotBlank(message = "sentence는 비어 있을 수 없습니다.")
+        String sentence
+){ }
+
+
+================================================================================
+File Path: .\groq\dto\request\GroqPromptRequest.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Builder;
+
+@Builder
+public record GroqPromptRequest(
+
+        @NotBlank(message = "prompt는 비어 있을 수 없습니다.")
+        String prompt,          // 필수: 사용자 프롬프트
+
+        // 선택: 기본 false. true면 groq/compound + Web Search 사용
+        Boolean useRealtime
+
+) { }
+
+
+================================================================================
+File Path: .\groq\dto\response\EvaluateHarmfulnessResponse.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.dto.response;
+
+import lombok.Builder;
+
+
+@Builder
+public record EvaluateHarmfulnessResponse(
+        int degree,
+        GroqMeta meta
+
+) { }
+
+
+================================================================================
+File Path: .\groq\dto\response\GroqMeta.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.dto.response;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import lombok.Builder;
+
+/**
+ * 모든 응답에 공통으로 담길 메타 정보
+ */
+@Builder
+public record GroqMeta(
+        String model,                         // 호출한 모델
+        Integer promptTokens,                 // usage.prompt_tokens
+        Integer completionTokens,             // usage.completion_tokens
+        Integer totalTokens,                  // usage.total_tokens
+        String requestId,                     // x-request-id
+        String rateLimitRequestsRemaining,    // x-ratelimit-remaining-requests
+        String rateLimitTokensRemaining,      // x-ratelimit-remaining-tokens (있을 때)
+        String rateLimitReset ,                // x-ratelimit-reset (있을 때)
+        JsonNode executedTools                  // ← choices[0].message.executed_tools 원본 JSON(있으면)
+
+) { }
+
+
+================================================================================
+File Path: .\groq\dto\response\GroqPromptResponse.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record GroqPromptResponse(
+        String content,   // 모델 응답 텍스트
+        GroqMeta meta
+) { }
+
+
+================================================================================
+File Path: .\groq\service\GroqApiService.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ocean.piuda.ai.groq.dto.request.EvaluateHarmfulnessRequest;
+import com.ocean.piuda.ai.groq.dto.request.GroqPromptRequest;
+import com.ocean.piuda.ai.groq.dto.response.EvaluateHarmfulnessResponse;
+import com.ocean.piuda.ai.groq.dto.response.GroqMeta;
+import com.ocean.piuda.ai.groq.dto.response.GroqPromptResponse;
+import com.ocean.piuda.ai.groq.util.GroqApiUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroqApiService {
+
+    private final RestTemplate restTemplate;
+    private final GroqApiUtil groqApiUtil;
+
+    @Value("${groq.api.key}")
+    private String apiKey;
+
+    /** 디폴트 모델 */
+    @Value("${groq.api.model}")
+    private String defaultModel;
+    private String REAL_TIME_MODEL= "groq/compound";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String GROQ_CHAT_URL = "https://api.groq.com/openai/v1/chat/completions";
+
+    /** 서버 고정 시스템 프롬프트(오프라인 모델용) */
+    private static final String SYS_OFFLINE =
+            "인터넷이나 최신 데이터에 직접 접근할 수 없다. 최신/실시간 정보를 요구받으면 "
+                    + "'실시간 정보에 접근 불가'라고 분명히 알리고, 비실시간 일반 지식만 답하라. "
+                    + "최종 답변 본문에는 절대 URL을 포함하지 말라.";
+
+    /** 서버 고정 시스템 프롬프트(compound 모델용) */
+    private static final String SYS_COMPOUND =
+            "최신 정보가 필요한 경우 내장 웹검색/브라우저 도구를 사용해 사실을 검증하라. "
+                    + "그러나 최종 답변 본문에는 URL을 포함하지 말고, 출처는 도구 실행 결과(executed_tools)에만 남겨라.";
+
+    /** 유해성 평가: 항상 오프라인(툴 차단) */
+    public EvaluateHarmfulnessResponse evaluateHarmfulness(EvaluateHarmfulnessRequest request) {
+        final String model = defaultModel; // 고정
+        final String userPrompt =
+                "Return only a number from 0 to 10 indicating the degree of harmfulness of the text. "
+                        + "Higher means more harmful. No explanations.\n\nText:\n"
+                        + String.valueOf(request.sentence());
+
+        ArrayNode messages = groqApiUtil.buildMessages(SYS_OFFLINE, userPrompt);
+        ObjectNode payload = groqApiUtil.buildRequestPayload(model, messages);
+
+        ResponseEntity<String> resp = groqApiUtil.postChat(payload);
+        String raw = resp.getBody();
+
+        int degree = -1;
+        try {
+            JsonNode rootNode = MAPPER.readTree(raw);
+            String content = rootNode.path("choices").path(0).path("message").path("content").asText("");
+            String digits = content.replaceAll("[^0-9]", "");
+            if (!digits.isEmpty()) degree = Integer.parseInt(digits);
+        } catch (Exception e) {
+            log.warn("Failed to parse harmfulness score", e);
+        }
+
+        GroqMeta meta = groqApiUtil.buildMeta(resp, raw, model);
+        return EvaluateHarmfulnessResponse.builder()
+                .degree(degree)
+                .meta(meta)
+                .build();
+    }
+
+    /** 일반 프롬프트: useRealtime=true면 compound, 아니면 오프라인 */
+    public GroqPromptResponse complete(GroqPromptRequest req) {
+        final boolean useRealtime = Boolean.TRUE.equals(req.useRealtime());
+        final String model = groqApiUtil.resolveModel(useRealtime);
+        final String sysPrompt = groqApiUtil.resolveSystemPrompt(model);
+
+        ArrayNode messages = groqApiUtil.buildMessages(sysPrompt, String.valueOf(req.prompt()));
+        ObjectNode payload = groqApiUtil.buildRequestPayload(
+                model, messages
+        );
+
+        ResponseEntity<String> resp = groqApiUtil.postChat(payload);
+        String raw = resp.getBody();
+
+        String content = groqApiUtil.extractCleanContent(raw); // URL 제거
+        GroqMeta meta = groqApiUtil.buildMeta(resp, raw, model);
+
+        return GroqPromptResponse.builder()
+                .content(content)
+                .meta(meta)
+                .build();
+    }
+
+}
+
+
+================================================================================
+File Path: .\groq\util\GroqApiUtil.java
+================================================================================
+
+package com.ocean.piuda.ai.groq.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ocean.piuda.ai.groq.dto.response.GroqMeta;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class GroqApiUtil {
+    private final RestTemplate restTemplate;
+
+    @Value("${groq.api.key}")
+    private String apiKey;
+
+    /** 디폴트 모델 (오프라인/기본) */
+    @Value("${groq.api.model}")
+    private String defaultModel;
+
+    /** 실시간 검색 모델 */
+    private static final String REAL_TIME_MODEL = "groq/compound";
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String GROQ_CHAT_URL = "https://api.groq.com/openai/v1/chat/completions";
+
+    /** 서버 고정 시스템 프롬프트(오프라인 모델용) */
+    private static final String SYS_OFFLINE =
+            "인터넷이나 최신 데이터에 직접 접근할 수 없다. 최신/실시간 정보를 요구받으면 "
+                    + "'실시간 정보에 접근 불가'라고 분명히 알리고, 비실시간 일반 지식만 답하라. "
+                    + "최종 답변 본문에는 절대 URL을 포함하지 말라.";
+
+    /** 서버 고정 시스템 프롬프트(compound 모델용) */
+    private static final String SYS_COMPOUND =
+            "최신 정보가 필요한 경우 내장 웹검색/브라우저 도구를 사용해 사실을 검증하라. "
+                    + "그러나 최종 답변 본문에는 URL을 포함하지 말고, 출처는 도구 실행 결과(executed_tools)에만 남겨라.";
+
+    /* ============================== 유틸 ============================== */
+
+    public static boolean isCompound(String model) {
+        return model != null && model.startsWith("groq/compound");
+    }
+
+    public HttpHeaders buildHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(apiKey);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setAccept(List.of(MediaType.APPLICATION_JSON));
+        return headers;
+    }
+
+    public static String header(ResponseEntity<?> resp, String name) {
+        if (resp == null || resp.getHeaders() == null) return null;
+        List<String> v = resp.getHeaders().get(name);
+        if (v != null && !v.isEmpty()) return v.get(0);
+        return resp.getHeaders().entrySet().stream()
+                .filter(e -> e.getKey() != null && e.getKey().equalsIgnoreCase(name))
+                .map(e -> (e.getValue() != null && !e.getValue().isEmpty()) ? e.getValue().get(0) : null)
+                .filter(Objects::nonNull)
+                .findFirst().orElse(null);
+    }
+
+    /** 본문 내 URL 제거(마크다운 링크 및 맨몸 URL) */
+    public static String stripUrls(String text) {
+        if (text == null) return "";
+        // [text](url) -> text
+        text = text.replaceAll("\\[([^\\]]+)\\]\\((https?://[^)\\s]+)\\)", "$1");
+        // bare URL 제거
+        text = text.replaceAll("https?://\\S+", "");
+        // 잉여 공백 정리
+        return text.replaceAll("[ \\t]+\\n", "\n").trim();
+    }
+
+    /** 모델 선택 (useRealtime=true면 compound로 강제) */
+    public String resolveModel(boolean useRealtime) {
+        return useRealtime ? REAL_TIME_MODEL : defaultModel;
+    }
+
+    /** 서버 고정 시스템 프롬프트 */
+    public String resolveSystemPrompt(String model) {
+        return isCompound(model) ? SYS_COMPOUND : SYS_OFFLINE;
+    }
+
+    /** 공통: messages 생성 */
+    public ArrayNode buildMessages(String systemContent, String userContent) {
+        ArrayNode messages = MAPPER.createArrayNode();
+
+        ObjectNode sys = MAPPER.createObjectNode();
+        sys.put("role", "system");
+        sys.put("content", systemContent);
+        messages.add(sys);
+
+        ObjectNode user = MAPPER.createObjectNode();
+        user.put("role", "user");
+        user.put("content", userContent);
+        messages.add(user);
+
+        return messages;
+    }
+
+    /** 공통: 요청 payload 생성 */
+    public ObjectNode buildRequestPayload(String model, ArrayNode messages) {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("model", model);
+        root.set("messages", messages);
+        if (!isCompound(model)) {
+            // 오프라인 모델은 툴 사용 차단
+            root.put("tool_choice", "none");
+        }
+        return root;
+    }
+
+    /** 공통: HTTP 호출 */
+    public ResponseEntity<String> postChat(ObjectNode payload) {
+        try {
+            return restTemplate.exchange(
+                    GROQ_CHAT_URL, HttpMethod.POST,
+                    new HttpEntity<>(payload.toString(), buildHeaders()),
+                    String.class
+            );
+        } catch (HttpClientErrorException e) {
+            throw new BusinessException(
+                    ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR,
+                    Map.of("status", e.getStatusCode().value(),
+                            "reason", "Groq 4xx",
+                            "body", e.getResponseBodyAsString())
+            );
+        } catch (HttpServerErrorException e) {
+            throw new BusinessException(
+                    ExceptionType.UNEXPECTED_SERVER_ERROR,
+                    Map.of("status", e.getStatusCode().value(),
+                            "reason", "Groq 5xx",
+                            "body", e.getResponseBodyAsString())
+            );
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ExceptionType.UNEXPECTED_SERVER_ERROR,
+                    Map.of("reason", "Groq call failed",
+                            "message", e.getMessage())
+            );
+        }
+    }
+
+    /** 공통: content 추출(+URL 제거) */
+    public String extractCleanContent(String raw) {
+        try {
+            JsonNode rootNode = MAPPER.readTree(raw);
+            String content = rootNode.path("choices").path(0).path("message").path("content").asText("");
+            return stripUrls(content);
+        } catch (Exception e) {
+            log.warn("Failed to parse content from Groq response", e);
+            return "";
+        }
+    }
+
+    /** 공통: 메타 생성 (usage, executed_tools 포함) */
+    public GroqMeta buildMeta(ResponseEntity<String> resp, String raw, String modelUsed) {
+        Integer pt = null, ct = null, tt = null;
+        JsonNode executedTools = null;
+
+        try {
+            if (raw != null) {
+                JsonNode rootNode = MAPPER.readTree(raw);
+                JsonNode usage = rootNode.path("usage");
+                if (!usage.isMissingNode()) {
+                    pt = usage.path("prompt_tokens").isInt() ? usage.path("prompt_tokens").asInt() : null;
+                    ct = usage.path("completion_tokens").isInt() ? usage.path("completion_tokens").asInt() : null;
+                    tt = usage.path("total_tokens").isInt() ? usage.path("total_tokens").asInt() : null;
+                }
+                JsonNode executed = rootNode.path("choices").path(0).path("message").path("executed_tools");
+                if (executed.isArray() && executed.size() > 0) {
+                    executedTools = executed;
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Failed to parse usage/executed_tools", e);
+        }
+
+        String requestId = header(resp, "x-request-id");
+        String rlReqRemain = header(resp, "x-ratelimit-remaining-requests");
+        String rlTokRemain = header(resp, "x-ratelimit-remaining-tokens");
+        String rlReset     = header(resp, "x-ratelimit-reset");
+
+        return GroqMeta.builder()
+                .model(modelUsed)
+                .promptTokens(pt)
+                .completionTokens(ct)
+                .totalTokens(tt)
+                .requestId(requestId)
+                .rateLimitRequestsRemaining(rlReqRemain)
+                .rateLimitTokensRemaining(rlTokRemain)
+                .rateLimitReset(rlReset)
+                .executedTools(executedTools) 
+                .build();
+    }
+
+}
+
+
+================================================================================
+File Path: .\openAI\controller\OpenAIApiController.java
+================================================================================
+
+//package com.ocean.piuda.ai.openAI.controller;
+//
+//import com.ocean.piuda.ai.openAI.dto.request.OpenAIRequest;
+//import com.ocean.piuda.ai.openAI.service.OpenAIApiService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import java.io.IOException;
+//
+//@RequiredArgsConstructor
+//@RestController
+//@RequestMapping("/api/ai/openai")
+//public class OpenAIApiController {
+//
+//    private final OpenAIApiService openAIService;
+//
+//
+//    // 프롬프트 직접
+//    @PostMapping("/complete")
+//    public String complete(@RequestBody OpenAIRequest.Basic openAIRequest) throws IOException {
+//        return openAIService.complete(openAIRequest);
+//    }
+//
+//
+//    // 글을 첨삭
+//    @PostMapping("/advice")
+//    public String enhanceWriting(@RequestBody OpenAIRequest.Basic openAIRequest) throws IOException {
+//        return openAIService.enhanceWriting(openAIRequest);
+//    }
+//
+//
+//    //글의 유해성 판단
+//    @PostMapping("/harmfulness")
+//    public String evaluateHarmfulness(@RequestBody String prompt) throws IOException {
+//        return openAIService.evaluateHarmfulness(prompt);
+//    }
+//
+//    // 여러 문장을 하나로 합쳐 글을 작성
+//    @PostMapping("/compose")
+//    public String composeText(@RequestBody  OpenAIRequest.TextCompose request) throws IOException {
+//        return openAIService.composeText(request);
+//    }
+//
+//
+//
+//
+//
+//
+//
+//}
+
+
+================================================================================
+File Path: .\openAI\dto\request\OpenAIRequest.java
+================================================================================
+
+package com.ocean.piuda.ai.openAI.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class OpenAIRequest {
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ChatMessage {
+        // "system" | "user" | "assistant"
+        private String role;
+        private String content;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class Basic {
+        private String model;
+        private String prompt;                // 기존 호환용
+        private List<ChatMessage> messages;   // 신규 메시지 배열
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class TextCompose {
+        private String model;
+        private List<String> sentences;
+    }
+}
+
+
+================================================================================
+File Path: .\openAI\service\OpenAIApiService.java
+================================================================================
+
+package com.ocean.piuda.ai.openAI.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.ocean.piuda.ai.openAI.dto.request.OpenAIRequest;
+import lombok.extern.slf4j.Slf4j;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Optional;
+
+@Slf4j
+@Service
+public class OpenAIApiService {
+    @Value("${openai.api.key}")
+    private String apiKey;
+
+    private static final String OPENAI_API_URL = "https://api.openai.com/v1/chat/completions";
+    private static final MediaType JSON = MediaType.get("application/json; charset=utf-8");
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private final OkHttpClient client = new OkHttpClient.Builder()
+            .connectTimeout(Duration.ofSeconds(10))
+            .readTimeout(Duration.ofSeconds(60))
+            .writeTimeout(Duration.ofSeconds(30))
+            .build();
+
+    /** 재시도 없이 단 한 번만 호출하는 executeRequest */
+    private String executeRequest(ObjectNode json) throws IOException {
+        RequestBody body = RequestBody.create(JSON, MAPPER.writeValueAsBytes(json));
+
+        Request request = new Request.Builder()
+                .url(OPENAI_API_URL)
+                .header("Authorization", "Bearer " + apiKey)
+                .header("Content-Type", "application/json")
+                .post(body)
+                .build();
+
+        try (Response response = client.newCall(request).execute()) {
+            if (response.isSuccessful()) {
+                ResponseBody rb = response.body();
+                return rb != null ? rb.string() : "";
+            }
+            int code = response.code();
+            String respText = safeBody(response);
+            log.warn("OpenAI non-2xx: code={}, body={}", code, respText);
+            throw buildApiException(code, respText);
+        }
+    }
+
+    /** 에러 본문 안전 추출 */
+    private static String safeBody(Response response) {
+        try {
+            ResponseBody rb = response.body();
+            return rb != null ? rb.string() : "";
+        } catch (Exception e) {
+            return "";
+        }
+    }
+
+    /** OpenAI 형식의 에러 본문을 읽어 의미 있는 메시지로 래핑 */
+    private static IOException buildApiException(int code, String respText) {
+        try {
+            JsonNode node = MAPPER.readTree(respText == null ? "{}" : respText);
+            String msg = node.path("error").path("message").asText("");
+            String type = node.path("error").path("type").asText("");
+            String param = node.path("error").path("param").asText("");
+            String full = String.format("OpenAI API error %d: %s (type=%s, param=%s)", code, msg, type, param);
+            return new IOException(full);
+        } catch (Exception e) {
+            return new IOException("OpenAI API error " + code + ": " + respText);
+        }
+    }
+
+    /** 공통 페이로드 빌더 */
+    private static ObjectNode basePayload(String model, Integer maxTokens) {
+        ObjectNode root = MAPPER.createObjectNode();
+        root.put("model", model);
+        ArrayNode messages = MAPPER.createArrayNode();
+        root.set("messages", messages);
+        if (maxTokens != null && maxTokens > 0) root.put("max_tokens", maxTokens);
+        return root;
+    }
+
+    /** 메시지 노드 */
+    private static ObjectNode message(String role, String content) {
+        ObjectNode m = MAPPER.createObjectNode();
+        m.put("role", role);
+        m.put("content", content == null ? "" : content);
+        return m;
+    }
+
+    // ===================== 퍼블릭 API =====================
+
+    public String enhanceWriting(OpenAIRequest.Basic openAIRequest) throws IOException {
+        ObjectNode root = basePayload(openAIRequest.getModel(), 512);
+        ArrayNode messages = (ArrayNode) root.get("messages");
+        messages.add(message("system",
+                "You are a helpful assistant. Your task is to edit the user's text to improve clarity, grammar, and flow while maintaining the original meaning and tone. Do not change the context or style unless asked."));
+        messages.add(message("user", Optional.ofNullable(openAIRequest.getPrompt()).orElse("")));
+        log.info("Request Body: {}", root);
+        return executeRequest(root);
+    }
+
+    public String complete(OpenAIRequest.Basic openAIRequest) throws IOException {
+        ObjectNode root = basePayload(openAIRequest.getModel(), 512);
+        ArrayNode messages = (ArrayNode) root.get("messages");
+        messages.add(message("system", "You are a helpful assistant."));
+        messages.add(message("user", Optional.ofNullable(openAIRequest.getPrompt()).orElse("")));
+        log.info("Request Body: {}", root);
+        return executeRequest(root);
+    }
+
+    /** gpt-4o-mini 고정 사용 */
+    public String evaluateHarmfulness(String prompt) throws IOException {
+        ObjectNode root = basePayload("gpt-4o-mini", 32);
+        ArrayNode messages = (ArrayNode) root.get("messages");
+        messages.add(message("system",
+                "You are a content moderation assistant. Analyze the following text for any harmful, offensive, or inappropriate content. Rate the harmfulness on a scale from 0 to 10 without further explanation."));
+        messages.add(message("user", Optional.ofNullable(prompt).orElse("")));
+        log.info("Request Body for Harmfulness Evaluation: {}", root);
+        String responseBody = executeRequest(root);
+        return extractHarmfulnessRating(responseBody);
+    }
+
+    public String composeText(OpenAIRequest.TextCompose openAIRequest) throws IOException {
+        String prompt = String.join(" ", openAIRequest.getSentences()).trim();
+        ObjectNode root = basePayload(openAIRequest.getModel(), 512);
+        ArrayNode messages = (ArrayNode) root.get("messages");
+        messages.add(message("system",
+                "You are a writing assistant. Please assist in composing a coherent text from the following list of sentences. The final text should flow naturally and maintain the original meaning of the sentences."));
+        messages.add(message("user", prompt));
+        log.info("Compose Text Request Body: {}", root);
+        return executeRequest(root);
+    }
+
+    private String extractHarmfulnessRating(String responseBody) throws IOException {
+        JsonNode rootNode = MAPPER.readTree(responseBody);
+        String content = rootNode.path("choices").get(0).path("message").path("content").asText();
+        String ratingText = content.replaceAll("[^0-9]", "");
+        return ratingText.isEmpty() ? "0" : ratingText;
+    }
+}
+
+
+================================================================================
+File Path: .\ProjectExporter.java
+================================================================================
+
+package com.ocean.piuda.ai;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n" + "=".repeat(80) + "\n");
+            writer.write("File Path: " + file.toString() + "\n");
+            writer.write("=".repeat(80) + "\n\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+


### PR DESCRIPTION
## 💡 개요 (Summary)

관리자(Admin)가 선택한 해양 활동 제출물(Submission)을 기반으로 Gemini를 이용해 4종 리포트 초안(INTERNAL / NEWSLETTER / INSTAGRAM / PUBLICATION)을 생성할 수 있는 API를 신규 구현했습니다.
개인정보/민감정보 차단, 사실 기반 생성(추측/날조 금지), 단일 타입만 반환 등 운영 안전성을 고려한 프롬프트/응답 파싱 전략을 포함했습니다.

---

## 📝 작업 내용 (Key Changes)

### 1. Report Draft 도메인 신규 추가 (com.ocean.piuda.admin.report)

- **요청 단위:**
  - `POST /api/admin/reports/drafts/by-ids` : 선택한 submission ids 기반 생성
  - `POST /api/admin/reports/drafts/by-period` : 기간(dateFrom~dateTo) 기반 생성

- **리포트 타입(4종) Enum화:** `INTERNAL_DRAFT`, `EXTERNAL_NEWSLETTER`, `EXTERNAL_INSTAGRAM`, `EXTERNAL_PUBLICATION`


### 2. Gemini 기반 리포트 생성 파이프라인 구현

- `ReportDraftService`에서 submissions 조회 → 프롬프트 생성 → Gemini 호출 → JSON 파싱 → 타입별 응답 매핑

- `GeminiTextService.generateReportDraft(prompt)` 호출 결과에서
  - `content()`(raw) → `cleanupJson()`으로 코드펜스 등 노이즈 제거
  - `ObjectMapper`로 파싱 후 `type.jsonKey()` 값만 추출하여 반환

- 파싱 실패 시 운영 디버깅을 위해 raw 반환 fallback 처리(로그 경고 포함)

### 3. 프롬프트 안전장치 강화 (개인정보/좌표 제거 & 사실 기반)

- `ReportPromptBuilder`에서 프롬프트에 다음 원칙 강제:
  - 제공 JSON 데이터 기반 사실만 사용 (추측/날조 금지)
  - 외부홍보용(external*)에 개인정보/정확 좌표 포함 금지
  - "JSON만 출력", "지정된 키 1개만 출력"(다른 키/설명 금지)

- Prompt 입력 데이터는 `toPromptRow()`에서 민감/불필요 필드 제거 및 축약

---

## 🛠️ 기술적 의사결정 (Technical Decisions)
초기에는 submission 상세 데이터(attachments, participants, 긴 텍스트 등)를 다수 포함하고, 4종 리포트를 한 번에 생성하도록 구성하면서 promptTokens / candidatesTokens가 급증했고 일부 케이스에서 응답이 불안정했습니다. 이를 아래와 같은 방식으로 해결하였습니다.

1. 단일 타입 출력 강제
- ReportDraftType을 요청 파라미터로 받고, Gemini 출력도 지정된 키 1개만 내보내도록 프롬프트에서 강제
응답에서도 해당 타입 필드 1개만 채워 반환
- 효과: 출력 토큰을 근본적으로 제한

2. 입력 데이터 축소 (Data Minimization)
- toPromptRow()에서 민감/불필요/중복 필드를 제거하고, 필요한 핵심 필드만 JSON으로 전달
- 효과: promptTokens 안정화

3. 상한선(Trim) 적용
- Submissions가 너무 많을 경우 최대 50건까지만 포함(trimmed)
- 효과: 최악 케이스에서도 프롬프트 폭증 방지
- 결과: 실제 응답(meta)에서 totalTokens가 과도하게 튀는 상황이 크게 줄었고, 타입별 결과 품질도 더 안정적으로 나왔습니다.