### PR TITLE
fix : 로그아웃 쿠키 삭제 로직 하드코딩 제거 및 정책 일원화 Closes #38

### DIFF
--- a/project_context.txt
+++ b/project_context.txt
@@ -1746,6 +1746,463 @@ public class ProjectExporter {
 
 
 ================================================================================
+File Path: .\REFCTORING_explain.md
+================================================================================
+
+# OC Diver App - Backend
+
+Spring Boot 기반 해양 활동 기록 관리 시스템 백엔드입니다.
+
+## 목차
+
+- [프로젝트 개요](#프로젝트-개요)
+- [주요 기능](#주요-기능)
+- [리팩토링 개요](#리팩토링-개요)
+- [아키텍처](#아키텍처)
+- [API 엔드포인트](#api-엔드포인트)
+- [데이터 모델](#데이터-모델)
+- [검증 전략](#검증-전략)
+- [주요 변경사항](#주요-변경사항)
+
+---
+
+## 프로젝트 개요
+
+OC Diver App은 해양 활동(이식, 조식동물 작업, 부착기질 개선, 모니터링, 해양정화)을 기록하고 관리하는 시스템입니다. 관리자는 제출된 기록을 검수하고 승인/반려할 수 있으며, CSV 내보내기 기능을 제공합니다.
+
+---
+
+## 주요 기능
+
+### 1. 기록 관리
+- **임시저장 (DRAFT)**: 작업 중인 기록을 임시저장하여 나중에 이어서 작성 가능
+- **제출 (SUBMITTED)**: 기록을 제출하여 관리자 검수 대기
+- **승인/반려**: 관리자가 제출된 기록을 검수하고 승인 또는 반려 처리
+- **수정**: 임시저장된 기록은 수정 가능
+
+### 2. 작업 유형별 기록
+- **이식 (TRANSPLANT)**: 해조류 이식 작업 기록
+- **조식동물 작업 (GRAZER_REMOVAL)**: 조식동물 제거 작업 기록
+- **부착기질 개선 (SUBSTRATE_IMPROVEMENT)**: 부착기질 개선 작업 기록
+- **모니터링 (MONITORING)**: 해조류 모니터링 기록
+- **해양정화 (MARINE_CLEANUP)**: 해양 폐기물 수거 기록
+
+### 3. 검수 및 내보내기
+- 일괄 승인/반려
+- CSV 내보내기 (스트리밍 방식)
+- 검수 이력 조회
+
+---
+
+## 리팩토링 개요
+
+### 목표
+기존 코드의 중복을 제거하고, 확장 가능한 구조로 개선했습니다.
+
+### 주요 개선사항
+
+1. **도메인 분리**
+   - 기본 정보 (항상 저장)
+   - 공통 환경 기록 (항상 저장)
+   - 작업 유형별 기록 (조건부 저장)
+   - 공통 후처리 (작업 내용, 미디어, 상태)
+
+2. **작업 유형별 스키마 분리**
+   - 각 작업 유형별로 별도 엔티티 생성
+   - Null 폭증 문제 해결
+   - 확장 가능한 구조
+
+3. **검증 로직 개선**
+   - 작업 유형별 조건부 검증
+   - 상태 전이 검증 강화
+
+4. **API 구조 개선**
+   - 임시저장/제출 분리
+   - 명확한 상태 관리
+
+---
+
+## 아키텍처
+
+### 엔티티 구조
+
+```
+Submission (기본 정보)
+├── BasicEnv (공통 환경 기록)
+├── Participants (참여자 정보)
+├── ActivityTransplant (이식 작업)
+├── ActivityGrazerRemoval (조식동물 작업)
+├── ActivitySubstrateImprovement (부착기질 개선)
+├── ActivityMonitoring (모니터링)
+├── ActivityMarineCleanup (해양정화)
+├── Attachment (첨부파일)
+└── AuditLog (검수 이력)
+```
+
+
+## API 엔드포인트
+
+### 기록 생성 및 제출
+
+| Method | Endpoint | 설명 |
+|--------|----------|------|
+| POST | `/api/admin/submissions/draft` | 기록 임시저장 (DRAFT) |
+| POST | `/api/admin/submissions/submit` | 기록 바로 제출 (SUBMITTED) |
+| GET | `/api/admin/submissions/draft/{id}` | 임시저장된 기록 조회 |
+| PUT | `/api/admin/submissions/draft/{id}` | 임시저장된 기록 수정 (선택적 제출) |
+
+### 기록 조회
+
+| Method | Endpoint | 설명 |
+|--------|----------|------|
+| GET | `/api/admin/submissions` | 기록 목록 조회 (필터링, 페이지네이션) |
+| GET | `/api/admin/submissions/{id}` | 기록 상세 조회 |
+| GET | `/api/admin/submissions/{id}/logs` | 검수 이력 조회 |
+
+### 검수 처리
+
+| Method | Endpoint | 설명 |
+|--------|----------|------|
+| POST | `/api/admin/submissions/{id}/approve` | 단건 승인 |
+| POST | `/api/admin/submissions/{id}/reject` | 단건 반려 |
+| POST | `/api/admin/submissions/bulk/approve` | 일괄 승인 |
+| POST | `/api/admin/submissions/bulk/reject` | 일괄 반려 |
+| DELETE | `/api/admin/submissions/{id}` | 단건 삭제 |
+| DELETE | `/api/admin/submissions/bulk` | 일괄 삭제 |
+
+---
+
+## 데이터 모델
+
+### Submission (기본 정보)
+
+```java
+- submissionId: Long
+- siteName: String (필수)
+- structureType: StructureType (선택, 기본값: OTHER)
+- customStructureType: String (OTHER일 때 커스텀 텍스트)
+- recordDate: LocalDate (기본값: 현재 날짜)
+- divingRound: Integer (1~5, 필수)
+- activityType: ActivityType (필수)
+- status: SubmissionStatus (기본값: DRAFT)
+- authorName: String (필수)
+- authorEmail: String
+- workDescription: String
+- latitude: BigDecimal
+- longitude: BigDecimal
+- submittedAt: LocalDateTime (DRAFT일 때는 null)
+```
+
+### BasicEnv (공통 환경 기록)
+
+```java
+- recordDate: LocalDate
+- avgDepthM: Double (평균 수심, m)
+- maxDepthM: Double (최대 수심, m)
+- waterTempC: Double (수온, °C)
+- visibilityStatus: MarineCondition (시야: BAD/NORMAL/GOOD)
+- waveStatus: MarineCondition (파도: BAD/NORMAL/GOOD)
+- surgeStatus: MarineCondition (서지: BAD/NORMAL/GOOD)
+- currentStatus: MarineCondition (조류: BAD/NORMAL/GOOD)
+```
+
+### 작업 유형별 Activity
+
+#### ActivityTransplant (이식)
+```java
+- speciesType: TransplantSpeciesType (감태/다시마/곰피/모자반/대황/기타)
+- locationType: TransplantLocationType (어초/암반/기타)
+- methodType: TransplantMethodType (로프/연승/종자/직접이식/이식용 모듈/기타)
+- scale: String (이식 규모)
+- zone: String (A/B/C/D)
+- healthStatus: HealthStatus (A/B/C/D)
+```
+
+#### ActivityGrazerRemoval (조식동물 작업)
+```java
+- targetSpecies: Set<GrazerSpeciesType> (성게/소라/전복/불가사리/기타)
+- densityBeforeWork: DensityLevel (LOW/MID/HIGH)
+- workScope: WorkScope (LOCAL/ZONE/WIDE)
+- supplementaryExplanation: String (보충 설명)
+- collectionAmount: String (수거량)
+```
+
+#### ActivitySubstrateImprovement (부착기질 개선)
+```java
+- targetType: SubstrateTargetType (암반/어초/구조물/기타)
+- workScope: String (작업 범위)
+- substrateState: String (작업 후 기질 상태)
+```
+
+#### ActivityMonitoring (모니터링)
+```java
+// 적지조사
+- entryCoordinate: String (입수 좌표)
+- exitCoordinate: String (출수 좌표)
+- direction: String (진행방위)
+- terrain: TerrainType (암반/모래/혼합/기타)
+- barrenExtent: BarrenExtent (없음/진행중/심각)
+- grazerDistribution: DensityLevel (낮음/중간/높음)
+- rockFeatures: List<RockFeature> (매끈/균열/석회조류우점/혼합/해조류식생)
+- suitability: Suitability (적합/부적합)
+
+// 해조류 상태
+- seaweedIdNumber: String (식별번호)
+- seaweedHealthStatus: SeaweedHealthStatus (양호/쇠약/탈락)
+- precisionMeasurement: Boolean (정밀측정 여부)
+- leafLength: String (엽장)
+- maxLeafWidth: String (최대엽폭)
+```
+
+#### ActivityMarineCleanup (해양정화)
+```java
+- wasteTypes: Set<WasteType> (그물/통발/기타어구/낚시도구/플라스틱/기타)
+- method: CleanupMethodType (수작업/인양백/크레인)
+- collectionAmount: String (수거량)
+- uncollectedScale: UncollectedScale (소/중/대)
+```
+
+---
+
+## 검증 전략
+
+### 1. 작업 유형별 조건부 검증
+
+`ActivityValidator`가 `activityType`에 따라 해당 DTO만 검증합니다.
+
+```java
+// 예: TRANSPLANT 선택 시
+{
+  "activityType": "TRANSPLANT",
+  "transplantActivity": { ... },  // ✅ 검증됨
+  "grazerRemovalActivity": null    // ✅ 무시됨
+}
+```
+
+**중요**: `@Valid`를 제거하여 Spring의 자동 검증을 방지하고, `ActivityValidator`에서만 검증합니다.
+
+### 2. 상태 전이 검증
+
+`SubmissionStatusValidator`가 상태 전이를 검증합니다.
+
+```
+DRAFT → SUBMITTED (제출)
+SUBMITTED → APPROVED (승인)
+SUBMITTED → REJECTED (반려)
+```
+
+### 3. 필수 필드 검증
+
+- **기본 정보**: `siteName`, `divingRound`, `activityType`, `authorName` 필수
+- **공통 환경 기록**: 모든 필드 필수
+- **작업 유형별 기록**: 선택한 작업 유형의 필수 필드만 검증
+
+---
+
+## 주요 변경사항
+
+### 1. Enum 추가/수정
+
+#### 새로 추가된 Enum
+- `StructureType`: 구조물 유형 (십자형 어초/가두리/기타)
+- `MarineCondition`: 해양 조건 (나쁨/보통/좋음)
+- `HealthStatus`: 건강 상태 (A/B/C/D)
+- `DensityLevel`: 밀도 레벨 (낮음/중간/높음, 없음/진행중/심각)
+- `WorkScope`: 작업 범위 (국지적/구역별/광범위)
+- `SeaweedHealthStatus`: 해조류 생육 상태 (양호/쇠약/탈락)
+
+#### 작업 유형별 Enum
+- `TransplantSpeciesType`, `TransplantLocationType`, `TransplantMethodType`
+- `GrazerSpeciesType`
+- `SubstrateTargetType`
+- `CleanupMethodType`, `WasteType`, `UncollectedScale`
+
+#### 수정된 Enum
+- `SubmissionStatus`: `DRAFT` 상태 추가
+- `ActivityType`: `GRAZER_REMOVAL`, `SUBSTRATE_IMPROVEMENT`, `MARINE_CLEANUP` 추가
+
+### 2. 엔티티 변경
+
+#### Submission
+- 새 필드: `structureType`, `customStructureType`, `recordDate`, `divingRound`, `workDescription`, `adminMemo`
+- 상태 기본값: `DRAFT`
+- `submittedAt`: nullable (DRAFT일 때는 null)
+- 작업 유형별 Activity 관계 추가 (1:1)
+- 상태 전이 메서드: `submit()`, `approve()`, `reject()`
+
+#### BasicEnv
+- 필드 변경: `avgDepthM`, `maxDepthM`, `waterTempC`, `visibilityStatus`, `waveStatus`, `surgeStatus`, `currentStatus`
+- 기존 필드 deprecated 처리 (하위 호환성)
+
+#### Participants
+- `participantNames`: comma-separated 텍스트
+
+### 3. 작업 유형별 Activity 엔티티 생성
+
+각 작업 유형별로 별도 엔티티를 생성하여 Null 폭증 문제를 해결했습니다.
+
+- `ActivityTransplant`
+- `ActivityGrazerRemoval`
+- `ActivitySubstrateImprovement`
+- `ActivityMonitoring`
+- `ActivityMarineCleanup`
+
+### 4. 검증 로직 분리
+
+- `ActivityValidator`: 작업 유형별 조건부 검증
+- `SubmissionStatusValidator`: 상태 전이 검증
+
+### 5. API 구조 개선
+
+#### 임시저장/제출 분리
+- `POST /api/admin/submissions/draft`: 임시저장
+- `POST /api/admin/submissions/submit`: 바로 제출
+- `GET /api/admin/submissions/draft/{id}`: 임시저장 조회
+- `PUT /api/admin/submissions/draft/{id}`: 임시저장 수정 (선택적 제출)
+
+#### 상태 관리
+- DRAFT: 임시저장 상태
+- SUBMITTED: 제출 완료 (검수 대기)
+- APPROVED: 승인됨
+- REJECTED: 반려됨
+- DELETED: 삭제됨
+
+---
+
+## 파일 구조
+
+### 새로 생성된 파일
+
+#### Enum
+```
+src/main/java/com/ocean/piuda/admin/common/enums/
+├── StructureType.java
+├── MarineCondition.java
+├── HealthStatus.java
+├── DensityLevel.java
+├── WorkScope.java
+├── SeaweedHealthStatus.java
+├── TransplantSpeciesType.java
+├── TransplantLocationType.java
+├── TransplantMethodType.java
+├── GrazerSpeciesType.java
+├── SubstrateTargetType.java
+├── CleanupMethodType.java
+├── WasteType.java
+└── UncollectedScale.java
+```
+
+#### Entity
+```
+src/main/java/com/ocean/piuda/admin/submission/entity/
+├── ActivityTransplant.java
+├── ActivityGrazerRemoval.java
+├── ActivitySubstrateImprovement.java
+├── ActivityMonitoring.java
+└── ActivityMarineCleanup.java
+```
+
+#### Validator
+```
+src/main/java/com/ocean/piuda/admin/submission/validator/
+├── ActivityValidator.java
+└── SubmissionStatusValidator.java
+```
+
+### 주요 수정 파일
+
+- `Submission.java`: 새 필드 추가, 상태 전이 메서드 추가
+- `BasicEnv.java`: 필드 변경
+- `Participants.java`: 필드 변경
+- `CreateSubmissionRequest.java`: 작업 유형별 DTO 추가, 조건부 검증
+- `SubmissionCommandService.java`: 작업 유형별 처리 로직 추가
+- `SubmissionController.java`: 임시저장/제출 엔드포인트 분리
+
+---
+
+## 사용 예시
+
+### 1. 기록 임시저장
+
+```json
+POST /api/admin/submissions/draft
+{
+  "siteName": "제주 해역",
+  "structureType": "CROSS_REEF",
+  "divingRound": 1,
+  "activityType": "TRANSPLANT",
+  "authorName": "홍길동",
+  "basicEnv": {
+    "recordDate": "2024-01-15",
+    "avgDepthM": 5.0,
+    "maxDepthM": 10.0,
+    "waterTempC": 18.5,
+    "visibilityStatus": "GOOD",
+    "waveStatus": "NORMAL",
+    "surgeStatus": "NORMAL",
+    "currentStatus": "NORMAL"
+  },
+  "transplantActivity": {
+    "speciesType": "ECKLONIA_CAVA",
+    "locationType": "ARTIFICIAL_REEF",
+    "methodType": "ROPE",
+    "scale": "100m²",
+    "zone": "A",
+    "healthStatus": "A"
+  }
+}
+```
+
+### 2. 기록 제출
+
+```json
+POST /api/admin/submissions/submit
+{
+  // 위와 동일한 구조
+}
+```
+
+### 3. 임시저장된 기록 수정 및 제출
+
+```json
+PUT /api/admin/submissions/draft/1?submit=true
+{
+  // 수정할 필드들
+}
+```
+
+---
+
+## 주의사항
+
+1. **하위 호환성**: 기존 `Activity` 엔티티는 deprecated 처리했으나 유지됨
+2. **데이터베이스 마이그레이션 필요**: 새 컬럼 추가 및 작업 유형별 테이블 생성 필요
+3. **검증 로직**: `@Valid`를 제거하여 `ActivityValidator`에서만 검증하도록 변경됨
+4. **상태 전이**: 상태 전이는 엔티티의 비즈니스 메서드(`submit()`, `approve()`, `reject()`)를 통해서만 가능
+
+---
+
+## 개발 환경
+
+- Java 17+
+- Spring Boot 3.x
+- PostgreSQL 14+
+- PostGIS (지리 정보 시스템)
+
+---
+
+## 라이선스
+
+[라이선스 정보]
+
+---
+
+## 기여자
+
+[기여자 목록]
+
+
+================================================================================
 File Path: .\settings.gradle
 ================================================================================
 
@@ -1759,12 +2216,16 @@ File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ActivityType.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ActivityType {
-    TRANSPLANT,          // 이식
-    TRASH_COLLECTION,    // 폐기물수거
-    RESEARCH,            // 연구
-    MONITORING,          // 모니터링
-    URCHIN_REMOVAL,
-    OTHER                // 기타
+    TRANSPLANT,              // 이식
+    GRAZER_REMOVAL,          // 조식동물 작업
+    SUBSTRATE_IMPROVEMENT,   // 부착기질 개선
+    MONITORING,              // 모니터링
+    MARINE_CLEANUP,          // 해양정화
+    // 하위 호환성을 위한 기존 값들
+    TRASH_COLLECTION,        // 폐기물수거 (MARINE_CLEANUP과 동일)
+    RESEARCH,                // 연구
+    URCHIN_REMOVAL,          // 성게 제거 (GRAZER_REMOVAL과 동일)
+    OTHER                    // 기타
 }
 
 
@@ -1784,15 +2245,74 @@ public enum AuditAction {
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\CurrentState.java
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\BarrenExtent.java
 ================================================================================
 
 package com.ocean.piuda.admin.common.enums;
 
-public enum CurrentState {
-    LOW,     // 약
-    MEDIUM,  // 중
-    HIGH     // 강
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 모니터링 - 갯녹음 정도
+ */
+@Getter
+@RequiredArgsConstructor
+public enum BarrenExtent {
+    NONE("없음"),
+    ONGOING("진행중"),
+    SEVERE("심각");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\CleanupMethodType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 해양정화 인양 방식
+ */
+@Getter
+@RequiredArgsConstructor
+public enum CleanupMethodType {
+    HAND("수작업"),
+    BAG("인양백"),
+    CRANE("크레인");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\DensityLevel.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 밀도/분포 레벨
+ */
+@Getter
+@RequiredArgsConstructor
+public enum DensityLevel {
+    LOW("낮음/적음"),
+    MID("중간/보통"),
+    HIGH("높음/많음"),
+    NONE("없음"),
+    ONGOING("진행중"),
+    SEVERE("심각");
+
+    private final String description;
 }
 
 
@@ -1822,13 +2342,60 @@ public enum ExportStatus {
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\HealthGrade.java
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\GrazerSpeciesType.java
 ================================================================================
 
 package com.ocean.piuda.admin.common.enums;
 
-public enum HealthGrade {
-    A, B, C, D
+/**
+ * 조식동물 종류
+ */
+public enum GrazerSpeciesType {
+    URCHIN,      // 성게
+    SNAIL,       // 소라
+    ABALONE,     // 전복
+    STARFISH,    // 불가사리
+    OTHER        // 기타
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\HealthStatus.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 건강 상태 (이식 작업 전용)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum HealthStatus {
+    A("활착 양호, 생육 정상"),
+    B("부분 스트레스"),
+    C("쇠약/탈락 진행"),
+    D("대부분 탈락");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\MarineCondition.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+/**
+ * 해양 조건 상태 (시야/파도/서지/조류)
+ */
+public enum MarineCondition {
+    BAD,
+    NORMAL,
+    GOOD
 }
 
 
@@ -1847,13 +2414,61 @@ public enum ParticipantRole {
 
 
 ================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\RockFeature.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 모니터링 - 암반 특성
+ */
+@Getter
+@RequiredArgsConstructor
+public enum RockFeature {
+    SMOOTH("매끈"),
+    CRACKED("균열"),
+    CALCAREOUS_ALGAE("석회조류 우점"),
+    MIXED("혼합"),
+    SEAWEED_VEGETATION("해조류 식생");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SeaweedHealthStatus.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 해조류 생육 상태 (모니터링 전용)
+ */
+@Getter
+@RequiredArgsConstructor
+public enum SeaweedHealthStatus {
+    GOOD("양호"),
+    WEAK("쇠약"),
+    DROPPED("탈락");
+
+    private final String description;
+}
+
+
+================================================================================
 File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SubmissionStatus.java
 ================================================================================
 
 package com.ocean.piuda.admin.common.enums;
 
 public enum SubmissionStatus {
-    PENDING,    // 검수 대기
+    SUBMITTED,  // 제출 (검수 대기)
     APPROVED,   // 승인
     REJECTED,   // 반려
     DELETED     // 삭제
@@ -1861,17 +2476,174 @@ public enum SubmissionStatus {
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\Weather.java
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SubstrateTargetType.java
 ================================================================================
 
 package com.ocean.piuda.admin.common.enums;
 
-public enum Weather {
-    SUNNY,   // 맑음
-    CLOUDY,  // 흐림
-    RAINY,   // 비
-    WINDY,   // 바람
-    OTHER    // 기타
+/**
+ * 부착기질 개선 작업 대상
+ */
+public enum SubstrateTargetType {
+    ROCK,        // 암반
+    REEF,        // 어초
+    STRUCTURE,   // 구조물
+    OTHER        // 기타
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\Suitability.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 모니터링 - 해조 이식 적합성
+ */
+@Getter
+@RequiredArgsConstructor
+public enum Suitability {
+    SUITABLE("적합"),
+    UNSUITABLE("부적합");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TerrainType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 모니터링 - 지형 구성
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TerrainType {
+    ROCK("암반"),
+    SAND("모래"),
+    MIXED("혼합"),
+    OTHER("기타");
+
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantLocationType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+/**
+ * 이식 장소
+ */
+public enum TransplantLocationType {
+    REEF,        // 어초
+    ROCK,        // 암반
+    OTHER        // 기타
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantMethodType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 이식 방식
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TransplantMethodType {
+    ROPE_LINE("로프 연승"),
+    SEED_DIRECT("종자 직접 이식"),
+    MODULE("이식용 모듈"),
+    OTHER("기타");
+    private final String description;
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantSpeciesType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+/**
+ * 이식 대상 종류
+ */
+public enum TransplantSpeciesType {
+    KAMTAE,      // 감태
+    DASIMA,      // 다시마
+    GOMPI,       // 곰피
+    MOJABAN,     // 모자반
+    DAEHWANG,    // 대황
+    OTHER        // 기타
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\UncollectedScale.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+/**
+ * 미수거 폐기물 규모
+ */
+public enum UncollectedScale {
+    SMALL,
+    MEDIUM,
+    LARGE
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\WasteType.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+/**
+ * 폐기물 유형
+ */
+public enum WasteType {
+    NET,             // 그물
+    TRAP,            // 통발
+    OTHER_GEAR,      // 기타어구
+    FISHING_TOOL,    // 낚시도구
+    PLASTIC,         // 플라스틱
+    OTHER            // 기타
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\WorkScope.java
+================================================================================
+
+package com.ocean.piuda.admin.common.enums;
+
+/**
+ * 작업 범위
+ */
+public enum WorkScope {
+    LOCAL,  // 국소적
+    ZONE,   // 구역
+    WIDE    // 광범위
 }
 
 
@@ -1971,12 +2743,13 @@ public class AdminDashboardService {
      */
     public AdminDashboardSummaryResponse getDashboardSummary() {
         long total = submissionRepository.count();
-        long pending = submissionRepository.countByStatus(SubmissionStatus.PENDING);
+        long submitted = submissionRepository.countByStatus(SubmissionStatus.SUBMITTED);
         long approved = submissionRepository.countByStatus(SubmissionStatus.APPROVED);
         long rejected = submissionRepository.countByStatus(SubmissionStatus.REJECTED);
         long deleted = submissionRepository.countByStatus(SubmissionStatus.DELETED);
 
-        return AdminDashboardSummaryResponse.of(total, pending, approved, rejected, deleted);
+        // 하위 호환성을 위해 pending 필드에 submitted 값을 전달
+        return AdminDashboardSummaryResponse.of(total, submitted, approved, rejected, deleted);
     }
 }
 
@@ -2324,7 +3097,7 @@ import com.ocean.piuda.admin.export.dto.request.ExportRequest;
 import com.ocean.piuda.admin.export.dto.response.ExportJobResponse;
 import com.ocean.piuda.admin.export.entity.ExportJob;
 import com.ocean.piuda.admin.export.repository.ExportJobRepository;
-import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.submission.entity.*;
 import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
 import com.ocean.piuda.global.api.exception.BusinessException;
 import com.ocean.piuda.global.api.exception.ExceptionType;
@@ -2354,6 +3127,9 @@ public class ExportService {
     private final SubmissionRepository submissionRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
 
+    /**
+     * 필터 조건에 따른 CSV 파일 생성 (전체 다운로드)
+     */
     @Transactional(readOnly = true)
     public byte[] generateExportFile(ExportRequest request) {
         try {
@@ -2365,10 +3141,35 @@ public class ExportService {
         }
     }
 
+    /**
+     * ID 목록에 따른 CSV 파일 생성 (선택 다운로드)
+     */
+    @Transactional(readOnly = true)
+    public byte[] generateExportFileByIds(ExportByIdsRequest request) {
+        try {
+            List<Submission> submissions = getSubmissionsForExportByIds(request.getIds());
+
+            // 요청한 ids 순서대로 정렬 (사용자가 선택한 순서 유지)
+            Map<Long, Integer> order = new HashMap<>();
+            for (int i = 0; i < request.getIds().size(); i++) {
+                order.put(request.getIds().get(i), i);
+            }
+            submissions.sort(Comparator.comparingInt(s -> order.getOrDefault(s.getSubmissionId(), Integer.MAX_VALUE)));
+
+            return generateCSV(submissions);
+        } catch (Exception e) {
+            log.error("Export(IDs) 파일 생성 실패: {}", e.getMessage(), e);
+            throw new BusinessException(ExceptionType.EXPORT_FAILED);
+        }
+    }
+
+    /**
+     * Export 이력 저장 (전체 다운로드용)
+     */
     @Transactional
     public ExportJobResponse saveExportHistory(ExportRequest request, String requestedBy) {
         try {
-            String filtersJson = request.getFilters() != null 
+            String filtersJson = request.getFilters() != null
                     ? objectMapper.writeValueAsString(request.getFilters())
                     : "{}";
 
@@ -2388,139 +3189,9 @@ public class ExportService {
         }
     }
 
-    private List<Submission> getSubmissionsForExport(ExportRequest request) {
-        try {
-            ExportRequest.ExportFilters filters = request.getFilters();
-
-            LocalDateTime startDate = filters != null && filters.getDateFrom() != null 
-                    ? filters.getDateFrom().atStartOfDay() 
-                    : null;
-            LocalDateTime endDate = filters != null && filters.getDateTo() != null 
-                    ? filters.getDateTo().atTime(23, 59, 59) 
-                    : null;
-
-            return submissionRepository.findWithFilters(
-                    null,
-                    SubmissionStatus.APPROVED,
-                    null,
-                    startDate,
-                    endDate,
-                    org.springframework.data.domain.Pageable.unpaged()
-            ).getContent();
-
-        } catch (Exception e) {
-            log.error("제출 데이터 조회 실패: {}", e.getMessage(), e);
-            return submissionRepository.findAll().stream()
-                    .filter(s -> s.getStatus() == SubmissionStatus.APPROVED)
-                    .collect(Collectors.toList());
-        }
-    }
-
-    private byte[] generateCSV(List<Submission> submissions) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-
-        // 1) UTF-8 BOM은 가장 먼저
-        baos.write(0xEF); baos.write(0xBB); baos.write(0xBF);
-
-        try (OutputStreamWriter writer = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
-            // 2) Excel 힌트 + CRLF
-            writer.write("sep=,\r\n");
-
-            // 3) 헤더 (CRLF)
-            writer.write("제출ID,현장명,활동유형,제출일,작성자,이메일,위도,경도,수심(m),수온(°C),시야(m),날씨,조류상태,참여인원,대표자명,역할,세부내용,수거량,활동후기,첨부파일수\r\n");
-
-            DateTimeFormatter dtf = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
-            for (Submission submission : submissions) {
-                writer.write(submission.getSubmissionId() + ",");
-                writer.write(escapeCsv(submission.getSiteName()) + ",");
-                writer.write((submission.getActivityType() != null ? submission.getActivityType().name() : "") + ",");
-                writer.write((submission.getSubmittedAt() != null ? submission.getSubmittedAt().format(dtf) : "") + ",");
-                writer.write(escapeCsv(submission.getAuthorName()) + ",");
-                writer.write(escapeCsv(submission.getAuthorEmail() != null ? submission.getAuthorEmail() : "") + ",");
-
-                // 4) (핵심) 콤마를 항상 붙이도록 괄호 위치 수정
-                writer.write((submission.getLatitude()  != null ? submission.getLatitude().toString()  : "") + ",");
-                writer.write((submission.getLongitude() != null ? submission.getLongitude().toString() : "") + ",");
-
-                if (submission.getBasicEnv() != null) {
-                    writer.write((submission.getBasicEnv().getDepthM()      != null ? submission.getBasicEnv().getDepthM().toString()      : "") + ",");
-                    writer.write((submission.getBasicEnv().getWaterTempC()  != null ? submission.getBasicEnv().getWaterTempC().toString()  : "") + ",");
-                    writer.write((submission.getBasicEnv().getVisibilityM() != null ? submission.getBasicEnv().getVisibilityM().toString() : "") + ",");
-                    writer.write((submission.getBasicEnv().getWeather()     != null ? submission.getBasicEnv().getWeather().name()         : "") + ",");
-                    writer.write((submission.getBasicEnv().getCurrentState()!= null ? submission.getBasicEnv().getCurrentState().name()    : "") + ",");
-                } else {
-                    writer.write(",,,,,");
-                }
-
-                if (submission.getParticipants() != null) {
-                    writer.write((submission.getParticipants().getParticipantCount() != null ? submission.getParticipants().getParticipantCount().toString() : "") + ",");
-                    writer.write(escapeCsv(submission.getParticipants().getLeaderName() != null ? submission.getParticipants().getLeaderName() : "") + ",");
-                    writer.write((submission.getParticipants().getRole() != null ? submission.getParticipants().getRole().name() : "") + ",");
-                } else {
-                    writer.write(",,,");
-                }
-
-                if (submission.getActivity() != null) {
-                    writer.write(escapeCsv(submission.getActivity().getDetails() != null ? submission.getActivity().getDetails() : "") + ",");
-                    writer.write((submission.getActivity().getCollectionAmount() != null ? submission.getActivity().getCollectionAmount().toString() : "") + ",");
-                } else {
-                    writer.write(",,");
-                }
-
-                writer.write(escapeCsv(submission.getFeedbackText() != null ? submission.getFeedbackText() : "") + ",");
-                writer.write((submission.getAttachmentCount() != null ? submission.getAttachmentCount().toString() : ""));
-                writer.write("\r\n"); // 5) 각 행 끝은 CRLF
-            }
-
-            writer.flush();
-        }
-
-        return baos.toByteArray();
-    }
-
-    private String escapeCsv(String value) {
-        if (value == null) return "";
-        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
-            return "\"" + value.replace("\"", "\"\"") + "\"";
-        }
-        return value;
-    }
-
-    public String generateFileName(ExportFormat format) {
-        String extension = format == ExportFormat.CSV ? ".csv" : ".xlsx";
-        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
-        return String.format("submissions_export_%s%s", timestamp, extension);
-    }
-
-    @Transactional(readOnly = true)
-    public List<ExportJobResponse> getExportHistory() {
-        return exportJobRepository.findAllByOrderByCreatedAtDesc()
-                .stream()
-                .map(ExportJobResponse::from)
-                .collect(Collectors.toList());
-    }
-
-
-    @Transactional(readOnly = true)
-    public byte[] generateExportFileByIds(ExportByIdsRequest request) {
-        try {
-            List<Submission> submissions = getSubmissionsForExportByIds(request.getIds());
-
-            // 요청한 ids 순서대로 정렬
-            Map<Long, Integer> order = new HashMap<>();
-            for (int i = 0; i < request.getIds().size(); i++) {
-                order.put(request.getIds().get(i), i);
-            }
-            submissions.sort(Comparator.comparingInt(s -> order.getOrDefault(s.getSubmissionId(), Integer.MAX_VALUE)));
-
-            return generateCSV(submissions);
-        } catch (Exception e) {
-            log.error("Export(IDs) 파일 생성 실패: {}", e.getMessage(), e);
-            throw new BusinessException(ExceptionType.EXPORT_FAILED);
-        }
-    }
-
+    /**
+     * Export 이력 저장 (ID 기반 다운로드용)
+     */
     @Transactional
     public ExportJobResponse saveExportHistory(ExportByIdsRequest request, String requestedBy) {
         try {
@@ -2544,9 +3215,205 @@ public class ExportService {
         }
     }
 
+    /**
+     * Export 이력 조회
+     */
+    @Transactional(readOnly = true)
+    public List<ExportJobResponse> getExportHistory() {
+        return exportJobRepository.findAllByOrderByCreatedAtDesc()
+                .stream()
+                .map(ExportJobResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    // =================================================================================
+    //  Internal Helper Methods
+    // =================================================================================
+
+    /**
+     * 필터 조건으로 Submission 목록 조회
+     */
+    private List<Submission> getSubmissionsForExport(ExportRequest request) {
+        try {
+            ExportRequest.ExportFilters filters = request.getFilters();
+
+            LocalDateTime startDate = filters != null && filters.getDateFrom() != null
+                    ? filters.getDateFrom().atStartOfDay()
+                    : null;
+            LocalDateTime endDate = filters != null && filters.getDateTo() != null
+                    ? filters.getDateTo().atTime(23, 59, 59)
+                    : null;
+
+            // 페이징 없이 전체 조회 (unpaged)
+            return submissionRepository.findWithFilters(
+                    null,
+                    SubmissionStatus.APPROVED,
+                    null,
+                    startDate,
+                    endDate,
+                    org.springframework.data.domain.Pageable.unpaged()
+            ).getContent();
+
+        } catch (Exception e) {
+            log.error("제출 데이터 조회 실패: {}", e.getMessage(), e);
+            return submissionRepository.findAll().stream()
+                    .filter(s -> s.getStatus() == SubmissionStatus.APPROVED)
+                    .collect(Collectors.toList());
+        }
+    }
+
+    /**
+     * ID 목록으로 Submission 목록 조회 (상세 정보 포함)
+     */
     private List<Submission> getSubmissionsForExportByIds(List<Long> ids) {
         if (ids == null || ids.isEmpty()) return List.of();
+        // N+1 문제를 방지하기 위해 Fetch Join이 적용된 쿼리 사용
         return submissionRepository.findAllByIdsAndStatusWithDetails(ids, SubmissionStatus.APPROVED);
+    }
+
+    /**
+     * CSV 파일 바이트 생성 로직 (핵심)
+     */
+    private byte[] generateCSV(List<Submission> submissions) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+
+        // 1) UTF-8 BOM 추가 (Excel에서 한글 깨짐 방지)
+        baos.write(0xEF); baos.write(0xBB); baos.write(0xBF);
+
+        try (OutputStreamWriter writer = new OutputStreamWriter(baos, StandardCharsets.UTF_8)) {
+            // 2) Excel용 구분자 힌트
+            writer.write("sep=,\r\n");
+
+            // 3) Header 작성 (기획서 순서 반영)
+            // 기본정보: 현장명, 날짜, 회차, 활동유형, 공동작업자
+            // 환경정보: 평균수심, 최대수심, 수온, 시야, 파도, 서지, 조류
+            // 상세정보: 활동상세내용(Type Specific - 모든 필드 포함), 수거량/규모
+            // 기타: 작업내용(후기), 첨부파일수, 작성자, 이메일, 제출일시
+            writer.write("제출ID,현장명,날짜,회차,활동유형,공동작업자," +
+                    "평균수심(m),최대수심(m),수온(°C),시야,파도,서지,조류," +
+                    "활동상세내용(Type Specific),수거량/규모," +
+                    "작업내용(Description),첨부파일수,작성자,이메일,제출일시\r\n");
+
+            DateTimeFormatter dtf = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+
+            for (Submission submission : submissions) {
+                // --- [1] 기본 정보 ---
+                writer.write(submission.getSubmissionId() + ",");
+                writer.write(escapeCsv(submission.getSiteName()) + ",");
+                writer.write((submission.getRecordDate() != null ? submission.getRecordDate().toString() : "") + ",");
+                writer.write(submission.getDivingRound() + ",");
+                writer.write((submission.getActivityType() != null ? submission.getActivityType().name() : "") + ",");
+                writer.write(escapeCsv(submission.getParticipantNames()) + ",");
+
+                // --- [2] 공통 환경 기록 ---
+                if (submission.getBasicEnv() != null) {
+                    BasicEnv env = submission.getBasicEnv();
+                    writer.write((env.getAvgDepthM() != null ? env.getAvgDepthM().toString() : "") + ",");
+                    writer.write((env.getMaxDepthM() != null ? env.getMaxDepthM().toString() : "") + ",");
+                    writer.write((env.getWaterTempC() != null ? env.getWaterTempC().toString() : "") + ",");
+                    writer.write((env.getVisibilityStatus() != null ? env.getVisibilityStatus().name() : "") + ",");
+                    writer.write((env.getWaveStatus() != null ? env.getWaveStatus().name() : "") + ",");
+                    writer.write((env.getSurgeStatus() != null ? env.getSurgeStatus().name() : "") + ",");
+                    writer.write((env.getCurrentStatus() != null ? env.getCurrentStatus().name() : "") + ",");
+                } else {
+                    writer.write(",,,,,,,"); // 환경정보 7개 필드 공란 처리
+                }
+
+                // --- [3] 유형별 활동 상세 기록 (조건부) ---
+                String activityDetails = "";
+                String amountOrScale = "";
+
+                if (submission.getActivityTransplant() != null) {
+                    // [이식] 대상종, 장소, 방식, 건강상태
+                    ActivityTransplant t = submission.getActivityTransplant();
+                    activityDetails = String.format("대상:%s, 장소:%s, 방식:%s, 건강상태:%s",
+                            t.getSpeciesType(), t.getLocationType(), t.getMethodType(), t.getHealthStatus());
+                    amountOrScale = t.getScale(); // 이식 규모
+
+                } else if (submission.getActivityGrazerRemoval() != null) {
+                    // [조식동물] 대상생물(List), 밀도, 범위, 비고
+                    ActivityGrazerRemoval g = submission.getActivityGrazerRemoval();
+                    String targets = g.getTargetSpecies() != null ? g.getTargetSpecies().toString() : "[]";
+                    activityDetails = String.format("대상:%s, 밀도:%s, 범위:%s(%s)",
+                            targets, g.getDensityBeforeWork(), g.getWorkScope(),
+                            g.getNote() != null ? g.getNote() : "");
+                    amountOrScale = g.getCollectionAmount(); // 수거량
+
+                } else if (submission.getActivitySubstrateImprovement() != null) {
+                    // [부착기질] 대상, 기질상태
+                    ActivitySubstrateImprovement s = submission.getActivitySubstrateImprovement();
+                    activityDetails = String.format("대상:%s, 기질상태:%s",
+                            s.getTargetType(), s.getSubstrateState());
+                    amountOrScale = s.getWorkScope(); // 작업 범위
+
+                } else if (submission.getActivityMonitoring() != null) {
+                    // [모니터링] 적지조사(좌표,방위,지형,갯녹음,분포,암반,적합성) + 해조류(ID,상태,정밀측정)
+                    ActivityMonitoring m = submission.getActivityMonitoring();
+                    StringBuilder sb = new StringBuilder();
+
+                    // a. 적지조사
+                    sb.append(String.format("[적지조사] 입수:%s, 출수:%s, 방위:%s, 지형:%s, 갯녹음:%s, 조식동물분포:%s, 암반:%s, 적합성:%s",
+                            m.getEntryCoordinate(), m.getExitCoordinate(), m.getDirection(),
+                            m.getTerrain(), m.getBarrenExtent(), m.getGrazerDistribution(),
+                            m.getRockFeatures() != null ? m.getRockFeatures().toString() : "[]",
+                            m.getSuitability()));
+
+                    // b. 해조류 상태
+                    sb.append(String.format(" / [해조류] ID:%s, 상태:%s",
+                            m.getSeaweedIdNumber(), m.getSeaweedHealthStatus()));
+
+                    // 정밀 측정 (값이 있을 때만 표시)
+                    if (m.getLeafLength() != null || m.getMaxLeafWidth() != null) {
+                        sb.append(String.format(", 엽장:%s, 엽폭:%s", m.getLeafLength(), m.getMaxLeafWidth()));
+                    }
+                    activityDetails = sb.toString();
+                    amountOrScale = "-"; // 모니터링은 별도 수거량 없음
+
+                } else if (submission.getActivityMarineCleanup() != null) {
+                    // [해양정화] 폐기물유형, 방식, 미수거규모
+                    ActivityMarineCleanup c = submission.getActivityMarineCleanup();
+                    String wastes = c.getWasteTypes() != null ? c.getWasteTypes().toString() : "[]";
+                    activityDetails = String.format("유형:%s, 방식:%s, 미수거규모:%s",
+                            wastes, c.getMethod(), c.getUncollectedScale());
+                    amountOrScale = c.getCollectionAmount(); // 수거량
+                }
+
+                writer.write(escapeCsv(activityDetails) + ",");
+                writer.write(escapeCsv(amountOrScale) + ",");
+
+                // --- [4] 기타 정보 ---
+                writer.write(escapeCsv(submission.getWorkDescription() != null ? submission.getWorkDescription() : "") + ",");
+                writer.write((submission.getAttachmentCount() != null ? submission.getAttachmentCount().toString() : "0") + ",");
+                writer.write(escapeCsv(submission.getAuthorName()) + ",");
+                writer.write(escapeCsv(submission.getAuthorEmail() != null ? submission.getAuthorEmail() : "") + ",");
+                writer.write((submission.getSubmittedAt() != null ? submission.getSubmittedAt().format(dtf) : ""));
+
+                writer.write("\r\n"); // 행 끝
+            }
+            writer.flush();
+        }
+
+        return baos.toByteArray();
+    }
+
+    /**
+     * CSV 특수문자 처리 (따옴표, 콤마, 개행)
+     */
+    private String escapeCsv(String value) {
+        if (value == null) return "";
+        if (value.contains(",") || value.contains("\"") || value.contains("\n")) {
+            return "\"" + value.replace("\"", "\"\"") + "\"";
+        }
+        return value;
+    }
+
+    /**
+     * 파일명 생성 유틸
+     */
+    public String generateFileName(ExportFormat format) {
+        String extension = format == ExportFormat.CSV ? ".csv" : ".xlsx";
+        String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+        return String.format("submissions_export_%s%s", timestamp, extension);
     }
 }
 
@@ -2758,98 +3625,98 @@ public class ProjectExporter {
 File Path: .\src\main\java\com\ocean\piuda\admin\report\controller\ReportDraftController.java
 ================================================================================
 
-package com.ocean.piuda.admin.report.controller;
-import org.springframework.http.ContentDisposition;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import java.nio.charset.StandardCharsets;
-
-import com.ocean.piuda.admin.report.dto.request.ReportDraftByIdsRequest;
-import com.ocean.piuda.admin.report.dto.request.ReportDraftByPeriodRequest;
-import com.ocean.piuda.admin.report.dto.response.ReportDraftResponse;
-import com.ocean.piuda.admin.report.service.ReportDraftService;
-import com.ocean.piuda.global.api.dto.ApiData;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-@RestController
-@RequestMapping("/api/admin/reports/drafts")
-@RequiredArgsConstructor
-@Tag(name = "Admin Report Draft", description = "선택한 해양 활동 제출물로 리포트 초안을 Gemini로 생성합니다.")
-public class ReportDraftController {
-
-    private final ReportDraftService reportDraftService;
-
-    @PostMapping("/by-ids")
-    @Operation(
-            summary = "리포트 초안 생성 (IDs 기반)",
-            description = "선택한 submission ids(기본: APPROVED)를 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
-    )
-    public ApiData<ReportDraftResponse> byIds(@RequestBody @Valid ReportDraftByIdsRequest request) {
-        return ApiData.ok(reportDraftService.generateByIds(request));
-    }
-
-    @PostMapping("/by-period")
-    @Operation(
-            summary = "리포트 초안 생성 (기간 기반)",
-            description = "dateFrom~dateTo 기간(기본: APPROVED)을 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
-    )
-    public ApiData<ReportDraftResponse> byPeriod(@RequestBody @Valid ReportDraftByPeriodRequest request) {
-        return ApiData.ok(reportDraftService.generateByPeriod(request));
-    }
-
-    @PostMapping(
-            value = "/by-ids/pdf",
-            produces = { MediaType.APPLICATION_PDF_VALUE, MediaType.APPLICATION_JSON_VALUE }
-    )
-    @Operation(summary = "리포트 PDF 생성 (IDs 기반)", description = "리포트 초안을 PDF로 생성하여 다운로드합니다.")
-    public ResponseEntity<byte[]> byIdsPdf(@RequestBody @Valid ReportDraftByIdsRequest request) {
-        var pdf = reportDraftService.generatePdfByIds(request);
-
-        ContentDisposition cd = ContentDisposition.attachment()
-                .filename(pdf.fileName(), StandardCharsets.UTF_8)
-                .build();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_PDF);
-        headers.setContentDisposition(cd);
-        headers.setContentLength(pdf.bytes().length);
-        headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
-        headers.add("Pragma", "no-cache");
-        headers.add("Expires", "0");
-
-        return ResponseEntity.ok().headers(headers).body(pdf.bytes());
-    }
-
-    @PostMapping(
-            value = "/by-period/pdf",
-            produces = { MediaType.APPLICATION_PDF_VALUE, MediaType.APPLICATION_JSON_VALUE }
-    )
-    @Operation(summary = "리포트 PDF 생성 (기간 기반)", description = "리포트 초안을 PDF로 생성하여 다운로드합니다.")
-    public ResponseEntity<byte[]> byPeriodPdf(@RequestBody @Valid ReportDraftByPeriodRequest request) {
-        var pdf = reportDraftService.generatePdfByPeriod(request);
-
-        ContentDisposition cd = ContentDisposition.attachment()
-                .filename(pdf.fileName(), StandardCharsets.UTF_8)
-                .build();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_PDF);
-        headers.setContentDisposition(cd);
-        headers.setContentLength(pdf.bytes().length);
-        headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
-        headers.add("Pragma", "no-cache");
-        headers.add("Expires", "0");
-
-        return ResponseEntity.ok().headers(headers).body(pdf.bytes());
-    }
-
-}
+//package com.ocean.piuda.admin.report.controller;
+//import org.springframework.http.ContentDisposition;
+//import org.springframework.http.HttpHeaders;
+//import org.springframework.http.MediaType;
+//import org.springframework.http.ResponseEntity;
+//import java.nio.charset.StandardCharsets;
+//
+//import com.ocean.piuda.admin.report.dto.request.ReportDraftByIdsRequest;
+//import com.ocean.piuda.admin.report.dto.request.ReportDraftByPeriodRequest;
+//import com.ocean.piuda.admin.report.dto.response.ReportDraftResponse;
+//import com.ocean.piuda.admin.report.service.ReportDraftService;
+//import com.ocean.piuda.global.api.dto.ApiData;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import jakarta.validation.Valid;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.http.ResponseEntity;
+//import org.springframework.web.bind.annotation.*;
+//
+//@RestController
+//@RequestMapping("/api/admin/reports/drafts")
+//@RequiredArgsConstructor
+//@Tag(name = "Admin Report Draft", description = "선택한 해양 활동 제출물로 리포트 초안을 Gemini로 생성합니다.")
+//public class ReportDraftController {
+//
+//    private final ReportDraftService reportDraftService;
+//
+//    @PostMapping("/by-ids")
+//    @Operation(
+//            summary = "리포트 초안 생성 (IDs 기반)",
+//            description = "선택한 submission ids(기본: APPROVED)를 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
+//    )
+//    public ApiData<ReportDraftResponse> byIds(@RequestBody @Valid ReportDraftByIdsRequest request) {
+//        return ApiData.ok(reportDraftService.generateByIds(request));
+//    }
+//
+//    @PostMapping("/by-period")
+//    @Operation(
+//            summary = "리포트 초안 생성 (기간 기반)",
+//            description = "dateFrom~dateTo 기간(기본: APPROVED)을 기반으로 내부/대외홍보용 리포트 초안을 생성합니다."
+//    )
+//    public ApiData<ReportDraftResponse> byPeriod(@RequestBody @Valid ReportDraftByPeriodRequest request) {
+//        return ApiData.ok(reportDraftService.generateByPeriod(request));
+//    }
+//
+//    @PostMapping(
+//            value = "/by-ids/pdf",
+//            produces = { MediaType.APPLICATION_PDF_VALUE, MediaType.APPLICATION_JSON_VALUE }
+//    )
+//    @Operation(summary = "리포트 PDF 생성 (IDs 기반)", description = "리포트 초안을 PDF로 생성하여 다운로드합니다.")
+//    public ResponseEntity<byte[]> byIdsPdf(@RequestBody @Valid ReportDraftByIdsRequest request) {
+//        var pdf = reportDraftService.generatePdfByIds(request);
+//
+//        ContentDisposition cd = ContentDisposition.attachment()
+//                .filename(pdf.fileName(), StandardCharsets.UTF_8)
+//                .build();
+//
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_PDF);
+//        headers.setContentDisposition(cd);
+//        headers.setContentLength(pdf.bytes().length);
+//        headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
+//        headers.add("Pragma", "no-cache");
+//        headers.add("Expires", "0");
+//
+//        return ResponseEntity.ok().headers(headers).body(pdf.bytes());
+//    }
+//
+//    @PostMapping(
+//            value = "/by-period/pdf",
+//            produces = { MediaType.APPLICATION_PDF_VALUE, MediaType.APPLICATION_JSON_VALUE }
+//    )
+//    @Operation(summary = "리포트 PDF 생성 (기간 기반)", description = "리포트 초안을 PDF로 생성하여 다운로드합니다.")
+//    public ResponseEntity<byte[]> byPeriodPdf(@RequestBody @Valid ReportDraftByPeriodRequest request) {
+//        var pdf = reportDraftService.generatePdfByPeriod(request);
+//
+//        ContentDisposition cd = ContentDisposition.attachment()
+//                .filename(pdf.fileName(), StandardCharsets.UTF_8)
+//                .build();
+//
+//        HttpHeaders headers = new HttpHeaders();
+//        headers.setContentType(MediaType.APPLICATION_PDF);
+//        headers.setContentDisposition(cd);
+//        headers.setContentLength(pdf.bytes().length);
+//        headers.add("Cache-Control", "no-cache, no-store, must-revalidate");
+//        headers.add("Pragma", "no-cache");
+//        headers.add("Expires", "0");
+//
+//        return ResponseEntity.ok().headers(headers).body(pdf.bytes());
+//    }
+//
+//}
 
 
 ================================================================================
@@ -2974,6 +3841,7 @@ public enum ReportDraftType {
 File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportDraftService.java
 ================================================================================
 
+/*
 package com.ocean.piuda.admin.report.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -3157,7 +4025,7 @@ public class ReportDraftService {
 
             ActivityType type = s.getActivity().getType();
             if (type == ActivityType.TRANSPLANT || type == ActivityType.MONITORING || type == ActivityType.RESEARCH) {
-                putIfNotNull(a, "healthGrade", s.getActivity().getHealthGrade() != null ? s.getActivity().getHealthGrade().name() : null);
+                putIfNotNull(a, "healthGrade", s.getActivity().getHealthStatus() != null ? s.getActivity().getHealthStatus().name() : null);
                 putIfNotNull(a, "growthCm", s.getActivity().getGrowthCm());
 
                 if (s.getActivity().getNaturalReproduction() != null) {
@@ -3182,7 +4050,7 @@ public class ReportDraftService {
             if (!a.isEmpty()) m.put("activity", a);
         }
 
-        putIfNotBlank(m, "feedbackText", truncate(s.getFeedbackText(), 600));
+        putIfNotBlank(m, "feedbackText", truncate(s.getWorkDescription(), 600));  // API 하위 호환성을 위해 키명 유지
 
         removeNullsDeep(m);
         return m;
@@ -3257,214 +4125,218 @@ public class ReportDraftService {
         return new ReportPdfResponse(fileName, pdfBytes);
     }
 }
+ */
 
 
 ================================================================================
 File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportPdfService.java
 ================================================================================
 
-package com.ocean.piuda.admin.report.service;
-
-import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
-import com.vladsch.flexmark.html.HtmlRenderer;
-import com.vladsch.flexmark.parser.Parser;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.core.io.ClassPathResource;
-import org.springframework.stereotype.Service;
-import com.openhtmltopdf.extend.FSSupplier;
-
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-
-@Slf4j
-@Service
-@RequiredArgsConstructor
-public class ReportPdfService {
-
-    private final Parser mdParser = Parser.builder().build();
-    private final HtmlRenderer htmlRenderer = HtmlRenderer.builder().build();
-
-    private static FSSupplier<InputStream> cp(String path) {
-        return () -> {
-            try {
-                return new ClassPathResource(path).getInputStream();
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
-        };
-    }
-
-    public byte[] renderMarkdownToPdf(String markdown, String title) {
-        try {
-            String safeMarkdown = stripEmoji(markdown == null ? "" : markdown);
-            String safeTitle = stripEmoji(title);
-
-            String htmlBody = htmlRenderer.render(mdParser.parse(safeMarkdown));
-            String html = wrapHtml(htmlBody, safeTitle);
-
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            PdfRendererBuilder builder = new PdfRendererBuilder();
-            builder.useFastMode();
-            builder.withHtmlContent(html, null);
-            builder.toStream(baos);
-
-            builder.useFont(cp("fonts/NotoSansKR-Regular.ttf"), "NotoSansKR", 400,
-                    PdfRendererBuilder.FontStyle.NORMAL, true);
-            builder.useFont(cp("fonts/NotoSansKR-Bold.ttf"), "NotoSansKR", 700,
-                    PdfRendererBuilder.FontStyle.NORMAL, true);
-
-            builder.run();
-            return baos.toByteArray();
-        } catch (Exception e) {
-            log.error("PDF 렌더링 실패: {}", e.getMessage(), e);
-            throw new RuntimeException("REPORT_PDF_RENDER_FAILED", e);
-        }
-    }
-
-    private String wrapHtml(String body, String title) {
-        String generatedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
-
-        return ("""
-    <!DOCTYPE html>
-    <html xmlns="http://www.w3.org/1999/xhtml" lang="ko">
-    <head>
-      <meta charset="UTF-8" />
-      <style>
-        @page { size: A4; margin: 18mm; }
-
-        body {
-          font-family: "NotoSansKR", sans-serif;
-          font-size: 11pt;
-          line-height: 1.6;
-          color: #111;
-        }
-
-        h1 { font-size: 20pt; margin: 0 0 10pt 0; font-weight: 700; }
-        h2 { font-size: 15pt; margin: 16pt 0 8pt 0; font-weight: 700; }
-        h3 { font-size: 13pt; margin: 14pt 0 6pt 0; font-weight: 700; }
-
-        p { margin: 6pt 0; }
-
-        /*  리스트 bullet 크기/모양 커스텀 (기본 마커 대신 ::before 사용) */
-        ul, ol {
-          margin: 6pt 0 6pt 0;
-          padding-left: 0;
-        }
-
-        ul { list-style: none; }
-        ul > li {
-          position: relative;
-          padding-left: 12pt;   /* bullet + 간격 */
-          margin: 2pt 0;
-        }
-        ul > li::before {
-          content: "•";
-          position: absolute;
-          left: 0;
-          top: 0;
-          font-size: 8.5pt;     /*  bullet 크기 */
-          line-height: 1.6;     /* 텍스트 라인과 맞춤 */
-        }
-
-        /* 중첩 ul은 더 작은 마커 */
-        ul ul > li { padding-left: 11pt; }
-        ul ul > li::before {
-          content: "◦";
-          font-size: 8pt;
-          line-height: 1.6;
-        }
-
-        /* 번호 목록은 기본 유지 */
-        ol { padding-left: 18pt; }
-        ol li { margin: 2pt 0; }
-
-        code, pre { font-family: monospace; font-size: 10pt; }
-        pre {
-          background: #f6f6f6;
-          padding: 10pt;
-          border-radius: 6pt;
-          white-space: pre-wrap;
-        }
-
-        table { width: 100%%; border-collapse: collapse; margin: 10pt 0; }
-        th, td { border: 1px solid #ddd; padding: 6pt; }
-        th { background: #f2f2f2; }
-
-        .meta { font-size: 9.5pt; color: #555; margin-bottom: 12pt; }
-      </style>
-      <title>%s</title>
-    </head>
-    <body>
-      <div class="meta">생성일시: %s</div>
-      %s
-    </body>
-    </html>
-    """).formatted(escapeHtml(title), generatedAt, body).strip();
-    }
-
-    private String escapeHtml(String s) {
-        if (s == null) return "";
-        return s.replace("&", "&amp;")
-                .replace("<", "&lt;")
-                .replace(">", "&gt;");
-    }
-
-    private static String stripEmoji(String s) {
-        if (s == null || s.isBlank()) return s;
-
-        StringBuilder out = new StringBuilder(s.length());
-        for (int i = 0; i < s.length(); ) {
-            int cp = s.codePointAt(i);
-            i += Character.charCount(cp);
-
-            if (isEmojiLike(cp)) {
-                // 필요하면 공백 하나로 치환하고 싶으면 아래 주석 해제
-                // out.append(' ');
-                continue;
-            }
-            out.appendCodePoint(cp);
-        }
-        return out.toString();
-    }
-
-    /**
-     * “대부분의” 이모지/이모지 조합을 제거하기 위한 범위 체크
-     * (표시 안 해도 되는 목적이면 이 정도가 실무에서 가장 무난합니다)
-     */
-    private static boolean isEmojiLike(int cp) {
-        // variation selectors (emoji 스타일 선택), ZWJ(결합자), keycap 결합자
-        if (cp == 0xFE0E || cp == 0xFE0F || cp == 0x200D || cp == 0x20E3) return true;
-
-        // skin tone modifiers
-        if (cp >= 0x1F3FB && cp <= 0x1F3FF) return true;
-
-        // flags (regional indicator symbols)
-        if (cp >= 0x1F1E6 && cp <= 0x1F1FF) return true;
-
-        // Misc symbols / dingbats (♻️ ☀️ ✨ 같은 것들)
-        if (cp >= 0x2600 && cp <= 0x26FF) return true;
-        if (cp >= 0x2700 && cp <= 0x27BF) return true;
-
-        // Main emoji blocks
-        if (cp >= 0x1F300 && cp <= 0x1F5FF) return true; // pictographs
-        if (cp >= 0x1F600 && cp <= 0x1F64F) return true; // emoticons
-        if (cp >= 0x1F680 && cp <= 0x1F6FF) return true; // transport
-        if (cp >= 0x1F700 && cp <= 0x1F77F) return true; // alchemical
-        if (cp >= 0x1F780 && cp <= 0x1F7FF) return true; // geometric ext
-        if (cp >= 0x1F800 && cp <= 0x1F8FF) return true; // arrows-c
-        if (cp >= 0x1F900 && cp <= 0x1F9FF) return true; // supplemental
-        if (cp >= 0x1FA00 && cp <= 0x1FA6F) return true; // chess etc
-        if (cp >= 0x1FA70 && cp <= 0x1FAFF) return true; // extended-a
-
-        return false;
-    }
-
-}
+//
+//package com.ocean.piuda.admin.report.service;
+//
+//import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+//import com.vladsch.flexmark.html.HtmlRenderer;
+//import com.vladsch.flexmark.parser.Parser;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.core.io.ClassPathResource;
+//import org.springframework.stereotype.Service;
+//import com.openhtmltopdf.extend.FSSupplier;
+//
+//import java.io.ByteArrayOutputStream;
+//import java.io.IOException;
+//import java.io.InputStream;
+//import java.io.UncheckedIOException;
+//import java.time.LocalDateTime;
+//import java.time.format.DateTimeFormatter;
+//
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
+//public class ReportPdfService {
+//
+//    private final Parser mdParser = Parser.builder().build();
+//    private final HtmlRenderer htmlRenderer = HtmlRenderer.builder().build();
+//
+//    private static FSSupplier<InputStream> cp(String path) {
+//        return () -> {
+//            try {
+//                return new ClassPathResource(path).getInputStream();
+//            } catch (IOException e) {
+//                throw new UncheckedIOException(e);
+//            }
+//        };
+//    }
+//
+//    public byte[] renderMarkdownToPdf(String markdown, String title) {
+//        try {
+//            String safeMarkdown = stripEmoji(markdown == null ? "" : markdown);
+//            String safeTitle = stripEmoji(title);
+//
+//            String htmlBody = htmlRenderer.render(mdParser.parse(safeMarkdown));
+//            String html = wrapHtml(htmlBody, safeTitle);
+//
+//            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+//            PdfRendererBuilder builder = new PdfRendererBuilder();
+//            builder.useFastMode();
+//            builder.withHtmlContent(html, null);
+//            builder.toStream(baos);
+//
+//            builder.useFont(cp("fonts/NotoSansKR-Regular.ttf"), "NotoSansKR", 400,
+//                    PdfRendererBuilder.FontStyle.NORMAL, true);
+//            builder.useFont(cp("fonts/NotoSansKR-Bold.ttf"), "NotoSansKR", 700,
+//                    PdfRendererBuilder.FontStyle.NORMAL, true);
+//
+//            builder.run();
+//            return baos.toByteArray();
+//        } catch (Exception e) {
+//            log.error("PDF 렌더링 실패: {}", e.getMessage(), e);
+//            throw new RuntimeException("REPORT_PDF_RENDER_FAILED", e);
+//        }
+//    }
+//
+//    private String wrapHtml(String body, String title) {
+//        String generatedAt = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+//
+//        return ("""
+//    <!DOCTYPE html>
+//    <html xmlns="http://www.w3.org/1999/xhtml" lang="ko">
+//    <head>
+//      <meta charset="UTF-8" />
+//      <style>
+//        @page { size: A4; margin: 18mm; }
+//
+//        body {
+//          font-family: "NotoSansKR", sans-serif;
+//          font-size: 11pt;
+//          line-height: 1.6;
+//          color: #111;
+//        }
+//
+//        h1 { font-size: 20pt; margin: 0 0 10pt 0; font-weight: 700; }
+//        h2 { font-size: 15pt; margin: 16pt 0 8pt 0; font-weight: 700; }
+//        h3 { font-size: 13pt; margin: 14pt 0 6pt 0; font-weight: 700; }
+//
+//        p { margin: 6pt 0; }
+//
+//        /*  리스트 bullet 크기/모양 커스텀 (기본 마커 대신 ::before 사용) */
+//        ul, ol {
+//          margin: 6pt 0 6pt 0;
+//          padding-left: 0;
+//        }
+//
+//        ul { list-style: none; }
+//        ul > li {
+//          position: relative;
+//          padding-left: 12pt;   /* bullet + 간격 */
+//          margin: 2pt 0;
+//        }
+//        ul > li::before {
+//          content: "•";
+//          position: absolute;
+//          left: 0;
+//          top: 0;
+//          font-size: 8.5pt;     /*  bullet 크기 */
+//          line-height: 1.6;     /* 텍스트 라인과 맞춤 */
+//        }
+//
+//        /* 중첩 ul은 더 작은 마커 */
+//        ul ul > li { padding-left: 11pt; }
+//        ul ul > li::before {
+//          content: "◦";
+//          font-size: 8pt;
+//          line-height: 1.6;
+//        }
+//
+//        /* 번호 목록은 기본 유지 */
+//        ol { padding-left: 18pt; }
+//        ol li { margin: 2pt 0; }
+//
+//        code, pre { font-family: monospace; font-size: 10pt; }
+//        pre {
+//          background: #f6f6f6;
+//          padding: 10pt;
+//          border-radius: 6pt;
+//          white-space: pre-wrap;
+//        }
+//
+//        table { width: 100%%; border-collapse: collapse; margin: 10pt 0; }
+//        th, td { border: 1px solid #ddd; padding: 6pt; }
+//        th { background: #f2f2f2; }
+//
+//        .meta { font-size: 9.5pt; color: #555; margin-bottom: 12pt; }
+//      </style>
+//      <title>%s</title>
+//    </head>
+//    <body>
+//      <div class="meta">생성일시: %s</div>
+//      %s
+//    </body>
+//    </html>
+//    """).formatted(escapeHtml(title), generatedAt, body).strip();
+//    }
+//
+//    private String escapeHtml(String s) {
+//        if (s == null) return "";
+//        return s.replace("&", "&amp;")
+//                .replace("<", "&lt;")
+//                .replace(">", "&gt;");
+//    }
+//
+//    private static String stripEmoji(String s) {
+//        if (s == null || s.isBlank()) return s;
+//
+//        StringBuilder out = new StringBuilder(s.length());
+//        for (int i = 0; i < s.length(); ) {
+//            int cp = s.codePointAt(i);
+//            i += Character.charCount(cp);
+//
+//            if (isEmojiLike(cp)) {
+//                // 필요하면 공백 하나로 치환하고 싶으면 아래 주석 해제
+//                // out.append(' ');
+//                continue;
+//            }
+//            out.appendCodePoint(cp);
+//        }
+//        return out.toString();
+//    }
+//
+//    /**
+//     * “대부분의” 이모지/이모지 조합을 제거하기 위한 범위 체크
+//     * (표시 안 해도 되는 목적이면 이 정도가 실무에서 가장 무난합니다)
+//     */
+//    private static boolean isEmojiLike(int cp) {
+//        // variation selectors (emoji 스타일 선택), ZWJ(결합자), keycap 결합자
+//        if (cp == 0xFE0E || cp == 0xFE0F || cp == 0x200D || cp == 0x20E3) return true;
+//
+//        // skin tone modifiers
+//        if (cp >= 0x1F3FB && cp <= 0x1F3FF) return true;
+//
+//        // flags (regional indicator symbols)
+//        if (cp >= 0x1F1E6 && cp <= 0x1F1FF) return true;
+//
+//        // Misc symbols / dingbats (♻️ ☀️ ✨ 같은 것들)
+//        if (cp >= 0x2600 && cp <= 0x26FF) return true;
+//        if (cp >= 0x2700 && cp <= 0x27BF) return true;
+//
+//        // Main emoji blocks
+//        if (cp >= 0x1F300 && cp <= 0x1F5FF) return true; // pictographs
+//        if (cp >= 0x1F600 && cp <= 0x1F64F) return true; // emoticons
+//        if (cp >= 0x1F680 && cp <= 0x1F6FF) return true; // transport
+//        if (cp >= 0x1F700 && cp <= 0x1F77F) return true; // alchemical
+//        if (cp >= 0x1F780 && cp <= 0x1F7FF) return true; // geometric ext
+//        if (cp >= 0x1F800 && cp <= 0x1F8FF) return true; // arrows-c
+//        if (cp >= 0x1F900 && cp <= 0x1F9FF) return true; // supplemental
+//        if (cp >= 0x1FA00 && cp <= 0x1FA6F) return true; // chess etc
+//        if (cp >= 0x1FA70 && cp <= 0x1FAFF) return true; // extended-a
+//
+//        return false;
+//    }
+//
+//}
+//
+//
 
 
 ================================================================================
@@ -3530,6 +4402,263 @@ public class ReportPromptBuilder {
 
 
 ================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\controller\SiteNameOptionController.java
+================================================================================
+
+package com.ocean.piuda.admin.site.controller;
+
+import com.ocean.piuda.admin.site.dto.request.CreateSiteOptionRequest;
+import com.ocean.piuda.admin.site.dto.request.UpdateSiteOptionRequest;
+import com.ocean.piuda.admin.site.dto.response.SiteNameOptionResponse;
+import com.ocean.piuda.admin.site.service.SiteNameOptionService;
+import com.ocean.piuda.global.api.dto.ApiData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/admin/site")
+@RequiredArgsConstructor
+@Tag(name = "Site Name Options", description = "현장 명칭 선택지 관리 API")
+public class SiteNameOptionController {
+
+    private final SiteNameOptionService service;
+
+    @GetMapping
+    @Operation(summary = "현장 명칭 목록 조회 (Active)", description = "작성 화면 드롭다운에 표시할 활성화된 현장 명칭 목록을 조회합니다.")
+    public ApiData<List<SiteNameOptionResponse>> getOptions() {
+        return ApiData.ok(service.getActiveOptions());
+    }
+
+    @PostMapping
+    @Operation(summary = "현장 명칭 추가", description = "새로운 현장 명칭 선택지를 추가합니다.")
+    public ApiData<SiteNameOptionResponse> createOption(@RequestBody @Valid CreateSiteOptionRequest request) {
+        return ApiData.ok(service.createOption(request));
+    }
+
+    @DeleteMapping("/{optionId}")
+    @Operation(summary = "현장 명칭 비활성화", description = "해당 ID의 현장 명칭을 목록에서 숨김 처리합니다. (기존 기록은 유지됨)")
+    public ApiData<Void> deleteOption(@PathVariable Long optionId) {
+        service.deactivateOption(optionId);
+        return ApiData.ok(null);
+    }
+
+    @PatchMapping("/{optionId}")
+    @Operation(summary = "현장 명칭 수정", description = "현장 명칭을 변경하거나 활성/비활성 상태를 변경합니다. (변경할 필드만 보내면 됩니다)")
+    public ApiData<SiteNameOptionResponse> updateOption(
+            @PathVariable Long optionId,
+            @RequestBody @Valid UpdateSiteOptionRequest request
+    ) {
+        return ApiData.ok(service.updateOption(optionId, request));
+    }}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\request\CreateSiteOptionRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.site.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateSiteOptionRequest(
+        @NotBlank(message = "현장 명칭은 필수입니다.")
+        String name
+) {}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\request\UpdateSiteOptionRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.site.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateSiteOptionRequest(
+        @Size(min = 1, message = "현장 명칭은 최소 1글자 이상이어야 합니다.")
+        String name,
+
+        Boolean isActive
+) {}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\response\SiteNameOptionResponse.java
+================================================================================
+
+package com.ocean.piuda.admin.site.dto.response;
+
+import com.ocean.piuda.admin.site.entity.SiteNameOption;
+
+public record SiteNameOptionResponse(
+        Long id,
+        String name
+) {
+    public static SiteNameOptionResponse from(SiteNameOption entity) {
+        return new SiteNameOptionResponse(entity.getId(), entity.getName());
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\entity\SiteNameOption.java
+================================================================================
+
+package com.ocean.piuda.admin.site.entity;
+
+import com.ocean.piuda.global.api.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "site_name_option")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
+public class SiteNameOption extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "site_option_id")
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(name = "is_active", nullable = false)
+    private boolean isActive;
+
+    public void update(String name, Boolean isActive) {
+        if (name != null) this.name = name;
+        if (isActive!= null) this.isActive = isActive;
+    }
+
+    public void deactivate() {
+        this.isActive = false;
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\repository\SiteNameOptionRepository.java
+================================================================================
+
+package com.ocean.piuda.admin.site.repository;
+
+import com.ocean.piuda.admin.site.entity.SiteNameOption;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SiteNameOptionRepository extends JpaRepository<SiteNameOption, Long> {
+    // 활성화된 목록만 조회 (사용자 화면용)
+    List<SiteNameOption> findAllByIsActiveTrueOrderByCreatedAtDesc();
+
+    // 전체 목록 (관리자용)
+    List<SiteNameOption> findAllByOrderByCreatedAtDesc();
+
+    // 중복 체크용
+    boolean existsByName(String name);
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\site\service\SiteNameOptionService.java
+================================================================================
+
+package com.ocean.piuda.admin.site.service;
+
+
+import com.ocean.piuda.admin.site.dto.request.CreateSiteOptionRequest;
+import com.ocean.piuda.admin.site.dto.request.UpdateSiteOptionRequest;
+import com.ocean.piuda.admin.site.dto.response.SiteNameOptionResponse;
+import com.ocean.piuda.admin.site.entity.SiteNameOption;
+import com.ocean.piuda.admin.site.repository.SiteNameOptionRepository;
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SiteNameOptionService {
+
+    private final SiteNameOptionRepository siteNameOptionRepository;
+
+    /**
+     * [user] 활성화된 현장 명칭 목록 조회
+     */
+    public List<SiteNameOptionResponse> getActiveOptions() {
+        return siteNameOptionRepository.findAllByIsActiveTrueOrderByCreatedAtDesc().stream()
+                .map(SiteNameOptionResponse::from)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * [Admin] 현장 명칭 추가
+     */
+    @Transactional
+    public SiteNameOptionResponse createOption(CreateSiteOptionRequest request) {
+        if (siteNameOptionRepository.existsByName(request.name())) {
+            throw new BusinessException(ExceptionType.DUPLICATE_VALUE_ERROR);
+        }
+
+        SiteNameOption option = SiteNameOption.builder()
+                .name(request.name())
+                .isActive(true)
+                .build();
+
+        return SiteNameOptionResponse.from(siteNameOptionRepository.save(option));
+    }
+
+    /**
+     * [Admin] 현장 명칭 비활성화 (soft delete)
+     */
+    @Transactional
+    public void deactivateOption(Long optionId) {
+        SiteNameOption option = siteNameOptionRepository.findById(optionId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        option.deactivate();
+    }
+
+
+    /**
+     * [Admin] 현장 명칭 수정 (이름 변경 또는 활성 상태 변경)
+     */
+    @Transactional
+    public SiteNameOptionResponse updateOption(Long optionId, UpdateSiteOptionRequest request) {
+        SiteNameOption option = siteNameOptionRepository.findById(optionId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        // 이름 변경 요청이 있고, 기존 이름과 다를 경우 중복 체크 수행
+        if (request.name() != null && !request.name().equals(option.getName())) {
+            if (siteNameOptionRepository.existsByName(request.name())) {
+                throw new BusinessException(ExceptionType.DUPLICATE_VALUE_ERROR);
+            }
+        }
+
+        option.update(request.name(), request.isActive());
+
+        return SiteNameOptionResponse.from(option);
+    }
+}
+
+
+================================================================================
 File Path: .\src\main\java\com\ocean\piuda\admin\submission\controller\SubmissionController.java
 ================================================================================
 
@@ -3565,28 +4694,32 @@ import java.util.List;
 @RequiredArgsConstructor
 @Tag(
         name = "Admin Submission",
-        description = "해양 활동 제출 데이터 관리 API입니다. 제출 데이터의 조회, 생성, 승인, 반려, 삭제 기능을 제공합니다."
+        description = "해양 활동 제출 데이터 관리 API입니다. 활동 기록의 조회, 승인, 반려, 삭제 기능을 제공합니다."
 )
 public class SubmissionController {
 
     private final SubmissionQueryService submissionQueryService;
     private final SubmissionCommandService submissionCommandService;
 
+
     /**
-     * 제출 데이터 생성
+     * 기록 바로 제출 (SUBMITTED)
      */
     @PostMapping
-    @Operation(summary = "제출 데이터 생성", description = "Admin이 직접 제출 데이터를 생성합니다.")
+    @Operation(
+            summary = "기록 제출 (신규 등록)",
+            description = "새로운 활동 기록을 제출합니다. 상태는 '제출됨(SUBMITTED)'으로 저장되며, 관리자 승인 대기 상태가 됩니다."
+    )
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "생성 성공"),
-            @ApiResponse(responseCode = "400", description = "필수 필드 누락 또는 형식 오류"),
-            @ApiResponse(responseCode = "401", description = "인증 실패"),
-            @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
+            @ApiResponse(responseCode = "200", description = "제출 성공"),
+            @ApiResponse(responseCode = "400", description = "필수 필드 누락 또는 데이터 형식 오류"),
+            @ApiResponse(responseCode = "401", description = "인증 실패 (로그인 필요)"),
+            @ApiResponse(responseCode = "403", description = "권한 없음")
     })
-    public ApiData<SubmissionDetailResponse> createSubmission(
+    public ApiData<SubmissionDetailResponse> submitSubmission(
             @RequestBody @Valid CreateSubmissionRequest request
     ) {
-        SubmissionDetailResponse response = submissionCommandService.createSubmission(request);
+        SubmissionDetailResponse response = submissionCommandService.submitSubmission(request);
         return ApiData.ok(response);
     }
 
@@ -3594,7 +4727,7 @@ public class SubmissionController {
      * 제출 목록 조회
      */
     @GetMapping
-    @Operation(summary = "제출 목록 조회", description = "제출 목록을 페이지네이션과 함께 조회합니다. 검색, 필터링, 정렬을 지원합니다.")
+    @Operation(summary = "제출 목록 조회", description = "제출된 기록 목록을 페이지네이션, 필터링, 정렬하여 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
@@ -3602,22 +4735,22 @@ public class SubmissionController {
     })
     public ApiData<PageResponse<SubmissionListResponse>> getSubmissions(
             @Parameter(description = "검색 키워드 (현장명, 작성자)") @RequestParam(required = false) String keyword,
-            @Parameter(description = "상태 필터 (PENDING, APPROVED, REJECTED, DELETED)") @RequestParam(required = false) SubmissionStatus status,
-            @Parameter(description = "활동 유형 필터 (TRANSPLANT, TRASH_COLLECTION, RESEARCH, MONITORING, OTHER)") @RequestParam(required = false) ActivityType activityType,
-            @Parameter(description = "시작 날짜 (ISO 8601 형식)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
-            @Parameter(description = "종료 날짜 (ISO 8601 형식)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
-            @Parameter(description = "페이지 번호 (기본값: 0)") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "상태 필터 (SUBMITTED, APPROVED, REJECTED, DELETED)") @RequestParam(required = false) SubmissionStatus status,
+            @Parameter(description = "활동 유형 필터 (TRANSPLANT, GRAZER_REMOVAL, SUBSTRATE_IMPROVEMENT, MONITORING, MARINE_CLEANUP, ETC)") @RequestParam(required = false) ActivityType activityType,
+            @Parameter(description = "시작 날짜 (ISO 8601, 예: 2024-01-01T00:00:00)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+            @Parameter(description = "종료 날짜 (ISO 8601)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
+            @Parameter(description = "페이지 번호 (0부터 시작, 기본값: 0)") @RequestParam(defaultValue = "0") int page,
             @Parameter(description = "페이지 크기 (기본값: 20)") @RequestParam(defaultValue = "20") int size,
             @Parameter(description = "정렬 필드 (기본값: submittedAt)") @RequestParam(defaultValue = "submittedAt") String sortBy,
             @Parameter(description = "정렬 방향 (ASC, DESC, 기본값: DESC)") @RequestParam(defaultValue = "DESC") String sortDir
     ) {
         Sort sort = Sort.by(Sort.Direction.fromString(sortDir), sortBy);
         Pageable pageable = PageRequest.of(page, size, sort);
-        
+
         PageResponse<SubmissionListResponse> result = submissionQueryService.getSubmissions(
                 keyword, status, activityType, startDate, endDate, pageable
         );
-        
+
         return ApiData.ok(result);
     }
 
@@ -3628,7 +4761,7 @@ public class SubmissionController {
     @Operation(summary = "제출 상세 조회", description = "특정 제출 데이터의 상세 정보를 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 제출 데이터를 찾을 수 없음"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3642,10 +4775,10 @@ public class SubmissionController {
      * 검수 로그 조회
      */
     @GetMapping("/{submissionId}/logs")
-    @Operation(summary = "검수 로그 조회", description = "특정 제출 데이터의 검수 이력을 조회합니다.")
+    @Operation(summary = "검수 로그 조회", description = "특정 제출 데이터의 상태 변경(승인/반려/삭제) 이력을 조회합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "조회 성공"),
-            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "404", description = "해당 ID의 제출 데이터를 찾을 수 없음"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3659,11 +4792,11 @@ public class SubmissionController {
      * 단건 승인
      */
     @PostMapping("/{submissionId}/approve")
-    @Operation(summary = "단건 승인", description = "특정 제출 데이터를 승인합니다.")
+    @Operation(summary = "단건 승인", description = "특정 제출 데이터를 승인(APPROVED) 처리합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "승인 성공"),
-            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "이미 승인/반려/삭제된 제출"),
+            @ApiResponse(responseCode = "404", description = "데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 승인/반려/삭제된 상태라 변경 불가"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3677,12 +4810,12 @@ public class SubmissionController {
      * 단건 반려
      */
     @PostMapping("/{submissionId}/reject")
-    @Operation(summary = "단건 반려", description = "특정 제출 데이터를 반려합니다. 반려 사유를 필수로 입력해야 합니다.")
+    @Operation(summary = "단건 반려", description = "특정 제출 데이터를 반려(REJECTED) 처리합니다. 반려 사유 입력이 필수입니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "200", description = "반려 성공"),
-            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
-            @ApiResponse(responseCode = "409", description = "이미 승인/반려/삭제된 제출"),
-            @ApiResponse(responseCode = "422", description = "반려 사유가 공란"),
+            @ApiResponse(responseCode = "404", description = "데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "409", description = "이미 승인/반려/삭제된 상태라 변경 불가"),
+            @ApiResponse(responseCode = "422", description = "반려 사유 미입력"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3697,11 +4830,11 @@ public class SubmissionController {
     /**
      * 단건 삭제
      */
-    @DeleteMapping("/{submissionId}")
+    @DeleteMapping("/{submissionId:[0-9]+}")
     @Operation(summary = "단건 삭제", description = "특정 제출 데이터를 영구 삭제합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "404", description = "제출 데이터를 찾을 수 없음"),
+            @ApiResponse(responseCode = "204", description = "삭제 성공 (No Content)"),
+            @ApiResponse(responseCode = "404", description = "데이터를 찾을 수 없음"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3722,7 +4855,7 @@ public class SubmissionController {
     @PostMapping("/bulk/approve")
     @Operation(summary = "일괄 승인", description = "여러 제출 데이터를 한 번에 승인합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "일괄 승인 완료"),
+            @ApiResponse(responseCode = "200", description = "일괄 승인 완료 (성공/실패 건수 반환)"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3737,10 +4870,10 @@ public class SubmissionController {
      * 일괄 반려
      */
     @PostMapping("/bulk/reject")
-    @Operation(summary = "일괄 반려", description = "여러 제출 데이터를 한 번에 반려합니다. 반려 사유를 필수로 입력해야 합니다.")
+    @Operation(summary = "일괄 반려", description = "여러 제출 데이터를 한 번에 반려합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "일괄 반려 완료"),
-            @ApiResponse(responseCode = "422", description = "반려 사유가 공란"),
+            @ApiResponse(responseCode = "200", description = "일괄 반려 완료 (성공/실패 건수 반환)"),
+            @ApiResponse(responseCode = "422", description = "반려 사유 미입력"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3757,7 +4890,7 @@ public class SubmissionController {
     @DeleteMapping("/bulk")
     @Operation(summary = "일괄 삭제", description = "여러 제출 데이터를 한 번에 영구 삭제합니다.")
     @ApiResponses({
-            @ApiResponse(responseCode = "200", description = "일괄 삭제 완료"),
+            @ApiResponse(responseCode = "200", description = "일괄 삭제 완료 (성공/실패 건수 반환)"),
             @ApiResponse(responseCode = "401", description = "인증 실패"),
             @ApiResponse(responseCode = "403", description = "Admin 권한 없음")
     })
@@ -3835,11 +4968,7 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\CreateSu
 
 package com.ocean.piuda.admin.submission.dto.request;
 
-import com.ocean.piuda.admin.common.enums.ActivityType;
-import com.ocean.piuda.admin.common.enums.CurrentState;
-import com.ocean.piuda.admin.common.enums.HealthGrade;
-import com.ocean.piuda.admin.common.enums.ParticipantRole;
-import com.ocean.piuda.admin.common.enums.Weather;
+import com.ocean.piuda.admin.common.enums.*;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -3851,7 +4980,6 @@ import lombok.NoArgsConstructor;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 
 @Getter
@@ -3860,50 +4988,103 @@ import java.util.List;
 @AllArgsConstructor
 public class CreateSubmissionRequest {
 
-    @NotBlank(message = "현장명은 필수입니다")
+    /**
+     * siteName : 옵션 ID가 있으면 이건 null이어도 됨
+     * siteNameOptionId : 옵션 현장명을 사용한 경우 기입. 사용하지 않은 경우는 null.
+     */
     private String siteName;
+    private Long siteNameOptionId;
 
-    @NotNull(message = "활동유형은 필수입니다")
+    private LocalDate recordDate;  // null이면 현재 날짜
+
+    @NotNull(message = "다이빙 회차는 필수입니다")
+    private Integer divingRound;  // 1~5
+
+    @NotNull(message = "작업 유형은 필수입니다")
     private ActivityType activityType;
 
-    private LocalDateTime submittedAt; // null이면 현재 시간 사용
-
-    @NotBlank(message = "작성자명은 필수입니다")
-    private String authorName;
-
-    private String authorEmail;
-
-    private String feedbackText;
-
-    private BigDecimal latitude;
-    private BigDecimal longitude;
+    private String workDescription;  // 작업 내용
 
     @Valid
+    @NotNull(message = "기본 환경 정보는 필수입니다")
     private BasicEnvDto basicEnv;
 
     @Valid
     private ParticipantsDto participants;
 
-    @Valid
-    @NotNull(message = "활동 정보는 필수입니다")
-    private ActivityDto activity;
+
+    /**
+     * TRANSPLANT (이식) 작업 시 사용되는 필드
+     * activityType이 TRANSPLANT일 때만 필수
+     */
+    private TransplantActivityDto transplantActivity;
+
+    /**
+     * GRAZER_REMOVAL (조식동물 작업) 작업 시 사용되는 필드
+     * activityType이 GRAZER_REMOVAL일 때만 필수
+     * 
+     * @Valid 제거: ActivityValidator에서만 검증 (다른 activity DTO와 충돌 방지)
+     */
+    private GrazerRemovalActivityDto grazerRemovalActivity;
+
+    /**
+     * SUBSTRATE_IMPROVEMENT (부착기질 개선) 작업 시 사용되는 필드
+     * activityType이 SUBSTRATE_IMPROVEMENT일 때만 필수
+     * 
+     * @Valid 제거: ActivityValidator에서만 검증 (다른 activity DTO와 충돌 방지)
+     */
+    private SubstrateImprovementActivityDto substrateImprovementActivity;
+
+    /**
+     * MONITORING (모니터링) 작업 시 사용되는 필드
+     * activityType이 MONITORING일 때만 필수
+     * 
+     * @Valid 제거: ActivityValidator에서만 검증 (다른 activity DTO와 충돌 방지)
+     */
+    private MonitoringActivityDto monitoringActivity;
+
+    /**
+     * MARINE_CLEANUP (해양정화) 작업 시 사용되는 필드
+     * activityType이 MARINE_CLEANUP일 때만 필수
+     * 
+     * @Valid 제거: ActivityValidator에서만 검증 (다른 activity DTO와 충돌 방지)
+     */
+    private MarineCleanupActivityDto marineCleanupActivity;
 
     @Valid
     private List<AttachmentDto> attachments;
+
+
+    // === 내부 DTO 클래스들 ===
 
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
     public static class BasicEnvDto {
+        @NotNull(message = "기록 날짜는 필수입니다")
         private LocalDate recordDate;
-        private LocalTime startTime;
-        private LocalTime endTime;
-        private Float waterTempC;
-        private Float visibilityM;
-        private Float depthM;
-        private CurrentState currentState;
-        private Weather weather;
+
+        @NotNull(message = "평균 수심은 필수입니다")
+        private Double avgDepthM;
+
+        @NotNull(message = "최대 수심은 필수입니다")
+        private Double maxDepthM;
+
+        @NotNull(message = "수온은 필수입니다")
+        private Double waterTempC;
+
+        @NotNull(message = "시야 상태는 필수입니다")
+        private MarineCondition visibilityStatus;
+
+        @NotNull(message = "파도 상태는 필수입니다")
+        private MarineCondition waveStatus;
+
+        @NotNull(message = "서지 상태는 필수입니다")
+        private MarineCondition surgeStatus;
+
+        @NotNull(message = "조류 상태는 필수입니다")
+        private MarineCondition currentStatus;
     }
 
     @Getter
@@ -3911,46 +5092,180 @@ public class CreateSubmissionRequest {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ParticipantsDto {
-        private String leaderName;
-        private Integer participantCount;
-        private ParticipantRole role;
+        private String participantNames;  // comma-separated 또는 JSON 배열
     }
 
+    /**
+     * TRANSPLANT (이식) 작업 전용 DTO
+     * activityType이 TRANSPLANT일 때만 사용
+     * 
+     * 필드:
+     * - speciesType: 대상 종류 (감태/다시마/곰피/모자반/대황/기타)
+     * - locationType: 이식 장소 (어초/암반/기타)
+     * - methodType: 이식 방식
+     * - scale: 이식 규모 (텍스트)
+     * - healthStatus: 건강상태
+     */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ActivityDto {
-        @NotNull(message = "활동유형은 필수입니다")
-        private ActivityType type;
-        private String details;
-        private Float collectionAmount;
-        private Float durationHours;
+    public static class TransplantActivityDto {
+        @NotNull(message = "대상 종류는 필수입니다")
+        private TransplantSpeciesType speciesType;
 
-        // --- 추가된 필드 ---
-        private HealthGrade healthGrade;
-        private Float growthCm;
-        private NaturalReproductionDto naturalReproduction;
-        private SurvivalDto survival;
+        @NotNull(message = "이식 장소는 필수입니다")
+        private TransplantLocationType locationType;
+
+        @NotNull(message = "이식 방식은 필수입니다")
+        private TransplantMethodType methodType;
+
+        @NotBlank(message = "이식 규모는 필수입니다")
+        private String scale;
+
+        @NotNull(message = "건강상태는 필수입니다")
+        private HealthStatus healthStatus;
     }
 
+    /**
+     * GRAZER_REMOVAL (조식동물 작업) 전용 DTO
+     * activityType이 GRAZER_REMOVAL일 때만 사용
+     * 
+     * 필드:
+     * - targetSpecies: 대상 생물 (복수 선택: 성게/소라/전복/불가사리/기타)
+     * - densityBeforeWork: 작업 전 밀도 (LOW/MID/HIGH)
+     * - workScope: 작업 범위 (LOCAL/ZONE/WIDE)
+     * - note: 보충 설명 (선택)
+     * - collectionAmount: 수거량 (텍스트)
+     */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class NaturalReproductionDto {
-        private Float radiusM;
-        private Float numerator;
-        private Float denominator;
+    public static class GrazerRemovalActivityDto {
+        @NotNull(message = "대상 생물은 필수입니다")
+        private List<GrazerSpeciesType> targetSpecies;
+
+        @NotNull(message = "작업 전 밀도는 필수입니다")
+        private DensityLevel densityBeforeWork;
+
+        @NotNull(message = "작업 범위는 필수입니다")
+        private WorkScope workScope;
+
+        private String note;  // 보충 설명
+
+        @NotBlank(message = "수거량은 필수입니다")
+        private String collectionAmount;
     }
 
+    /**
+     * SUBSTRATE_IMPROVEMENT (부착기질 개선) 전용 DTO
+     * activityType이 SUBSTRATE_IMPROVEMENT일 때만 사용
+     * 
+     * 필드:
+     * - targetType: 작업 대상 (암반/어초/구조물/기타)
+     * - workScope: 작업 범위 (텍스트)
+     * - substrateState: 작업 후 기질 상태 (텍스트)
+     */
     @Getter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class SurvivalDto {
-        private Float dieCount;
-        private Float totalCount;
+    public static class SubstrateImprovementActivityDto {
+        @NotNull(message = "작업 대상은 필수입니다")
+        private SubstrateTargetType targetType;
+
+        @NotBlank(message = "작업 범위는 필수입니다")
+        private String workScope;
+
+        @NotBlank(message = "작업 후 기질 상태는 필수입니다")
+        private String substrateState;
+    }
+
+    /**
+     * MONITORING (모니터링) 전용 DTO
+     * activityType이 MONITORING일 때만 사용
+     * 
+     * 필드:
+     * - entryCoordinate: 입수 좌표 (텍스트 또는 lat/lon 구조)
+     * - exitCoordinate: 출수 좌표 (텍스트 또는 lat/lon 구조)
+     * - direction: 진행방위 (텍스트)
+     * - terrain: 지형 구성 (enum: ROCK/SAND/MIXED/OTHER)
+     * - barrenExtent: 갯녹음 정도 (enum: NONE/ONGOING/SEVERE)
+     * - grazerDistribution: 조식동물 분포 (enum: LOW/MID/HIGH)
+     * - rockFeatures: 암반 특성 (복수 enum: SMOOTH/CRACKED/CALCAREOUS_ALGAE/MIXED/SEAWEED_VEGETATION)
+     * - suitability: 해조 이식 적합성 (enum: SUITABLE/UNSUITABLE)
+     * - seaweedIdNumber: 해조류 식별번호 (텍스트)
+     * - seaweedHealthStatus: 해조류 생육상태 (enum: A/B/C/D)
+     * - precisionMeasurement: 정밀측정 여부 (boolean)
+     * - leafLength: 엽장 (텍스트 또는 숫자)
+     * - maxLeafWidth: 최대엽폭 (텍스트 또는 숫자)
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MonitoringActivityDto {
+        // 적지조사
+        private String entryCoordinate;
+        private String exitCoordinate;
+        private String direction;
+        
+        // 지형 구성
+        @NotNull(message = "지형 구성은 필수입니다")
+        private TerrainType terrain;
+        
+        // 갯녹음 정도
+        @NotNull(message = "갯녹음 정도는 필수입니다")
+        private BarrenExtent barrenExtent;
+        
+        // 조식동물 분포
+        @NotNull(message = "조식동물 분포는 필수입니다")
+        private DensityLevel grazerDistribution;
+        
+        // 암반 특성 (복수 선택)
+        @NotNull(message = "암반 특성은 최소 1개 이상 선택해야 합니다")
+        private List<RockFeature> rockFeatures;
+        
+        // 해조 이식 적합성
+        @NotNull(message = "해조 이식 적합성은 필수입니다")
+        private Suitability suitability;
+        
+        // 해조류 상태
+        private String seaweedIdNumber;  // 식별번호
+        private SeaweedHealthStatus seaweedHealthStatus;  // 생육상태 (양호/쇠약/탈락)
+        
+        // 정밀측정 여부
+        private Boolean precisionMeasurement;
+        private String leafLength;  // 엽장
+        private String maxLeafWidth;  // 최대엽폭
+    }
+
+    /**
+     * MARINE_CLEANUP (해양정화) 전용 DTO
+     * activityType이 MARINE_CLEANUP일 때만 사용
+     * 
+     * 필드:
+     * - wasteTypes: 폐기물 유형 (복수 선택: 그물/통발/기타어구/낚시도구/플라스틱/기타)
+     * - method: 인양 방식 (HAND/BAG/CRANE)
+     * - collectionAmount: 수거량 (텍스트)
+     * - uncollectedScale: 미수거 폐기물 규모 (SMALL/MEDIUM/LARGE, 선택)
+     */
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MarineCleanupActivityDto {
+        @NotNull(message = "폐기물 유형은 필수입니다")
+        private List<WasteType> wasteTypes;
+
+        @NotNull(message = "인양 방식은 필수입니다")
+        private CleanupMethodType method;
+
+        @NotBlank(message = "수거량은 필수입니다")
+        private String collectionAmount;
+
+        private UncollectedScale uncollectedScale;
     }
 
     @Getter
@@ -3960,9 +5275,12 @@ public class CreateSubmissionRequest {
     public static class AttachmentDto {
         private String fileName;
         private String fileUrl;
+        private String presignedUrl;  // presigned URL
         private String mimeType;
         private Integer fileSize;
     }
+
+
 }
 
 
@@ -4005,70 +5323,6 @@ public record SingleRejectRequest(
         @Valid
         RejectReasonDto reason
 ) {
-}
-
-
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\ActivityResponse.java
-================================================================================
-
-package com.ocean.piuda.admin.submission.dto.response;
-
-import com.ocean.piuda.admin.common.enums.ActivityType;
-import com.ocean.piuda.admin.common.enums.HealthGrade;
-import com.ocean.piuda.admin.submission.entity.Activity;
-import com.ocean.piuda.admin.submission.entity.embeded.NaturalReproduction;
-import com.ocean.piuda.admin.submission.entity.embeded.Survival;
-
-public record ActivityResponse(
-        ActivityType type,
-        String details,
-        Float collectionAmount,
-        Float durationHours,
-
-        // --- 추가된 필드 ---
-        HealthGrade healthGrade,
-        Float growthCm,
-        NaturalReproductionResponse naturalReproduction,
-        SurvivalResponse survival
-) {
-    public static ActivityResponse from(Activity activity) {
-        if (activity == null) return null;
-        return new ActivityResponse(
-                activity.getType(),
-                activity.getDetails(),
-                activity.getCollectionAmount(),
-                activity.getDurationHours(),
-
-                // 매핑 로직
-                activity.getHealthGrade(),
-                activity.getGrowthCm(),
-                NaturalReproductionResponse.from(activity.getNaturalReproduction()),
-                SurvivalResponse.from(activity.getSurvival())
-        );
-    }
-
-    // --- 내부 레코드 정의 ---
-    public record NaturalReproductionResponse(
-            Float radiusM,
-            Float numerator,
-            Float denominator
-    ) {
-        public static NaturalReproductionResponse from(NaturalReproduction vo) {
-            if (vo == null) return null;
-            return new NaturalReproductionResponse(vo.getRadiusM(), vo.getNumerator(), vo.getDenominator());
-        }
-    }
-
-    public record SurvivalResponse(
-            Float dieCount,
-            Float totalCount
-    ) {
-        public static SurvivalResponse from(Survival vo) {
-            if (vo == null) return null;
-            return new SurvivalResponse(vo.getDieCount(), vo.getTotalCount());
-        }
-    }
 }
 
 
@@ -4141,35 +5395,34 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BasicEn
 
 package com.ocean.piuda.admin.submission.dto.response;
 
-import com.ocean.piuda.admin.common.enums.CurrentState;
-import com.ocean.piuda.admin.common.enums.Weather;
+import com.ocean.piuda.admin.common.enums.MarineCondition;
 import com.ocean.piuda.admin.submission.entity.BasicEnv;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 public record BasicEnvResponse(
         LocalDate recordDate,
-        LocalTime startTime,
-        LocalTime endTime,
-        Float waterTempC,
-        Float visibilityM,
-        Float depthM,
-        CurrentState currentState,
-        Weather weather
+        // 새로운 필드 (우선 사용)
+        Double avgDepthM,  // 평균 수심
+        Double maxDepthM,  // 최대 수심
+        Double waterTempC,  // 수온
+        MarineCondition visibilityStatus,  // 시야 상태
+        MarineCondition waveStatus,  // 파도 상태
+        MarineCondition surgeStatus,  // 서지 상태
+        MarineCondition currentStatus  // 조류 상태
 ) {
     public static BasicEnvResponse from(BasicEnv basicEnv) {
         if (basicEnv == null) return null;
         return new BasicEnvResponse(
                 basicEnv.getRecordDate(),
-                basicEnv.getStartTime(),
-                basicEnv.getEndTime(),
+                // 새로운 필드
+                basicEnv.getAvgDepthM(),
+                basicEnv.getMaxDepthM(),
                 basicEnv.getWaterTempC(),
-                basicEnv.getVisibilityM(),
-                basicEnv.getDepthM(),
-                basicEnv.getCurrentState(),
-                basicEnv.getWeather()
-        );
+                basicEnv.getVisibilityStatus(),
+                basicEnv.getWaveStatus(),
+                basicEnv.getSurgeStatus(),
+                basicEnv.getCurrentStatus());
     }
 }
 
@@ -4222,23 +5475,11 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\Partici
 
 package com.ocean.piuda.admin.submission.dto.response;
 
-import com.ocean.piuda.admin.common.enums.ParticipantRole;
-import com.ocean.piuda.admin.submission.entity.Participants;
+
 
 public record ParticipantsResponse(
-        String leaderName,
-        Integer participantCount,
-        ParticipantRole role
-) {
-    public static ParticipantsResponse from(Participants participants) {
-        if (participants == null) return null;
-        return new ParticipantsResponse(
-                participants.getLeaderName(),
-                participants.getParticipantCount(),
-                participants.getRole()
-        );
-    }
-}
+        String participantNames
+) { }
 
 
 ================================================================================
@@ -4247,9 +5488,8 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\Submiss
 
 package com.ocean.piuda.admin.submission.dto.response;
 
-import com.ocean.piuda.admin.common.enums.ActivityType;
-import com.ocean.piuda.admin.common.enums.SubmissionStatus;
-import com.ocean.piuda.admin.submission.entity.Submission;
+import com.ocean.piuda.admin.common.enums.*;
+import com.ocean.piuda.admin.submission.entity.*;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -4259,18 +5499,23 @@ import java.util.stream.Collectors;
 public record SubmissionDetailResponse(
         Long submissionId,
         String siteName,
+        Long siteNameOptionId,
         ActivityType activityType,
         LocalDateTime submittedAt,
         SubmissionStatus status,
         String authorName,
         String authorEmail,
         Integer attachmentCount,
-        String feedbackText,
-        BigDecimal latitude,
-        BigDecimal longitude,
+        String feedbackText,  // API 하위 호환성을 위해 필드명 유지 (내부적으로는 workDescription 사용)
         BasicEnvResponse basicEnv,
         ParticipantsResponse participants,
-        ActivityResponse activity,
+
+        TransplantResponse transplantActivity,
+        GrazerRemovalResponse grazerRemovalActivity,
+        SubstrateImprovementResponse substrateImprovementActivity,
+        MonitoringResponse monitoringActivity,
+        MarineCleanupResponse marineCleanupActivity,
+
         List<AttachmentResponse> attachments,
         String rejectReason,
         List<AuditLogResponse> auditLogs,
@@ -4300,24 +5545,135 @@ public record SubmissionDetailResponse(
         return new SubmissionDetailResponse(
                 submission.getSubmissionId(),
                 submission.getSiteName(),
+                submission.getSiteNameOption() != null ? submission.getSiteNameOption().getId() : null,
                 submission.getActivityType(),
                 submission.getSubmittedAt(),
                 submission.getStatus(),
                 submission.getAuthorName(),
                 submission.getAuthorEmail(),
                 submission.getAttachmentCount(),
-                submission.getFeedbackText(),
-                submission.getLatitude(),
-                submission.getLongitude(),
+                submission.getWorkDescription(),
                 BasicEnvResponse.from(submission.getBasicEnv()),
-                ParticipantsResponse.from(submission.getParticipants()),
-                ActivityResponse.from(submission.getActivity()),
+                new ParticipantsResponse(submission.getParticipantNames()),
+
+                // Activity Type별 매핑 (존재하는 것만 변환, 나머지는 null)
+                TransplantResponse.from(submission.getActivityTransplant()),
+                GrazerRemovalResponse.from(submission.getActivityGrazerRemoval()),
+                SubstrateImprovementResponse.from(submission.getActivitySubstrateImprovement()),
+                MonitoringResponse.from(submission.getActivityMonitoring()),
+                MarineCleanupResponse.from(submission.getActivityMarineCleanup()),
+
                 attachments,
                 rejectReason,
                 auditLogs,
                 submission.getCreatedAt(),
                 submission.getModifiedAt()
         );
+    }
+
+
+    //  Inner Record Classes (각 활동 유형별 응답 DTO)
+    public record TransplantResponse(
+            TransplantSpeciesType speciesType,
+            TransplantLocationType locationType,
+            TransplantMethodType methodType,
+            String scale,
+            HealthStatus healthStatus
+    ) {
+        public static TransplantResponse from(ActivityTransplant entity) {
+            if (entity == null) return null;
+            return new TransplantResponse(
+                    entity.getSpeciesType(),
+                    entity.getLocationType(),
+                    entity.getMethodType(),
+                    entity.getScale(),
+                    entity.getHealthStatus()
+            );
+        }
+    }
+
+    public record GrazerRemovalResponse(
+            List<GrazerSpeciesType> targetSpecies,
+            DensityLevel densityBeforeWork,
+            WorkScope workScope,
+            String note,
+            String collectionAmount
+    ) {
+        public static GrazerRemovalResponse from(ActivityGrazerRemoval entity) {
+            if (entity == null) return null;
+            return new GrazerRemovalResponse(
+                    entity.getTargetSpecies(),
+                    entity.getDensityBeforeWork(),
+                    entity.getWorkScope(),
+                    entity.getNote(),
+                    entity.getCollectionAmount()
+            );
+        }
+    }
+
+    public record SubstrateImprovementResponse(
+            SubstrateTargetType targetType,
+            String workScope,
+            String substrateState
+    ) {
+        public static SubstrateImprovementResponse from(ActivitySubstrateImprovement entity) {
+            if (entity == null) return null;
+            return new SubstrateImprovementResponse(
+                    entity.getTargetType(),
+                    entity.getWorkScope(),
+                    entity.getSubstrateState()
+            );
+        }
+    }
+
+    public record MonitoringResponse(
+            String entryCoordinate,
+            String exitCoordinate,
+            String direction,
+            TerrainType terrain,
+            BarrenExtent barrenExtent,
+            DensityLevel grazerDistribution,
+            List<RockFeature> rockFeatures,
+            Suitability suitability,
+            String seaweedIdNumber,
+            SeaweedHealthStatus seaweedHealthStatus,
+            String leafLength,
+            String maxLeafWidth
+    ) {
+        public static MonitoringResponse from(ActivityMonitoring entity) {
+            if (entity == null) return null;
+            return new MonitoringResponse(
+                    entity.getEntryCoordinate(),
+                    entity.getExitCoordinate(),
+                    entity.getDirection(),
+                    entity.getTerrain(),
+                    entity.getBarrenExtent(),
+                    entity.getGrazerDistribution(),
+                    entity.getRockFeatures(),
+                    entity.getSuitability(),
+                    entity.getSeaweedIdNumber(),
+                    entity.getSeaweedHealthStatus(),
+                    entity.getLeafLength(),
+                    entity.getMaxLeafWidth()
+            );
+        }
+    }
+
+    public record MarineCleanupResponse(
+            List<WasteType> wasteTypes,
+            CleanupMethodType method,
+            String collectionAmount,
+            UncollectedScale uncollectedScale
+    ) {
+        public static MarineCleanupResponse from(ActivityMarineCleanup entity) {
+            if (entity == null) return null;
+            return new MarineCleanupResponse(
+                    entity.getWasteTypes(),
+                    entity.getMethod(),
+                    entity.getCollectionAmount(),
+                    entity.getUncollectedScale()
+            );
+        }
     }
 }
 
@@ -4361,26 +5717,28 @@ public record SubmissionListResponse(
 
 
 ================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\Activity.java
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityGrazerRemoval.java
 ================================================================================
 
 package com.ocean.piuda.admin.submission.entity;
 
-import com.ocean.piuda.admin.common.enums.ActivityType;
-import com.ocean.piuda.admin.common.enums.HealthGrade;
-import com.ocean.piuda.admin.submission.entity.embeded.NaturalReproduction;
-import com.ocean.piuda.admin.submission.entity.embeded.Survival;
+import com.ocean.piuda.admin.common.enums.DensityLevel;
+import com.ocean.piuda.admin.common.enums.GrazerSpeciesType;
+import com.ocean.piuda.admin.common.enums.WorkScope;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
-@Table(name = "activity")
+@Table(name = "activity_grazer_removal")
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder(toBuilder = true)
-public class Activity {
+public class ActivityGrazerRemoval {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -4388,39 +5746,280 @@ public class Activity {
     private Long activityId;
 
     @OneToOne
-    @JoinColumn(name = "submission_id", nullable = false)
+    @JoinColumn(name = "submission_id", nullable = false, unique = true)
+    private Submission submission;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+        name = "grazer_removal_target_species",
+        joinColumns = @JoinColumn(name = "activity_id")
+    )
+    @Column(name = "species")
+    @Builder.Default
+    private List<GrazerSpeciesType> targetSpecies = new ArrayList<>();  // 대상 생물 (복수)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "density_before_work", nullable = false)
+    private DensityLevel densityBeforeWork;  // 작업 전 밀도
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "work_scope", nullable = false)
+    private WorkScope workScope;  // 작업 범위
+
+    @Column(columnDefinition = "TEXT")
+    private String note;  // 보충 설명
+
+    @Column(name = "collection_amount", nullable = false, length = 200)
+    private String collectionAmount;  // 수거량
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityMarineCleanup.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.CleanupMethodType;
+import com.ocean.piuda.admin.common.enums.UncollectedScale;
+import com.ocean.piuda.admin.common.enums.WasteType;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "activity_marine_cleanup")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ActivityMarineCleanup {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false, unique = true)
+    private Submission submission;
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+        name = "marine_cleanup_waste_types",
+        joinColumns = @JoinColumn(name = "activity_id")
+    )
+    @Column(name = "waste_type")
+    @Builder.Default
+    private List<WasteType> wasteTypes = new ArrayList<>();  // 폐기물 유형 (복수)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method", nullable = false)
+    private CleanupMethodType method;  // 인양 방식
+
+    @Column(name = "collection_amount", nullable = false, length = 200)
+    private String collectionAmount;  // 수거량
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "uncollected_scale")
+    private UncollectedScale uncollectedScale;  // 미수거 폐기물 규모
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityMonitoring.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.*;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "activity_monitoring")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ActivityMonitoring {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false, unique = true)
+    private Submission submission;
+
+    // 적지조사
+    @Column(name = "entry_coordinate", length = 200)
+    private String entryCoordinate;  // 입수좌표 (lat/lon 또는 text)
+
+    @Column(name = "exit_coordinate", length = 200)
+    private String exitCoordinate;  // 출수좌표
+
+    @Column(length = 100)
+    private String direction;  // 진행방위
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "terrain")
+    private TerrainType terrain;  // 지형 구성
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "barren_extent")
+    private BarrenExtent barrenExtent;  // 갯녹음 정도
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "grazer_distribution")
+    private DensityLevel grazerDistribution;  // 조식동물 분포
+
+    @ElementCollection
+    @Enumerated(EnumType.STRING)
+    @CollectionTable(
+        name = "monitoring_rock_features",
+        joinColumns = @JoinColumn(name = "activity_id")
+    )
+    @Column(name = "feature")
+    @Builder.Default
+    private List<RockFeature> rockFeatures = new ArrayList<>();  // 암반 특성 (복수)
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "suitability")
+    private Suitability suitability;  // 해조 이식 적합성
+
+    // 해조류 상태
+    @Column(name = "seaweed_id_number", length = 100)
+    private String seaweedIdNumber;  // 식별번호
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "seaweed_health_status")
+    private com.ocean.piuda.admin.common.enums.SeaweedHealthStatus seaweedHealthStatus;  // 생육상태 (양호/쇠약/탈락)
+
+    @Column(name = "leaf_length", length = 100)
+    private String leafLength;  // 엽장
+
+    @Column(name = "max_leaf_width", length = 100)
+    private String maxLeafWidth;  // 최대엽폭
+
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivitySubstrateImprovement.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.SubstrateTargetType;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "activity_substrate_improvement")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ActivitySubstrateImprovement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false, unique = true)
     private Submission submission;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private ActivityType type;
+    @Column(name = "target_type", nullable = false)
+    private SubstrateTargetType targetType;  // 작업 대상
 
-    @Column(columnDefinition = "TEXT")
-    private String details;
+    @Column(name = "work_scope", nullable = false, length = 200)
+    private String workScope;  // 작업 범위
 
-    @Column(name = "collection_amount")
-    @Builder.Default
-    private Float collectionAmount = 0f;
+    @Column(name = "substrate_state", nullable = false, columnDefinition = "TEXT")
+    private String substrateState;  // 작업 후 기질 상태
 
-    @Column(name = "duration_hours")
-    @Builder.Default
-    private Float durationHours = 0f;
+    public void updateSubmission(Submission submission) {
+        this.submission = submission;
+    }
+}
 
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityTransplant.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.entity;
+
+import com.ocean.piuda.admin.common.enums.HealthStatus;
+import com.ocean.piuda.admin.common.enums.TransplantLocationType;
+import com.ocean.piuda.admin.common.enums.TransplantMethodType;
+import com.ocean.piuda.admin.common.enums.TransplantSpeciesType;
+import jakarta.persistence.*;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+@Entity
+@Table(name = "activity_transplant")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@SuperBuilder(toBuilder = true)
+public class ActivityTransplant {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "activity_id")
+    private Long activityId;
+
+    @OneToOne
+    @JoinColumn(name = "submission_id", nullable = false, unique = true)
+    private Submission submission;
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "health_grade")
-    private HealthGrade healthGrade;
+    @Column(name = "species_type", nullable = false)
+    private TransplantSpeciesType speciesType;  // 대상 종류
 
-    @Column(name = "growth_cm")
-    @Builder.Default
-    private Float growthCm = 0f;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "location_type", nullable = false)
+    private TransplantLocationType locationType;  // 이식 장소
 
-    @Embedded
-    private NaturalReproduction naturalReproduction;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "method_type", nullable = false)
+    private TransplantMethodType methodType;  // 이식 방식
 
-    @Embedded
-    private Survival survival;
+    @Column(nullable = false, length = 200)
+    private String scale;  // 이식 규모
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "health_status", nullable = false)
+    private HealthStatus healthStatus;  // 건강상태
 
     public void updateSubmission(Submission submission) {
         this.submission = submission;
@@ -4530,14 +6129,12 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\BasicEnv.java
 
 package com.ocean.piuda.admin.submission.entity;
 
-import com.ocean.piuda.admin.common.enums.CurrentState;
-import com.ocean.piuda.admin.common.enums.Weather;
+import com.ocean.piuda.admin.common.enums.MarineCondition;
 import jakarta.persistence.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 @Entity
 @Table(name = "basic_env")
@@ -4559,132 +6156,31 @@ public class BasicEnv {
     @Column(name = "record_date", nullable = false)
     private LocalDate recordDate;
 
-    @Column(name = "start_time")
-    private LocalTime startTime;
+    @Column(name = "avg_depth_m", nullable = false)
+    private Double avgDepthM;  // 평균 수심
 
-    @Column(name = "end_time")
-    private LocalTime endTime;
+    @Column(name = "max_depth_m", nullable = false)
+    private Double maxDepthM;  // 최대 수심
 
-    @Column(name = "water_temp_c")
-    private Float waterTempC;
-
-    @Column(name = "visibility_m")
-    private Float visibilityM;
-
-    @Column(name = "depth_m")
-    private Float depthM;
+    @Column(name = "water_temp_c", nullable = false)
+    private Double waterTempC;  // 수온
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "current_state")
-    private CurrentState currentState;
+    @Column(name = "visibility_status", nullable = false)
+    private MarineCondition visibilityStatus;  // 시야 (BAD/NORMAL/GOOD)
 
     @Enumerated(EnumType.STRING)
-    private Weather weather;
-
-    public void updateSubmission(Submission submission) {
-        this.submission = submission;
-    }
-}
-
-
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\embeded\NaturalReproduction.java
-================================================================================
-
-package com.ocean.piuda.admin.submission.entity.embeded;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Embeddable
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class NaturalReproduction {
-
-    @Column(name = "nat_radius_m")
-    private Float radiusM;      // 관측 반경
-
-    @Column(name = "nat_numerator")
-    private Float numerator;    // 자연번식 개체수
-
-    @Column(name = "nat_denominator")
-    private Float denominator;  // 기준 개체수
-}
-
-
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\embeded\Survival.java
-================================================================================
-
-package com.ocean.piuda.admin.submission.entity.embeded;
-
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Embeddable;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
-@Embeddable
-@Getter
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class Survival {
-
-    @Column(name = "surv_die_count")
-    private Float dieCount;     // 죽은 개체수
-
-    @Column(name = "surv_total_count")
-    private Float totalCount;   // 총 개체수
-}
-
-
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\Participants.java
-================================================================================
-
-package com.ocean.piuda.admin.submission.entity;
-
-import com.ocean.piuda.admin.common.enums.ParticipantRole;
-import jakarta.persistence.*;
-import lombok.*;
-import lombok.experimental.SuperBuilder;
-
-@Entity
-@Table(name = "participants")
-@Getter
-@NoArgsConstructor
-@AllArgsConstructor
-@SuperBuilder(toBuilder = true)
-public class Participants {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "participant_id")
-    private Long participantId;
-
-    @OneToOne
-    @JoinColumn(name = "submission_id", nullable = false)
-    private Submission submission;
-
-    @Column(name = "leader_name", length = 100)
-    private String leaderName;
-
-    @Column(name = "participant_count")
-    @Builder.Default
-    private Integer participantCount = 1;
+    @Column(name = "wave_status", nullable = false)
+    private MarineCondition waveStatus;  // 파도
 
     @Enumerated(EnumType.STRING)
-    @Builder.Default
-    private ParticipantRole role = ParticipantRole.CITIZEN_DIVER;
+    @Column(name = "surge_status", nullable = false)
+    private MarineCondition surgeStatus;  // 서지
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "current_status", nullable = false)
+    private MarineCondition currentStatus;  // 조류
+
 
     public void updateSubmission(Submission submission) {
         this.submission = submission;
@@ -4748,12 +6244,18 @@ package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
 import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import com.ocean.piuda.admin.site.entity.SiteNameOption;
 import com.ocean.piuda.global.api.domain.BaseEntity;
+import com.ocean.piuda.user.entity.User;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
@@ -4772,21 +6274,51 @@ public class Submission extends BaseEntity {
     @Column(name = "submission_id")
     private Long submissionId;
 
+    /**
+     * 스냅샷 :실제 화면에 표시될 이름 (직접 입력 or 선택된 옵션의 이름)
+     */
     @Column(name = "site_name", nullable = false, length = 200)
     private String siteName;
+
+    /**
+     * 마스터 데이터 연동 (선택사항: 직접 입력 시 null)
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "site_option_id")
+    private SiteNameOption siteNameOption;
+
+
+    @Column(name = "record_date", nullable = false)
+    @Builder.Default
+    private LocalDate recordDate = LocalDate.now();
+
+    @Column(name = "diving_round", nullable = false)
+    @Min(1)
+    @Max(5)
+    private Integer divingRound;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "activity_type", nullable = false)
     private ActivityType activityType;
 
-    @Column(name = "submitted_at", nullable = false)
-    private java.time.LocalDateTime submittedAt;
+    @Column(name = "submitted_at")
+    private LocalDateTime submittedAt = LocalDateTime.now();  // 생성 시 제출 시점 기록
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
-    private SubmissionStatus status = SubmissionStatus.PENDING;
+    private SubmissionStatus status = SubmissionStatus.SUBMITTED;
 
+    /**
+     * 실제 유저 데이터
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    /**
+     * 유저의 탈퇴/정보 변경 이후에도 기록 당시 정보 보존 위한 스냅샷 필드
+     */
     @Column(name = "author_name", nullable = false, length = 100)
     private String authorName;
 
@@ -4797,24 +6329,35 @@ public class Submission extends BaseEntity {
     @Builder.Default
     private Integer attachmentCount = 0;
 
-    @Column(name = "feedback_text", columnDefinition = "TEXT")
-    private String feedbackText;
+    @Column(name = "work_description", columnDefinition = "TEXT")
+    private String workDescription;  // 작업 내용 (기존 feedbackText)
 
-    @Column(precision = 9, scale = 6)
-    private BigDecimal latitude;
+    @Column(name = "admin_memo", columnDefinition = "TEXT")
+    private String adminMemo;  // 관리자 검수 메모
 
-    @Column(precision = 9, scale = 6)
-    private BigDecimal longitude;
+    @Column(name = "participant_names", columnDefinition = "TEXT")
+    private String participantNames;
+
 
     // 관계 매핑
     @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
     private BasicEnv basicEnv;
 
+    // 작업 유형별 Activity (조건부 1:1)
     @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Participants participants;
+    private ActivityTransplant activityTransplant;
 
     @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Activity activity;
+    private ActivityGrazerRemoval activityGrazerRemoval;
+
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ActivitySubstrateImprovement activitySubstrateImprovement;
+
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ActivityMonitoring activityMonitoring;
+
+    @OneToOne(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
+    private ActivityMarineCleanup activityMarineCleanup;
 
     @OneToMany(mappedBy = "submission", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
@@ -4827,9 +6370,31 @@ public class Submission extends BaseEntity {
     @Builder.Default
     private List<AuditLog> auditLogs = new ArrayList<>();
 
+
+
     // 비즈니스 메서드
     public void updateStatus(SubmissionStatus status) {
         this.status = status;
+    }
+
+    /**
+     * 승인 (SUBMITTED -> APPROVED)
+     */
+    public void approve() {
+        if (this.status != SubmissionStatus.SUBMITTED) {
+            throw new IllegalStateException("SUBMITTED 상태만 승인 가능합니다. 현재 상태: " + this.status);
+        }
+        this.status = SubmissionStatus.APPROVED;
+    }
+
+    /**
+     * 반려 (SUBMITTED -> REJECTED)
+     */
+    public void reject() {
+        if (this.status != SubmissionStatus.SUBMITTED) {
+            throw new IllegalStateException("SUBMITTED 상태만 반려 가능합니다. 현재 상태: " + this.status);
+        }
+        this.status = SubmissionStatus.REJECTED;
     }
 
     public void addAttachment(Attachment attachment) {
@@ -4850,24 +6415,50 @@ public class Submission extends BaseEntity {
         }
     }
 
-    public void setParticipants(Participants participants) {
-        this.participants = participants;
-        if (participants != null) {
-            participants.updateSubmission(this);
-        }
+    public void updateParticipantNames(String participantNames) {
+        this.participantNames = participantNames;
     }
 
-    public void setActivity(Activity activity) {
-        this.activity = activity;
-        if (activity != null) {
-            activity.updateSubmission(this);
-        }
-    }
 
     public void setRejectReason(RejectReason rejectReason) {
         this.rejectReason = rejectReason;
         if (rejectReason != null) {
             rejectReason.updateSubmission(this);
+        }
+    }
+
+    public void setActivityTransplant(ActivityTransplant activityTransplant) {
+        this.activityTransplant = activityTransplant;
+        if (activityTransplant != null) {
+            activityTransplant.updateSubmission(this);
+        }
+    }
+
+    public void setActivityGrazerRemoval(ActivityGrazerRemoval activityGrazerRemoval) {
+        this.activityGrazerRemoval = activityGrazerRemoval;
+        if (activityGrazerRemoval != null) {
+            activityGrazerRemoval.updateSubmission(this);
+        }
+    }
+
+    public void setActivitySubstrateImprovement(ActivitySubstrateImprovement activitySubstrateImprovement) {
+        this.activitySubstrateImprovement = activitySubstrateImprovement;
+        if (activitySubstrateImprovement != null) {
+            activitySubstrateImprovement.updateSubmission(this);
+        }
+    }
+
+    public void setActivityMonitoring(ActivityMonitoring activityMonitoring) {
+        this.activityMonitoring = activityMonitoring;
+        if (activityMonitoring != null) {
+            activityMonitoring.updateSubmission(this);
+        }
+    }
+
+    public void setActivityMarineCleanup(ActivityMarineCleanup activityMarineCleanup) {
+        this.activityMarineCleanup = activityMarineCleanup;
+        if (activityMarineCleanup != null) {
+            activityMarineCleanup.updateSubmission(this);
         }
     }
 }
@@ -4880,6 +6471,8 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\initializer\Submissi
 package com.ocean.piuda.admin.submission.initializer;
 
 import com.ocean.piuda.admin.common.enums.*;
+import com.ocean.piuda.admin.site.entity.SiteNameOption;
+import com.ocean.piuda.admin.site.repository.SiteNameOptionRepository;
 import com.ocean.piuda.admin.submission.entity.*;
 import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
 import lombok.RequiredArgsConstructor;
@@ -4905,6 +6498,10 @@ import java.util.List;
 public class SubmissionDataInitializer implements CommandLineRunner {
 
     private final SubmissionRepository submissionRepository;
+    private final SiteNameOptionRepository siteNameOptionRepository;
+
+    // 이미지 URL 상수
+    private static final String VALID_IMAGE_URL = "/images/underSea.jpg";
 
     @Override
     @Transactional
@@ -4916,93 +6513,74 @@ public class SubmissionDataInitializer implements CommandLineRunner {
 
         log.info("Admin Submission 테스트 데이터 초기화 시작...");
 
+        // 0. SiteNameOption 마스터 데이터 생성
+        SiteNameOption optionCrossReef = siteNameOptionRepository.save(SiteNameOption.builder().name("십자형 어초").isActive(true).build());
+        SiteNameOption optionCage1 = siteNameOptionRepository.save(SiteNameOption.builder().name("가두리 #1").isActive(true).build());
+        SiteNameOption optionCage2 = siteNameOptionRepository.save(SiteNameOption.builder().name("가두리 #2").isActive(true).build());
+
         List<Submission> submissions = new ArrayList<>();
 
-        // 1. 검수 대기 중인 제출 (PENDING)
+        // 1. 검수 대기 (이식) - 옵션 선택(십자형 어초)
         submissions.add(createSubmission(
                 1L,
-                "포항 해안가",
-                ActivityType.TRANSPLANT,
-                SubmissionStatus.PENDING,
-                "홍길동",
-                "hong@example.com",
-                3,
+                "십자형 어초", // 스냅샷 이름
+                optionCrossReef, // 선택된 옵션 엔티티
+                ActivityType.TRANSPLANT, SubmissionStatus.SUBMITTED,
+                "홍길동", "hong@example.com", 3,
                 "깨끗해진 바다가 뿌듯합니다",
-                new BigDecimal("36.0322"),
-                new BigDecimal("129.3650"),
-                LocalDate.now().minusDays(2),
-                LocalTime.of(9, 0),
-                LocalTime.of(12, 30),
-                18.5f,
-                15.0f,
-                10.5f,
-                CurrentState.MEDIUM,
-                Weather.SUNNY,
-                "홍길동",
-                5,
-                ParticipantRole.CITIZEN_DIVER,
+                new BigDecimal("36.0322"), new BigDecimal("129.3650"),
+                LocalDate.now().minusDays(2), LocalTime.of(9, 0),
+                18.5,  // 수온
+                MarineCondition.GOOD,   // 시야
+                10.5,  // 수심
+                MarineCondition.NORMAL, // 파도
+                MarineCondition.NORMAL, // 서지
+                MarineCondition.NORMAL, // 조류
+                "홍길동, 김철수",
                 "이식 작업을 수행했습니다. 총 50개를 이식했습니다.",
-                50.0f,
-                3.5f,
-                "public/user_objects/2025-01-15/photo1.jpg"
+                "50개"
         ));
 
-        // 2. 승인된 제출 (APPROVED)
+        // 2. 승인 (해양정화) - 직접 입력(부산 송도해수욕장, 옵션 Null)
         submissions.add(createSubmission(
                 2L,
                 "부산 송도해수욕장",
-                ActivityType.TRASH_COLLECTION,
-                SubmissionStatus.APPROVED,
-                "김철수",
-                "kim@example.com",
-                2,
+                null, // 직접 입력
+                ActivityType.TRASH_COLLECTION, SubmissionStatus.APPROVED,
+                "김철수", "kim@example.com", 2,
                 "해변 청소 활동에 참여했습니다",
-                new BigDecimal("35.0784"),
-                new BigDecimal("129.0756"),
-                LocalDate.now().minusDays(5),
-                LocalTime.of(10, 0),
-                LocalTime.of(14, 0),
-                20.0f,
-                20.0f,
-                5.0f,
-                CurrentState.LOW,
-                Weather.SUNNY,
-                "김철수",
-                3,
-                ParticipantRole.CITIZEN_DIVER,
+                new BigDecimal("35.0784"), new BigDecimal("129.0756"),
+                LocalDate.now().minusDays(5), LocalTime.of(10, 0),
+                20.0,
+                MarineCondition.GOOD,
+                5.0,
+                MarineCondition.GOOD,   // 파도
+                MarineCondition.GOOD,   // 서지
+                MarineCondition.GOOD,   // 조류
+                "김철수, 이영희, 박민수",
                 "플라스틱 병 30개, 캔 15개를 수거했습니다.",
-                45.0f,
-                4.0f,
-                "public/user_objects/2025-01-10/photo2.jpg"
+                "45kg"
         ));
 
-        // 3. 반려된 제출 (REJECTED)
+        // 3. 반려 (기타) - 옵션 선택(가두리 #1)
         Submission rejectedSubmission = createSubmission(
                 3L,
-                "제주도 성산일출봉",
-                ActivityType.OTHER,
-                SubmissionStatus.REJECTED,
-                "이영희",
-                "lee@example.com",
-                1,
+                "가두리 #1",
+                optionCage1,
+                ActivityType.OTHER, SubmissionStatus.REJECTED,
+                "이영희", "lee@example.com", 1,
                 "제주도 바다 정화 활동",
-                new BigDecimal("33.4584"),
-                new BigDecimal("126.9426"),
-                LocalDate.now().minusDays(7),
-                LocalTime.of(8, 0),
-                LocalTime.of(11, 0),
-                22.0f,
-                25.0f,
-                8.0f,
-                CurrentState.LOW,
-                Weather.CLOUDY,
+                new BigDecimal("33.4584"), new BigDecimal("126.9426"),
+                LocalDate.now().minusDays(7), LocalTime.of(8, 0),
+                22.0,
+                MarineCondition.NORMAL,
+                8.0,
+                MarineCondition.GOOD,
+                MarineCondition.GOOD,
+                MarineCondition.GOOD,
                 "이영희",
-                2,
-                ParticipantRole.RESEARCHER,
                 "해양 생물 관찰 및 정화 활동",
-                10.0f,
-                3.0f,
-                "public/user_objects/2025-01-08/photo3.jpg"
+                null
         );
         RejectReason rejectReason = RejectReason.builder()
                 .submission(rejectedSubmission)
@@ -5014,62 +6592,46 @@ public class SubmissionDataInitializer implements CommandLineRunner {
         rejectedSubmission.setRejectReason(rejectReason);
         submissions.add(rejectedSubmission);
 
-        // 4. 검수 대기 중인 제출 (PENDING) - 추가
+        // 4. 검수 대기 (이식) - 직접 입력
         submissions.add(createSubmission(
                 4L,
                 "강원도 속초 해변",
-                ActivityType.TRANSPLANT,
-                SubmissionStatus.PENDING,
-                "박민수",
-                "park@example.com",
-                4,
+                null,
+                ActivityType.TRANSPLANT, SubmissionStatus.SUBMITTED,
+                "박민수", "park@example.com", 4,
                 "속초 바다 정화 활동에 참여했습니다",
-                new BigDecimal("38.2070"),
-                new BigDecimal("128.5918"),
-                LocalDate.now().minusDays(1),
-                LocalTime.of(13, 0),
-                LocalTime.of(17, 0),
-                16.0f,
-                12.0f,
-                15.0f,
-                CurrentState.HIGH,
-                Weather.WINDY,
-                "박민수",
-                4,
-                ParticipantRole.LOCAL_MANAGER,
+                new BigDecimal("38.2070"), new BigDecimal("128.5918"),
+                LocalDate.now().minusDays(1), LocalTime.of(13, 0),
+                16.0,
+                MarineCondition.BAD,
+                15.0,
+                MarineCondition.BAD,    // 파도 높음
+                MarineCondition.BAD,    // 서지 있음
+                MarineCondition.BAD,    // 조류 강함
+                "박민수, 최지영",
                 "이식 80개 완료",
-                80.0f,
-                4.0f,
-                "public/user_objects/2025-01-16/photo4.jpg"
+                "80개"
         ));
 
-        // 5. 승인된 제출 (APPROVED) - 추가
+        // 5. 승인 (해양정화) - 옵션 선택(가두리 #2)
         submissions.add(createSubmission(
                 5L,
-                "전라남도 여수 해수욕장",
-                ActivityType.TRASH_COLLECTION,
-                SubmissionStatus.APPROVED,
-                "최지영",
-                "choi@example.com",
-                5,
+                "가두리 #2",
+                optionCage2,
+                ActivityType.TRASH_COLLECTION, SubmissionStatus.APPROVED,
+                "최지영", "choi@example.com", 5,
                 "여수 바다가 아름답습니다",
-                new BigDecimal("34.7604"),
-                new BigDecimal("127.6622"),
-                LocalDate.now().minusDays(10),
-                LocalTime.of(9, 30),
-                LocalTime.of(13, 30),
-                19.0f,
-                18.0f,
-                7.0f,
-                CurrentState.MEDIUM,
-                Weather.SUNNY,
-                "최지영",
-                6,
-                ParticipantRole.CITIZEN_DIVER,
+                new BigDecimal("34.7604"), new BigDecimal("127.6622"),
+                LocalDate.now().minusDays(10), LocalTime.of(9, 30),
+                19.0,
+                MarineCondition.GOOD,
+                7.0,
+                MarineCondition.NORMAL,
+                MarineCondition.NORMAL,
+                MarineCondition.NORMAL,
+                "최지영, 홍길동",
                 "쓰레기 100개 수거 완료",
-                100.0f,
-                4.0f,
-                "public/user_objects/2025-01-07/photo5.jpg"
+                "100kg"
         ));
 
         submissionRepository.saveAll(submissions);
@@ -5079,94 +6641,76 @@ public class SubmissionDataInitializer implements CommandLineRunner {
     private Submission createSubmission(
             Long id,
             String siteName,
+            SiteNameOption siteNameOption, // [추가] 옵션 엔티티
             ActivityType activityType,
             SubmissionStatus status,
             String authorName,
             String authorEmail,
             int attachmentCount,
-            String feedbackText,
+            String workDescription,
             BigDecimal latitude,
             BigDecimal longitude,
             LocalDate recordDate,
             LocalTime startTime,
-            LocalTime endTime,
-            Float waterTempC,
-            Float visibilityM,
-            Float depthM,
-            CurrentState currentState,
-            Weather weather,
-            String leaderName,
-            int participantCount,
-            ParticipantRole role,
+            Double waterTempC,
+            MarineCondition visibilityStatus,
+            Double depthM,
+            MarineCondition waveStatus,
+            MarineCondition surgeStatus,
+            MarineCondition currentStatus,
+            String participantNames,
             String activityDetails,
-            Float collectionAmount,
-            Float durationHours,
-            String fileUrl
+            String amountOrScale
     ) {
         LocalDateTime submittedAt = LocalDateTime.of(recordDate, startTime);
 
-        // BasicEnv 생성
+        // 1. BasicEnv 생성
         BasicEnv basicEnv = BasicEnv.builder()
                 .recordDate(recordDate)
-                .startTime(startTime)
-                .endTime(endTime)
+                .avgDepthM(depthM)
+                .maxDepthM(depthM + 2.0)
                 .waterTempC(waterTempC)
-                .visibilityM(visibilityM)
-                .depthM(depthM)
-                .currentState(currentState)
-                .weather(weather)
+                .visibilityStatus(visibilityStatus)
+                .waveStatus(waveStatus)
+                .surgeStatus(surgeStatus)
+                .currentStatus(currentStatus)
                 .build();
 
-        // Participants 생성
-        Participants participants = Participants.builder()
-                .leaderName(leaderName)
-                .participantCount(participantCount)
-                .role(role)
-                .build();
-
-        // Activity 생성
-        Activity activity = Activity.builder()
-                .type(activityType)
-                .details(activityDetails)
-                .collectionAmount(collectionAmount)
-                .durationHours(durationHours)
-                .build();
-
-        // Attachments 생성
-        List<Attachment> attachments = new ArrayList<>();
-        String baseUrl = fileUrl.substring(0, fileUrl.lastIndexOf("/") + 1);
-        for (int i = 1; i <= attachmentCount; i++) {
-            Attachment attachment = Attachment.builder()
-                    .fileName("photo" + i + ".jpg")
-                    .fileUrl(baseUrl + "photo" + i + ".jpg")
-                    .mimeType("image/jpeg")
-                    .fileSize(1024 * 500 * i) // 500KB * i
-                    .uploadedAt(submittedAt)
-                    .build();
-            attachments.add(attachment);
-        }
-
-        // Submission 생성
+        // 2. Submission 생성 (StructureType 제거, SiteNameOption 추가)
         Submission submission = Submission.builder()
-                .siteName(siteName)
+                .siteName(siteName)             // 스냅샷
+                .siteNameOption(siteNameOption) // 연관관계 (Nullable)
+                .recordDate(recordDate)
+                .divingRound(1)
                 .activityType(activityType)
-                .submittedAt(submittedAt)
                 .status(status)
                 .authorName(authorName)
                 .authorEmail(authorEmail)
                 .attachmentCount(attachmentCount)
-                .feedbackText(feedbackText)
-                .latitude(latitude)
-                .longitude(longitude)
+                .workDescription(workDescription)
+                .participantNames(participantNames)
+                .submittedAt(submittedAt)
                 .build();
 
-        // 관계 설정
+        // 3. 관계 설정 (Env)
         submission.setBasicEnv(basicEnv);
-        submission.setParticipants(participants);
-        submission.setActivity(activity);
-        attachments.forEach(submission::addAttachment);
 
-        // AuditLog 생성 (제출됨)
+        // 4. Activity Type별 상세 엔티티 생성 및 연결
+        createSpecificActivity(submission, activityType, activityDetails, amountOrScale);
+
+        // 5. Attachments 생성
+        for (int i = 1; i <= attachmentCount; i++) {
+            Attachment attachment = Attachment.builder()
+                    .fileName("photo" + i + ".jpg")
+                    .fileUrl(VALID_IMAGE_URL)
+                    .mimeType("image/jpeg")
+                    .fileSize(1024 * 500 * i)
+                    .uploadedAt(submittedAt)
+                    .build();
+            submission.addAttachment(attachment);
+        }
+
+        // 6. AuditLog 생성 (제출됨)
         AuditLog submitLog = AuditLog.builder()
                 .submission(submission)
                 .action(AuditAction.SUBMITTED)
@@ -5176,7 +6720,6 @@ public class SubmissionDataInitializer implements CommandLineRunner {
                 .build();
         submission.addAuditLog(submitLog);
 
-        // 승인/반려된 경우 AuditLog 추가
         if (status == SubmissionStatus.APPROVED) {
             AuditLog approveLog = AuditLog.builder()
                     .submission(submission)
@@ -5191,13 +6734,80 @@ public class SubmissionDataInitializer implements CommandLineRunner {
                     .submission(submission)
                     .action(AuditAction.REJECTED)
                     .performedBy("admin@oceancampus.kr")
-                    .comment("사진이 부족합니다. 최소 3장 이상의 사진을 첨부해주세요.")
+                    .comment("사진이 부족합니다.")
                     .createdAt(submittedAt.plusDays(1))
                     .build();
             submission.addAuditLog(rejectLog);
         }
 
         return submission;
+    }
+
+    private void createSpecificActivity(Submission submission, ActivityType type, String details, String amount) {
+        switch (type) {
+            case TRANSPLANT:
+                ActivityTransplant transplant = ActivityTransplant.builder()
+                        .submission(submission)
+                        .speciesType(TransplantSpeciesType.KAMTAE)
+                        .locationType(TransplantLocationType.REEF)
+                        .methodType(TransplantMethodType.ROPE_LINE)
+                        .scale(amount != null ? amount : "규모 미상")
+                        .healthStatus(HealthStatus.A)
+                        .build();
+                submission.setActivityTransplant(transplant);
+                break;
+
+            case TRASH_COLLECTION:
+            case MARINE_CLEANUP:
+                ActivityMarineCleanup cleanup = ActivityMarineCleanup.builder()
+                        .submission(submission)
+                        .wasteTypes(List.of(WasteType.PLASTIC, WasteType.NET))
+                        .method(CleanupMethodType.HAND)
+                        .collectionAmount(amount != null ? amount : "0kg")
+                        .uncollectedScale(UncollectedScale.SMALL)
+                        .build();
+                submission.setActivityMarineCleanup(cleanup);
+                break;
+
+            case GRAZER_REMOVAL:
+                ActivityGrazerRemoval grazer = ActivityGrazerRemoval.builder()
+                        .submission(submission)
+                        .targetSpecies(List.of(GrazerSpeciesType.URCHIN))
+                        .densityBeforeWork(DensityLevel.HIGH)
+                        .workScope(WorkScope.ZONE)
+                        .collectionAmount(amount != null ? amount : "0kg")
+                        .note(details)
+                        .build();
+                submission.setActivityGrazerRemoval(grazer);
+                break;
+
+            case MONITORING:
+                ActivityMonitoring monitoring = ActivityMonitoring.builder()
+                        .submission(submission)
+                        .terrain(TerrainType.ROCK)
+                        .barrenExtent(BarrenExtent.ONGOING)
+                        .grazerDistribution(DensityLevel.MID)
+                        .rockFeatures(List.of(RockFeature.SMOOTH))
+                        .suitability(Suitability.SUITABLE)
+                        .seaweedHealthStatus(SeaweedHealthStatus.GOOD)
+                        .build();
+                submission.setActivityMonitoring(monitoring);
+                break;
+
+            case SUBSTRATE_IMPROVEMENT:
+                ActivitySubstrateImprovement substrate = ActivitySubstrateImprovement.builder()
+                        .submission(submission)
+                        .targetType(SubstrateTargetType.ROCK)
+                        .workScope(amount != null ? amount : "범위 미상")
+                        .substrateState("양호")
+                        .build();
+                submission.setActivitySubstrateImprovement(substrate);
+                break;
+
+            case OTHER:
+            default:
+                break;
+        }
     }
 }
 
@@ -5248,14 +6858,17 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     @Query("""
         SELECT DISTINCT s FROM Submission s
         LEFT JOIN FETCH s.basicEnv
-        LEFT JOIN FETCH s.participants
-        LEFT JOIN FETCH s.activity
         LEFT JOIN FETCH s.attachments
         LEFT JOIN FETCH s.rejectReason
+        LEFT JOIN FETCH s.activityTransplant
+        LEFT JOIN FETCH s.activityGrazerRemoval
+        LEFT JOIN FETCH s.activitySubstrateImprovement
+        LEFT JOIN FETCH s.activityMonitoring
+        LEFT JOIN FETCH s.activityMarineCleanup
         WHERE s.submissionId = :id
         """)
     Optional<Submission> findByIdWithDetails(@Param("id") Long id);
-    
+
     @Query("""
         SELECT DISTINCT s FROM Submission s
         LEFT JOIN FETCH s.auditLogs
@@ -5266,8 +6879,6 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     @Query("""
     SELECT DISTINCT s FROM Submission s
     LEFT JOIN FETCH s.basicEnv
-    LEFT JOIN FETCH s.participants
-    LEFT JOIN FETCH s.activity
     WHERE (:keyword IS NULL OR :keyword = '' OR 
            s.siteName LIKE %:keyword% OR 
            s.authorName LIKE %:keyword%)
@@ -5285,12 +6896,16 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
             Pageable pageable
     );
 
+    // [수정] Export용 등 다건 상세 조회: 개별 Activity JOIN 추가
     @Query("""
         SELECT DISTINCT s FROM Submission s
         LEFT JOIN FETCH s.basicEnv
-        LEFT JOIN FETCH s.participants
-        LEFT JOIN FETCH s.activity
         LEFT JOIN FETCH s.attachments
+        LEFT JOIN FETCH s.activityTransplant
+        LEFT JOIN FETCH s.activityGrazerRemoval
+        LEFT JOIN FETCH s.activitySubstrateImprovement
+        LEFT JOIN FETCH s.activityMonitoring
+        LEFT JOIN FETCH s.activityMarineCleanup
         WHERE s.status = :status
           AND s.submissionId IN :ids
         """)
@@ -5302,9 +6917,12 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
     @Query("""
     SELECT DISTINCT s FROM Submission s
     LEFT JOIN FETCH s.basicEnv
-    LEFT JOIN FETCH s.participants
-    LEFT JOIN FETCH s.activity
     LEFT JOIN FETCH s.attachments
+    LEFT JOIN FETCH s.activityTransplant
+    LEFT JOIN FETCH s.activityGrazerRemoval
+    LEFT JOIN FETCH s.activitySubstrateImprovement
+    LEFT JOIN FETCH s.activityMonitoring
+    LEFT JOIN FETCH s.activityMarineCleanup
     WHERE s.status = :status
       AND s.submittedAt BETWEEN :start AND :end
     ORDER BY s.submittedAt DESC
@@ -5314,10 +6932,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );
-
-
 }
-
 
 
 ================================================================================
@@ -5326,30 +6941,31 @@ File Path: .\src\main\java\com\ocean\piuda\admin\submission\service\SubmissionCo
 
 package com.ocean.piuda.admin.submission.service;
 
+import com.ocean.piuda.admin.site.entity.SiteNameOption;
+import com.ocean.piuda.admin.site.repository.SiteNameOptionRepository;
 import com.ocean.piuda.admin.submission.dto.response.*;
+import com.ocean.piuda.admin.common.enums.ActivityType;
 import com.ocean.piuda.admin.common.enums.AuditAction;
 import com.ocean.piuda.admin.common.enums.SubmissionStatus;
 import com.ocean.piuda.admin.submission.dto.request.*;
 import com.ocean.piuda.admin.submission.dto.response.SubmissionDetailResponse;
-import com.ocean.piuda.admin.submission.entity.Activity;
-import com.ocean.piuda.admin.submission.entity.Attachment;
-import com.ocean.piuda.admin.submission.entity.AuditLog;
-import com.ocean.piuda.admin.submission.entity.BasicEnv;
-import com.ocean.piuda.admin.submission.entity.Participants;
-import com.ocean.piuda.admin.submission.entity.RejectReason;
-import com.ocean.piuda.admin.submission.entity.Submission;
-import com.ocean.piuda.admin.submission.entity.embeded.NaturalReproduction;
-import com.ocean.piuda.admin.submission.entity.embeded.Survival;
+import com.ocean.piuda.admin.submission.entity.*;
 import com.ocean.piuda.admin.submission.repository.AuditLogRepository;
 import com.ocean.piuda.admin.submission.repository.SubmissionRepository;
+import com.ocean.piuda.admin.submission.validator.ActivityValidator;
+import com.ocean.piuda.admin.submission.validator.SubmissionStatusValidator;
 import com.ocean.piuda.global.api.exception.BusinessException;
 import com.ocean.piuda.global.api.exception.ExceptionType;
+import com.ocean.piuda.security.jwt.service.TokenUserService;
+import com.ocean.piuda.user.entity.User;
+import com.ocean.piuda.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -5362,27 +6978,64 @@ public class SubmissionCommandService {
     private final SubmissionRepository submissionRepository;
     private final AuditLogRepository auditLogRepository;
     private final SubmissionQueryService submissionQueryService;
+    private final ActivityValidator activityValidator;
+    private final SubmissionStatusValidator statusValidator;
+    private final TokenUserService tokenUserService;
+    private final SiteNameOptionRepository siteNameOptionRepository;
 
     /**
-     * 제출 데이터 생성
+     * 바로 제출 (SUBMITTED 상태로 저장)
      */
-    public SubmissionDetailResponse createSubmission(CreateSubmissionRequest request) {
+    public SubmissionDetailResponse submitSubmission(CreateSubmissionRequest request) {
+        return createSubmissionInternal(request, SubmissionStatus.SUBMITTED, LocalDateTime.now());
+    }
+
+    /**
+     * 제출 데이터 생성 내부 메서드
+     */
+    private SubmissionDetailResponse createSubmissionInternal(
+            CreateSubmissionRequest request,
+            SubmissionStatus status,
+            LocalDateTime submittedAt
+    ) {
+        // 작업 유형별 검증
+        activityValidator.validate(request.getActivityType(), request);
+
         // 기본값 설정
-        LocalDateTime submittedAt = request.getSubmittedAt() != null
-                ? request.getSubmittedAt()
-                : LocalDateTime.now();
+        LocalDate recordDate = request.getRecordDate() != null 
+                ? request.getRecordDate() 
+                : LocalDate.now();
+
+        // 구조물 유형 처리 (null이면 OTHER로 기본값, 커스텀 텍스트도 설정)
+        // 1현장 명칭 결정 (Snapshot & FK 설정)
+        String finalSiteName;
+        SiteNameOption siteOption = null;
+
+        if (request.getSiteNameOptionId() != null) {
+            // Case A: 선택지(Option)를 선택한 경우 -> DB에서 조회해서 이름 가져옴 (신뢰성 확보)
+            siteOption = siteNameOptionRepository.findById(request.getSiteNameOptionId()).orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+            finalSiteName = siteOption.getName();
+        } else {
+            // Case B: 직접 입력한 경우 -> 텍스트 값 사용
+            if (request.getSiteName() == null || request.getSiteName().isBlank())  throw new BusinessException(ExceptionType.INVALID_INPUT_VALUE);
+            finalSiteName = request.getSiteName();
+        }
+
+        // 현재 유저 정보 저장
+        User currentUser = tokenUserService.getCurrentUser();
 
         // Submission 생성
         Submission submission = Submission.builder()
-                .siteName(request.getSiteName())
+                .siteName(finalSiteName) // 결정된 최종 이름 스냅샷 저장
+                .siteNameOption(siteOption) // 연관관계 설정 (nullable)                .recordDate(recordDate)
+                .divingRound(request.getDivingRound())
                 .activityType(request.getActivityType())
+                .status(status)
                 .submittedAt(submittedAt)
-                .status(SubmissionStatus.PENDING)
-                .authorName(request.getAuthorName())
-                .authorEmail(request.getAuthorEmail())
-                .feedbackText(request.getFeedbackText())
-                .latitude(request.getLatitude())
-                .longitude(request.getLongitude())
+                .user(currentUser)
+                .authorName(currentUser.getNickname())
+                .authorEmail(currentUser.getEmail())
+                .workDescription(request.getWorkDescription())
                 .attachmentCount(0)
                 .build();
 
@@ -5390,14 +7043,14 @@ public class SubmissionCommandService {
         if (request.getBasicEnv() != null) {
             CreateSubmissionRequest.BasicEnvDto envDto = request.getBasicEnv();
             BasicEnv basicEnv = BasicEnv.builder()
-                    .recordDate(envDto.getRecordDate())
-                    .startTime(envDto.getStartTime())
-                    .endTime(envDto.getEndTime())
+                    .recordDate(envDto.getRecordDate() != null ? envDto.getRecordDate() : recordDate)
+                    .avgDepthM(envDto.getAvgDepthM())
+                    .maxDepthM(envDto.getMaxDepthM())
                     .waterTempC(envDto.getWaterTempC())
-                    .visibilityM(envDto.getVisibilityM())
-                    .depthM(envDto.getDepthM())
-                    .currentState(envDto.getCurrentState())
-                    .weather(envDto.getWeather())
+                    .visibilityStatus(envDto.getVisibilityStatus())
+                    .waveStatus(envDto.getWaveStatus())
+                    .surgeStatus(envDto.getSurgeStatus())
+                    .currentStatus(envDto.getCurrentStatus())
                     .build();
             submission.setBasicEnv(basicEnv);
         }
@@ -5405,57 +7058,11 @@ public class SubmissionCommandService {
         // Participants 생성
         if (request.getParticipants() != null) {
             CreateSubmissionRequest.ParticipantsDto participantsDto = request.getParticipants();
-            Participants participants = Participants.builder()
-                    .leaderName(participantsDto.getLeaderName())
-                    .participantCount(participantsDto.getParticipantCount() != null
-                            ? participantsDto.getParticipantCount()
-                            : 1)
-                    .role(participantsDto.getRole() != null
-                            ? participantsDto.getRole()
-                            : com.ocean.piuda.admin.common.enums.ParticipantRole.CITIZEN_DIVER)
-                    .build();
-            submission.setParticipants(participants);
+            submission.updateParticipantNames(participantsDto.getParticipantNames());
         }
 
-        // Activity 생성 및 신규 필드 매핑
-        CreateSubmissionRequest.ActivityDto activityDto = request.getActivity();
-
-        // NaturalReproduction VO 빌드
-        NaturalReproduction naturalReproduction = null;
-        if (activityDto.getNaturalReproduction() != null) {
-            naturalReproduction = NaturalReproduction.builder()
-                    .radiusM(activityDto.getNaturalReproduction().getRadiusM() != null ? activityDto.getNaturalReproduction().getRadiusM() : 0f)
-                    .numerator(activityDto.getNaturalReproduction().getNumerator() != null ? activityDto.getNaturalReproduction().getNumerator() : 0f)
-                    .denominator(activityDto.getNaturalReproduction().getDenominator() != null ? activityDto.getNaturalReproduction().getDenominator() : 0f)
-                    .build();
-        }
-
-        // Survival VO 빌드
-        Survival survival = null;
-        if (activityDto.getSurvival() != null) {
-            survival = Survival.builder()
-                    .dieCount(activityDto.getSurvival().getDieCount() != null ? activityDto.getSurvival().getDieCount() : 0f)
-                    .totalCount(activityDto.getSurvival().getTotalCount() != null ? activityDto.getSurvival().getTotalCount() : 0f)
-                    .build();
-        }
-
-        Activity activity = Activity.builder()
-                .type(activityDto.getType())
-                .details(activityDto.getDetails())
-                .collectionAmount(activityDto.getCollectionAmount() != null
-                        ? activityDto.getCollectionAmount()
-                        : 0f)
-                .durationHours(activityDto.getDurationHours() != null
-                        ? activityDto.getDurationHours()
-                        : 0f)
-                // 추가된 필드 매핑
-                .healthGrade(activityDto.getHealthGrade())
-                .growthCm(activityDto.getGrowthCm() != null ? activityDto.getGrowthCm() : 0f)
-                .naturalReproduction(naturalReproduction)
-                .survival(survival)
-                .build();
-
-        submission.setActivity(activity);
+        // 작업 유형별 Activity 생성
+        createActivityByType(submission, request);
 
         // Attachments 생성
         if (request.getAttachments() != null && !request.getAttachments().isEmpty()) {
@@ -5465,7 +7072,7 @@ public class SubmissionCommandService {
                         .fileUrl(attachmentDto.getFileUrl())
                         .mimeType(attachmentDto.getMimeType())
                         .fileSize(attachmentDto.getFileSize())
-                        .uploadedAt(submittedAt)
+                        .uploadedAt(LocalDateTime.now())
                         .build();
                 submission.addAttachment(attachment);
             }
@@ -5474,11 +7081,135 @@ public class SubmissionCommandService {
         // 저장
         Submission saved = submissionRepository.save(submission);
 
-        // AuditLog 생성 (제출됨)
-        createAuditLog(saved, AuditAction.SUBMITTED, null);
+        // AuditLog 생성
+        if (status == SubmissionStatus.SUBMITTED) {
+            createAuditLog(saved, AuditAction.SUBMITTED, null);  // 제출 시에만 로그 생성
+        }
+        // 임시저장(DRAFT)은 AuditLog 생성하지 않음 (제출 시점에 생성)
 
         return SubmissionDetailResponse.from(saved);
     }
+
+    /**
+     * 작업 유형별 Activity 생성 (조건부 처리)
+     * 
+     * activityType에 따라 해당하는 Activity 엔티티만 생성됨:
+     * - TRANSPLANT → ActivityTransplant (이식 작업)
+     * - GRAZER_REMOVAL → ActivityGrazerRemoval (조식동물 작업)
+     * - SUBSTRATE_IMPROVEMENT → ActivitySubstrateImprovement (부착기질 개선)
+     * - MONITORING → ActivityMonitoring (모니터링)
+     * - MARINE_CLEANUP → ActivityMarineCleanup (해양정화)
+     * 
+     * 각 작업 유형에 맞는 DTO만 사용되며, 나머지는 무시됨
+     */
+    private void createActivityByType(Submission submission, CreateSubmissionRequest request) {
+        ActivityType activityType = request.getActivityType();
+
+        switch (activityType) {
+            case TRANSPLANT:
+                // 이식 작업: transplantActivity DTO 사용
+                if (request.getTransplantActivity() != null) {
+                    CreateSubmissionRequest.TransplantActivityDto dto = request.getTransplantActivity();
+                    ActivityTransplant activity = ActivityTransplant.builder()
+                            .submission(submission)
+                            .speciesType(dto.getSpeciesType())
+                            .locationType(dto.getLocationType())
+                            .methodType(dto.getMethodType())
+                            .scale(dto.getScale())
+                            .healthStatus(dto.getHealthStatus())
+                            .build();
+                    activity.updateSubmission(submission);
+                    submission.setActivityTransplant(activity);
+                }
+                break;
+
+            case GRAZER_REMOVAL:
+                // 조식동물 작업: grazerRemovalActivity DTO 사용
+                if (request.getGrazerRemovalActivity() != null) {
+                    CreateSubmissionRequest.GrazerRemovalActivityDto dto = request.getGrazerRemovalActivity();
+                    ActivityGrazerRemoval activity = ActivityGrazerRemoval.builder()
+                            .submission(submission)
+                            .targetSpecies(dto.getTargetSpecies())
+                            .densityBeforeWork(dto.getDensityBeforeWork())
+                            .workScope(dto.getWorkScope())
+                            .note(dto.getNote())
+                            .collectionAmount(dto.getCollectionAmount())
+                            .build();
+                    activity.updateSubmission(submission);
+                    submission.setActivityGrazerRemoval(activity);
+                }
+                break;
+
+            case SUBSTRATE_IMPROVEMENT:
+                // 부착기질 개선: substrateImprovementActivity DTO 사용
+                if (request.getSubstrateImprovementActivity() != null) {
+                    CreateSubmissionRequest.SubstrateImprovementActivityDto dto = request.getSubstrateImprovementActivity();
+                    ActivitySubstrateImprovement activity = ActivitySubstrateImprovement.builder()
+                            .submission(submission)
+                            .targetType(dto.getTargetType())
+                            .workScope(dto.getWorkScope())
+                            .substrateState(dto.getSubstrateState())
+                            .build();
+                    activity.updateSubmission(submission);
+                    submission.setActivitySubstrateImprovement(activity);
+                }
+                break;
+
+            case MONITORING:
+                // 모니터링: monitoringActivity DTO 사용
+                if (request.getMonitoringActivity() != null) {
+                    CreateSubmissionRequest.MonitoringActivityDto dto = request.getMonitoringActivity();
+                    ActivityMonitoring activity = ActivityMonitoring.builder()
+                            .submission(submission)
+                            // 적지조사
+                            .entryCoordinate(dto.getEntryCoordinate())
+                            .exitCoordinate(dto.getExitCoordinate())
+                            .direction(dto.getDirection())
+                            // 지형 구성
+                            .terrain(dto.getTerrain())
+                            // 갯녹음 정도
+                            .barrenExtent(dto.getBarrenExtent())
+                            // 조식동물 분포
+                            .grazerDistribution(dto.getGrazerDistribution())
+                            // 암반 특성 (복수)
+                            .rockFeatures(dto.getRockFeatures() != null ? dto.getRockFeatures() : new ArrayList<>())
+                            // 해조 이식 적합성
+                            .suitability(dto.getSuitability())
+                            // 해조류 상태
+                            .seaweedIdNumber(dto.getSeaweedIdNumber())
+                            .seaweedHealthStatus(dto.getSeaweedHealthStatus())
+                            // 정밀측정
+                            .leafLength(dto.getLeafLength())
+                            .maxLeafWidth(dto.getMaxLeafWidth())
+                            .build();
+                    activity.updateSubmission(submission);
+                    submission.setActivityMonitoring(activity);
+                }
+                break;
+
+            case MARINE_CLEANUP:
+                // 해양정화: marineCleanupActivity DTO 사용
+                if (request.getMarineCleanupActivity() != null) {
+                    CreateSubmissionRequest.MarineCleanupActivityDto dto = request.getMarineCleanupActivity();
+                    ActivityMarineCleanup activity = ActivityMarineCleanup.builder()
+                            .submission(submission)
+                            .wasteTypes(dto.getWasteTypes())
+                            .method(dto.getMethod())
+                            .collectionAmount(dto.getCollectionAmount())
+                            .uncollectedScale(dto.getUncollectedScale())
+                            .build();
+                    activity.updateSubmission(submission);
+                    submission.setActivityMarineCleanup(activity);
+                }
+                break;
+
+            default:
+                break;
+        }
+    }
+
+
+
 
     /**
      * 단건 승인
@@ -5486,14 +7217,14 @@ public class SubmissionCommandService {
     public SubmissionDetailResponse approveSubmission(Long submissionId) {
         Submission submission = submissionQueryService.getSubmissionById(submissionId);
 
-        if (submission.getStatus() == SubmissionStatus.APPROVED) {
-            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_APPROVED);
-        }
-        if (submission.getStatus() == SubmissionStatus.DELETED) {
-            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_DELETED);
+        if (!statusValidator.canApprove(submission.getStatus())) {
+            if (submission.getStatus() == SubmissionStatus.APPROVED) {
+                throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_APPROVED);
+            }
+            throw new BusinessException(ExceptionType.SUBMISSION_INVALID_STATUS);
         }
 
-        submission.updateStatus(SubmissionStatus.APPROVED);
+        submission.approve();
         createAuditLog(submission, AuditAction.APPROVED, null);
 
         return SubmissionDetailResponse.from(submission);
@@ -5505,18 +7236,18 @@ public class SubmissionCommandService {
     public SubmissionDetailResponse rejectSubmission(Long submissionId, SingleRejectRequest request) {
         Submission submission = submissionQueryService.getSubmissionById(submissionId);
 
-        if (submission.getStatus() == SubmissionStatus.REJECTED) {
-            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_REJECTED);
-        }
-        if (submission.getStatus() == SubmissionStatus.DELETED) {
-            throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_DELETED);
+        if (!statusValidator.canReject(submission.getStatus())) {
+            if (submission.getStatus() == SubmissionStatus.REJECTED) {
+                throw new BusinessException(ExceptionType.SUBMISSION_ALREADY_REJECTED);
+            }
+            throw new BusinessException(ExceptionType.SUBMISSION_INVALID_STATUS);
         }
 
         if (request.reason() == null || request.reason().message() == null || request.reason().message().isBlank()) {
             throw new BusinessException(ExceptionType.REJECT_REASON_REQUIRED);
         }
 
-        submission.updateStatus(SubmissionStatus.REJECTED);
+        submission.reject();
 
         RejectReason rejectReason = RejectReason.builder()
                 .submission(submission)
@@ -5740,6 +7471,8 @@ public class SubmissionQueryService {
         return SubmissionDetailResponse.from(submission);
     }
 
+
+
     /**
      * 검수 로그 조회
      */
@@ -5757,6 +7490,177 @@ public class SubmissionQueryService {
         return submissionRepository.findById(submissionId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.SUBMISSION_NOT_FOUND));
     }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\validator\ActivityValidator.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.validator;
+
+import com.ocean.piuda.admin.common.enums.ActivityType;
+import com.ocean.piuda.admin.submission.dto.request.CreateSubmissionRequest;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+/**
+ * 작업 유형별 Activity 검증
+ */
+@Component
+@RequiredArgsConstructor
+public class ActivityValidator {
+
+    private final Validator validator;
+
+    /**
+     * 작업 유형별 필수값 검증
+     */
+    public void validate(ActivityType activityType, CreateSubmissionRequest request) {
+        switch (activityType) {
+            case TRANSPLANT:
+                validateTransplant(request.getTransplantActivity());
+                break;
+            case GRAZER_REMOVAL:
+                validateGrazerRemoval(request.getGrazerRemovalActivity());
+                break;
+            case SUBSTRATE_IMPROVEMENT:
+                validateSubstrateImprovement(request.getSubstrateImprovementActivity());
+                break;
+            case MONITORING:
+                validateMonitoring(request.getMonitoringActivity());
+                break;
+            case MARINE_CLEANUP:
+                validateMarineCleanup(request.getMarineCleanupActivity());
+                break;
+            default:
+                // OTHER 등 기타 유형은 별도 DTO 검증 없음 (필요시 추가)
+                break;
+        }
+    }
+
+    private void validateTransplant(CreateSubmissionRequest.TransplantActivityDto dto) {
+        if (dto == null) throw new IllegalArgumentException("이식 작업 정보는 필수입니다");
+        validateAnnotations(dto, "이식 작업");
+    }
+
+    private void validateGrazerRemoval(CreateSubmissionRequest.GrazerRemovalActivityDto dto) {
+        if (dto == null) throw new IllegalArgumentException("조식동물 작업 정보는 필수입니다");
+        validateAnnotations(dto, "조식동물 작업");
+        if (dto.getTargetSpecies() == null || dto.getTargetSpecies().isEmpty()) {
+            throw new IllegalArgumentException("대상 생물은 최소 1개 이상 선택해야 합니다");
+        }
+    }
+
+    private void validateSubstrateImprovement(CreateSubmissionRequest.SubstrateImprovementActivityDto dto) {
+        if (dto == null) throw new IllegalArgumentException("부착기질 개선 작업 정보는 필수입니다");
+        validateAnnotations(dto, "부착기질 개선 작업");
+    }
+
+    private void validateMonitoring(CreateSubmissionRequest.MonitoringActivityDto dto) {
+        if (dto == null) throw new IllegalArgumentException("모니터링 작업 정보는 필수입니다");
+
+        validateAnnotations(dto, "모니터링 작업");
+
+        // 암반 특성 리스트 검증
+        if (dto.getRockFeatures() == null || dto.getRockFeatures().isEmpty()) {
+            throw new IllegalArgumentException("암반 특성은 최소 1개 이상 선택해야 합니다");
+        }
+
+    }
+
+    private void validateMarineCleanup(CreateSubmissionRequest.MarineCleanupActivityDto dto) {
+        if (dto == null) throw new IllegalArgumentException("해양정화 작업 정보는 필수입니다");
+
+        validateAnnotations(dto, "해양정화 작업");
+
+        if (dto.getWasteTypes() == null || dto.getWasteTypes().isEmpty()) {
+            throw new IllegalArgumentException("폐기물 유형은 최소 1개 이상 선택해야 합니다");
+        }
+    }
+
+    /**
+     * DTO 내부의 어노테이션(@NotNull 등)을 수동으로 트리거하여 검증
+     */
+    private <T> void validateAnnotations(T dto, String targetName) {
+        Set<ConstraintViolation<T>> violations = validator.validate(dto);
+        if (!violations.isEmpty()) {
+            // 첫 번째 에러 메시지만 반환
+            throw new IllegalArgumentException(
+                    targetName + " 정보 검증 실패: " + violations.iterator().next().getMessage()
+            );
+        }
+    }
+}
+
+
+================================================================================
+File Path: .\src\main\java\com\ocean\piuda\admin\submission\validator\SubmissionStatusValidator.java
+================================================================================
+
+package com.ocean.piuda.admin.submission.validator;
+
+import com.ocean.piuda.admin.common.enums.SubmissionStatus;
+import org.springframework.stereotype.Component;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Submission 상태 전이 검증
+ */
+@Component
+public class SubmissionStatusValidator {
+
+    private static final Map<SubmissionStatus, Set<SubmissionStatus>> ALLOWED_TRANSITIONS = Map.of(
+        SubmissionStatus.SUBMITTED, Set.of(SubmissionStatus.APPROVED, SubmissionStatus.REJECTED),
+        SubmissionStatus.APPROVED, Set.of(),  // 최종 상태
+        SubmissionStatus.REJECTED, Set.of()   // 최종 상태
+    );
+
+    /**
+     * 상태 전이 검증
+     * @param from 현재 상태
+     * @param to 전이할 상태
+     * @throws IllegalStateException 전이가 불가능한 경우
+     */
+    public void validateTransition(SubmissionStatus from, SubmissionStatus to) {
+        if (from == null || to == null) {
+            throw new IllegalArgumentException("상태는 null일 수 없습니다");
+        }
+
+        Set<SubmissionStatus> allowed = ALLOWED_TRANSITIONS.get(from);
+        if (allowed == null) {
+            throw new IllegalStateException("알 수 없는 상태: " + from);
+        }
+
+        if (!allowed.contains(to)) {
+            throw new IllegalStateException(
+                String.format("상태 전이 불가: %s → %s", from, to)
+            );
+        }
+    }
+
+
+    /**
+     * 승인 가능 여부 확인
+     */
+    public boolean canApprove(SubmissionStatus status) {
+        return status == SubmissionStatus.SUBMITTED;
+    }
+
+    /**
+     * 반려 가능 여부 확인
+     */
+    public boolean canReject(SubmissionStatus status) {
+        return status == SubmissionStatus.SUBMITTED;
+    }
+
+
 }
 
 
@@ -7964,6 +9868,33 @@ public class DashboardController {
         return ApiData.ok(new IdResponse(id));
     }
 
+
+    /**
+     * ProjectArea Representative Species
+     */
+    @PatchMapping("/areas/{id}/representative-species")
+    @Operation(summary = "작업 영역 대표종 설정", description = "성장 추이 차트에 표시될 대표 종을 설정합니다.")
+    public ApiData<IdResponse> setRepresentativeSpecies(
+            @PathVariable Long id,
+            @RequestBody @Valid SetRepresentativeSpeciesRequest req
+    ) {
+        dashboardCommandService.setRepresentativeSpecies(id, req);
+        return ApiData.ok(new IdResponse(id));
+    }
+
+    @GetMapping("/areas/{id}/species")
+    @Operation(summary = "영역 내 이식된 종 목록 조회", description = "대표종 설정 팝업 등에서 사용할 '이 영역에 존재하는 종' 목록을 반환합니다.")
+    public ApiData<List<AreaSpeciesResponse>> getAreaSpecies(@PathVariable Long id) {
+        return ApiData.ok(dashboardQueryService.getAreaSpeciesCandidates(id));
+    }
+
+    @GetMapping("/areas/{id}/representative-species")
+    @Operation(summary = "작업 영역 현재 대표종 조회", description = "현재 설정된 대표종 정보를 반환합니다. 설정되지 않은 경우 null을 반환합니다.")
+    public ApiData<AreaSpeciesResponse> getRepresentativeSpecies(@PathVariable Long id) {
+        return ApiData.ok(dashboardQueryService.getRepresentativeSpecies(id));
+    }
+
+
     /**
      * TransplantLog
      */
@@ -8314,7 +10245,6 @@ import java.time.LocalDate;
 
 public record CreateGrowthLogRequest(
         @NotNull Long speciesId,
-        @NotNull Boolean isRepresentative,
         @NotNull LocalDate recordDate,
         @NotNull Double attachmentRate,
         @NotNull Double survivalRate,
@@ -8443,6 +10373,20 @@ public class LogPageRequest extends PageRequest<LogSort> {
 
 
 ================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\SetRepresentativeSpeciesRequest.java
+================================================================================
+
+package com.ocean.piuda.dashboard.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SetRepresentativeSpeciesRequest(
+        @NotNull(message = "종 ID는 필수입니다.")
+        Long speciesId
+) {}
+
+
+================================================================================
 File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateGrowthLogRequest.java
 ================================================================================
 
@@ -8454,7 +10398,6 @@ import java.time.LocalDate;
 
 public record UpdateGrowthLogRequest(
         Long speciesId,
-        Boolean isRepresentative,
         LocalDate recordDate,
         Double attachmentRate,
         Double survivalRate,
@@ -8488,6 +10431,7 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateProjectAr
 
 package com.ocean.piuda.dashboard.dto.request;
 
+import com.ocean.piuda.bio.entity.Species;
 import com.ocean.piuda.dashboard.enums.AreaAttachmentStatus;
 import com.ocean.piuda.dashboard.enums.HabitatType;
 import com.ocean.piuda.dashboard.enums.ProjectLevel;
@@ -8508,7 +10452,8 @@ public record UpdateProjectAreaRequest(
         ProjectLevel level,
         AreaAttachmentStatus attachmentStatus,
         Double lat,
-        Double lon
+        Double lon,
+        Long representativeSpeciesId
 ) {}
 
 
@@ -8743,6 +10688,31 @@ public class AreaMarkerResponse {
 
 
 ================================================================================
+File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaSpeciesResponse.java
+================================================================================
+
+package com.ocean.piuda.dashboard.dto.response;
+
+import com.ocean.piuda.bio.entity.Species;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AreaSpeciesResponse {
+    private Long speciesId;
+    private String speciesName;
+
+    public static AreaSpeciesResponse from(Species species) {
+        return AreaSpeciesResponse.builder()
+                .speciesId(species.getId())
+                .speciesName(species.getName())
+                .build();
+    }
+}
+
+
+================================================================================
 File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaStatResponse.java
 ================================================================================
 
@@ -8785,7 +10755,6 @@ public class GrowthLogResponse {
     private Long speciesId;
     private String speciesName;
 
-    private Boolean isRepresentative;
     private Double attachmentRate;
     private Double survivalRate;
     private Double growthLength;
@@ -8800,7 +10769,6 @@ public class GrowthLogResponse {
                 .recordDate(g.getRecordDate())
                 .speciesId(s != null ? s.getId() : null)
                 .speciesName(s != null ? s.getName() : null)
-                .isRepresentative(g.getIsRepresentative())
                 .attachmentRate(g.getAttachmentRate())
                 .survivalRate(g.getSurvivalRate())
                 .growthLength(g.getGrowthLength())
@@ -9039,6 +11007,7 @@ public record TimeSeriesChartDto(
         List<Double> values,    // y축 수치
         String unit,            // 단위
         String targetSpecies,   // 대상 종
+        Long targetSpeciesId,     // 대상 종의 ID
         String period           // 기간
 ) { }
 
@@ -9118,7 +11087,6 @@ public class GrowthLog extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "species_id", nullable = false)
     private Species species;
-    private Boolean isRepresentative; // 구역의 대표 개체 여부
 
 
     @Column(nullable = false)
@@ -9137,7 +11105,6 @@ public class GrowthLog extends BaseEntity {
 
     public void update(
             Species species,
-            Boolean isRepresentative,
             LocalDate recordDate,
             Double attachmentRate,
             Double survivalRate,
@@ -9145,7 +11112,6 @@ public class GrowthLog extends BaseEntity {
             SpeciesAttachmentStatus status
     ) {
         if (species != null) this.species = species;
-        if (isRepresentative != null) this.isRepresentative = isRepresentative;
         if (recordDate != null) this.recordDate = recordDate;
         if (attachmentRate != null) this.attachmentRate = attachmentRate;
         if (survivalRate != null) this.survivalRate = survivalRate;
@@ -9215,6 +11181,7 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\ProjectArea.java
 
 package com.ocean.piuda.dashboard.entity;
 
+import com.ocean.piuda.bio.entity.Species;
 import com.ocean.piuda.dashboard.enums.AreaAttachmentStatus;
 import com.ocean.piuda.dashboard.enums.HabitatType;
 import com.ocean.piuda.dashboard.enums.ProjectLevel;
@@ -9273,6 +11240,10 @@ public class ProjectArea extends BaseEntity {
     @Column(nullable = false)
     private AreaAttachmentStatus attachmentStatus;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "representative_species_id")
+    private Species representativeSpecies;
+
 
     // --- 하위 연관 관계 ---
 
@@ -9320,12 +11291,6 @@ public class ProjectArea extends BaseEntity {
         return this.location != null ? this.location.getX() : null;
     }
 
-    // --- 연관관계 편의 메서드 ---
-    public void addTransplant(TransplantLog log) { this.transplants.add(log); log.setProjectArea(this); }
-    public void addGrowth(GrowthLog log) { this.growthLogs.add(log); log.setProjectArea(this); }
-    public void addWater(WaterLog log) { this.waterLogs.add(log); log.setProjectArea(this); }
-//    public void setBiodiversity(BiodiversitySummary bio) { this.biodiversity = bio; bio.setProjectArea(this); }
-    public void addMedia(MediaLog log) { this.mediaLogs.add(log); log.setProjectArea(this); }
     public void update(
             String name,
             RestorationRegion restorationRegion,
@@ -9337,7 +11302,8 @@ public class ProjectArea extends BaseEntity {
             ProjectLevel level,
             AreaAttachmentStatus attachmentStatus,
             Double lat,
-            Double lon
+            Double lon,
+            Species species
     ) {
         if (name != null) this.name = name;
         if (restorationRegion != null) this.restorationRegion = restorationRegion;
@@ -9350,12 +11316,23 @@ public class ProjectArea extends BaseEntity {
         if (attachmentStatus != null) this.attachmentStatus = attachmentStatus;
 
         // 좌표는 둘 다 들어온 경우에만 업데이트 (한쪽만 오면 기존 유지)
-        if (lat != null && lon != null) {
-            this.setLocation(lat, lon);
-        }
+        if (lat != null && lon != null) this.setLocation(lat, lon);
+        if(species!=null) this.representativeSpecies = species;
     }
 
 
+    public void setRepresentativeSpecies(Species species) {
+        this.representativeSpecies = species;
+    }
+
+
+
+    // --- 연관관계 편의 메서드 ---
+    public void addTransplant(TransplantLog log) { this.transplants.add(log); log.setProjectArea(this); }
+    public void addGrowth(GrowthLog log) { this.growthLogs.add(log); log.setProjectArea(this); }
+    public void addWater(WaterLog log) { this.waterLogs.add(log); log.setProjectArea(this); }
+    //    public void setBiodiversity(BiodiversitySummary bio) { this.biodiversity = bio; bio.setProjectArea(this); }
+    public void addMedia(MediaLog log) { this.mediaLogs.add(log); log.setProjectArea(this); }
 
 
 
@@ -9799,11 +11776,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
     }
 
     /**
-     * 포항 테스트 영역 1: 이식 + 성장(대표개체) + 환경 + 미디어 데이터 모두 포함
-     * - TransplantLog: recordDate, attachmentStatus 필수
-     * - GrowthLog: recordDate/attachmentRate/survivalRate/growthLength/status 필수
-     * - WaterLog: recordDate/temperature/dissolvedOxygen/nutrient + MarineStatus 4종 필수
-     * - MediaLog: recordDate/mediaUrl/category 필수
+     * 포항 테스트 영역 1
      */
     private void createPohangDemoArea1(Species gamtae, Species dasima, Species mojaban) {
         ProjectArea area = ProjectArea.builder()
@@ -9818,10 +11791,12 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .attachmentStatus(AreaAttachmentStatus.STABLE)
                 .build();
 
-        // setLocation(lat, lon) (내부에서 Point(lon, lat) 생성)
         area.setLocation(36.0762, 129.4432);
 
-        // -------- Transplant Logs (필수값: recordDate, attachmentStatus 포함) --------
+        // [설정] 포항 영역 대표종: 감태
+        area.setRepresentativeSpecies(gamtae);
+
+        // -------- Transplant Logs --------
         area.addTransplant(TransplantLog.builder()
                 .recordDate(LocalDate.of(2025, 3, 10))
                 .species(gamtae)
@@ -9849,7 +11824,6 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .attachmentStatus(SpeciesAttachmentStatus.GOOD)
                 .build());
 
-        // 같은 method의 최신 착생상태 쿼리 검증용으로 하나 더(날짜 최신)
         area.addTransplant(TransplantLog.builder()
                 .recordDate(LocalDate.of(2025, 6, 20))
                 .species(mojaban)
@@ -9859,10 +11833,10 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .attachmentStatus(SpeciesAttachmentStatus.NORMAL)
                 .build());
 
-        // -------- Growth Logs (대표개체, 필수값 모두 포함) --------
+        // -------- Growth Logs (대표종 차트 데이터 포함) --------
+        // 1. 대표종(감태) 데이터 - 차트에 표시됨
         area.addGrowth(GrowthLog.builder()
                 .species(gamtae)
-                .isRepresentative(true)
                 .recordDate(LocalDate.of(2025, 5, 15))
                 .attachmentRate(85.0)
                 .survivalRate(90.0)
@@ -9872,7 +11846,6 @@ public class DashboardDataInitializer implements CommandLineRunner {
 
         area.addGrowth(GrowthLog.builder()
                 .species(gamtae)
-                .isRepresentative(true)
                 .recordDate(LocalDate.of(2025, 6, 15))
                 .attachmentRate(88.0)
                 .survivalRate(89.0)
@@ -9880,10 +11853,9 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .status(SpeciesAttachmentStatus.GOOD)
                 .build());
 
-        // 대표개체가 아닌 로그도 1개 추가(대표 차트 필터링 확인용)
+        // 2. 비대표종(다시마) 데이터 - 차트에 표시 안 됨 (필터링 테스트용)
         area.addGrowth(GrowthLog.builder()
                 .species(dasima)
-                .isRepresentative(false)
                 .recordDate(LocalDate.of(2025, 6, 15))
                 .attachmentRate(70.0)
                 .survivalRate(75.0)
@@ -9891,7 +11863,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .status(SpeciesAttachmentStatus.NORMAL)
                 .build());
 
-        // -------- Water Logs (필수값: recordDate, temperature, DO, nutrient + 상태값 4종) --------
+        // -------- Water Logs --------
         area.addWater(WaterLog.builder()
                 .recordDate(LocalDate.of(2025, 6, 1))
                 .temperature(18.2)
@@ -9914,7 +11886,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .wave(MarineStatus.NORMAL)
                 .build());
 
-        // -------- Media Logs (필수값: recordDate, mediaUrl, category) --------
+        // -------- Media Logs --------
         area.addMedia(MediaLog.builder()
                 .category(MediaCategory.BEFORE)
                 .mediaUrl(VALID_IMAGE_URL)
@@ -9940,7 +11912,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
     }
 
     /**
-     * 울진 테스트 영역 1: 마커/통계/nearest/bbox 테스트용으로 최소 구성 + 필수로그 몇 개
+     * 울진 테스트 영역 1
      */
     private void createUljinDemoArea1(Species gamtae, Species dasima) {
         ProjectArea area = ProjectArea.builder()
@@ -9956,6 +11928,9 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .build();
 
         area.setLocation(36.9950, 129.4020);
+
+        // [설정] 울진 영역 대표종: 감태
+        area.setRepresentativeSpecies(gamtae);
 
         area.addTransplant(TransplantLog.builder()
                 .recordDate(LocalDate.of(2025, 8, 5))
@@ -9973,6 +11948,25 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .count(15)
                 .areaSize(90.0)
                 .attachmentStatus(SpeciesAttachmentStatus.POOR)
+                .build());
+
+        // [추가] 대표종(감태) 성장 로그 데이터 추가 (차트 표시용)
+        area.addGrowth(GrowthLog.builder()
+                .species(gamtae)
+                .recordDate(LocalDate.of(2025, 8, 20))
+                .attachmentRate(75.0)
+                .survivalRate(85.0)
+                .growthLength(5.5)
+                .status(SpeciesAttachmentStatus.NORMAL)
+                .build());
+
+        area.addGrowth(GrowthLog.builder()
+                .species(gamtae)
+                .recordDate(LocalDate.of(2025, 9, 20))
+                .attachmentRate(78.0)
+                .survivalRate(82.0)
+                .growthLength(8.2)
+                .status(SpeciesAttachmentStatus.GOOD)
                 .build());
 
         area.addWater(WaterLog.builder()
@@ -10167,11 +12161,10 @@ public interface GrowthLogRepository extends JpaRepository<GrowthLog, Long> {
 
 
     /**
-     * 특정 작업 영역(ProjectArea)의 대표 개체 성장 로그만 조회
-     * - isRepresentative: true 인 데이터만 필터링
+     * 특정 작업 영역(ProjectArea)의 "특정 종" 성장 로그 조회 (대표종 차트용)
      * - recordDate: 시간순(오름차순) 정렬
      */
-    List<GrowthLog> findAllByProjectAreaIdAndIsRepresentativeTrueOrderByRecordDateAsc(Long projectAreaId);
+    List<GrowthLog> findAllByProjectAreaIdAndSpeciesIdOrderByRecordDateAsc(Long projectAreaId, Long speciesId);
 
     @EntityGraph(attributePaths = {"species"})
     Page<GrowthLog> findAllByProjectAreaIdAndRecordDateBetween(
@@ -10566,6 +12559,7 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\TransplantLogRep
 
 package com.ocean.piuda.dashboard.repository;
 
+import com.ocean.piuda.bio.entity.Species;
 import com.ocean.piuda.dashboard.entity.TransplantLog;
 import com.ocean.piuda.dashboard.entity.WaterLog;
 import com.ocean.piuda.dashboard.repository.projection.*;
@@ -10648,6 +12642,13 @@ public interface TransplantLogRepository extends JpaRepository<TransplantLog, Lo
     Page<TransplantLog> findAllByProjectAreaIdAndRecordDateBetween(
             Long projectAreaId, LocalDate from, LocalDate to, Pageable pageable
     );
+
+    /**
+     * 특정 영역에 이식된 적이 있는 모든 종(Species) 목록 조회 (중복 제거)
+     * - 드롭다운 후보군 제공용
+     */
+    @Query("SELECT DISTINCT t.species FROM TransplantLog t WHERE t.projectArea.id = :areaId")
+    List<Species> findDistinctSpeciesByAreaId(@Param("areaId") Long areaId);
 
 }
 
@@ -10880,13 +12881,20 @@ public class DashboardAggregateBuilder {
                 })
                 .toList();
 
+        String targetSpeciesName = "미지정";
+        Long targetSpeciesId = null;
+        if (area.getRepresentativeSpecies() != null) {
+            targetSpeciesName = area.getRepresentativeSpecies().getName();
+            targetSpeciesId = area.getRepresentativeSpecies().getId();
+        }
         return AreaDetailResponse.EcologyTab.builder()
                 .attachmentStatuses(attachmentStatuses)
                 .survivalStatus(area.getAttachmentStatus() != null ? area.getAttachmentStatus().getName() : "안정")
                 .representativeGrowthChart(TimeSeriesChartDto.builder()
                         .labels(repLogs.stream().map(GrowthLog::getRecordDate).toList())
                         .values(repLogs.stream().map(GrowthLog::getGrowthLength).toList())
-                        .targetSpecies(repLogs.isEmpty() ? "미지정" : repLogs.get(0).getSpecies().getName())
+                        .targetSpecies(targetSpeciesName)
+                        .targetSpeciesId(targetSpeciesId)
                         .unit("mm/월")
                         .build())
                 .build();
@@ -10995,6 +13003,10 @@ public class DashboardCommandService {
         ProjectArea area = projectAreaRepository.findById(areaId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
 
+
+        Species representativeSpecies = (req.representativeSpeciesId() != null ) ? speciesRepository.findById(req.representativeSpeciesId())
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND)) : null;
+
         area.update(
                 req.name(),
                 req.restorationRegion(),
@@ -11006,7 +13018,8 @@ public class DashboardCommandService {
                 req.level(),
                 req.attachmentStatus(),
                 req.lat(),
-                req.lon()
+                req.lon(),
+                representativeSpecies
         );
     }
 
@@ -11067,6 +13080,20 @@ public class DashboardCommandService {
         transplantLogRepository.delete(log);
     }
 
+
+    // -------------------------
+    // ProjectArea - Representative Species
+    // -------------------------
+    public void setRepresentativeSpecies(Long areaId, SetRepresentativeSpeciesRequest req) {
+        ProjectArea area = projectAreaRepository.findById(areaId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        Species species = speciesRepository.findById(req.speciesId())
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        area.setRepresentativeSpecies(species);
+    }
+
     // -------------------------
     // GrowthLog
     // -------------------------
@@ -11080,7 +13107,6 @@ public class DashboardCommandService {
 
         GrowthLog log = GrowthLog.builder()
                 .species(species)
-                .isRepresentative(req.isRepresentative())
                 .recordDate(req.recordDate())
                 .attachmentRate(req.attachmentRate())
                 .survivalRate(req.survivalRate())
@@ -11105,7 +13131,6 @@ public class DashboardCommandService {
 
         log.update(
                 species,
-                req.isRepresentative(),
                 req.recordDate(),
                 req.attachmentRate(),
                 req.survivalRate(),
@@ -11456,8 +13481,12 @@ public class DashboardQueryService {
         List<WorkHistoryPointProjection> history = transplantLogRepository.findWorkHistory(id);
 
         // 4. 생태 데이터 (조건부 필터링 조회)
-        // - 대표 개체로 지정된 로그의 전체 이력만 조회
-        List<GrowthLog> repGrowthLogs = growthLogRepository.findAllByProjectAreaIdAndIsRepresentativeTrueOrderByRecordDateAsc(id);
+        // - 대표 개체로 지정된 종의 로그만 시간순 조회
+        // - 대표종이 설정되어 있지 않으면 빈 리스트 (빈 차트용)
+        List<GrowthLog> repGrowthLogs = (area.getRepresentativeSpecies() != null)
+                ? growthLogRepository.findAllByProjectAreaIdAndSpeciesIdOrderByRecordDateAsc(id, area.getRepresentativeSpecies().getId())
+                : List.of();
+
         List<TransplantItemProjection> speciesItems = transplantLogRepository.findTransplantItems(id);
         List<MethodAttachmentStatusProjection> methodStatuses = transplantLogRepository.findLatestAttachmentStatusPerMethod(id);
 
@@ -11575,6 +13604,30 @@ public class DashboardQueryService {
                 .build();
     }
 
+    /**
+     * 영역 내 후보 종 목록 조회
+     */
+    public List<AreaSpeciesResponse> getAreaSpeciesCandidates(Long areaId) {
+        // 영역의 존재 여부
+        if (!projectAreaRepository.existsById(areaId)) throw new BusinessException(ExceptionType.RESOURCE_NOT_FOUND);
+
+        // 이식 로그 테이블에서 해당 영역에 사용된 종들을 중복없이 가져옴
+        return transplantLogRepository.findDistinctSpeciesByAreaId(areaId)
+                .stream()
+                .map(AreaSpeciesResponse::from)
+                .toList();
+    }
+
+    /**
+     * 영역의 현재 대표 종 조회
+     */
+    public AreaSpeciesResponse getRepresentativeSpecies(Long areaId) {
+        ProjectArea area = projectAreaRepository.findById(areaId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        if (area.getRepresentativeSpecies() == null)  return null;
+        return AreaSpeciesResponse.from(area.getRepresentativeSpecies());
+    }
 
 }
 
@@ -15337,7 +17390,7 @@ public enum ExceptionType {
     NOT_VALID_REQUEST_FIELDS_ERROR(BAD_REQUEST , "C006","요청 필드 검증에 실패했습니다."),
     MEDIA_TYPE_MISMATCHED(BAD_REQUEST, "C007","잘못된 콘텐츠 타입 사용"),
     RESOURCE_NOT_FOUND(NOT_FOUND,"C008","해당 자원을 찾을 수 없습니다."),
-
+    INVALID_INPUT_VALUE(NOT_FOUND, "C009","입력값이 잘못되었습니다."),
     // auth
     INVALID_REFRESH_TOKEN(NOT_ACCEPTABLE , "A001","유효하지 않은 리프레시 토큰"),
     REFRESH_TOKEN_EXPIRED(UNAUTHORIZED,"A002","리프레시 토큰 만료"),
@@ -15364,6 +17417,8 @@ public enum ExceptionType {
     SUBMISSION_ALREADY_APPROVED(CONFLICT, "AD002", "이미 승인된 제출입니다."),
     SUBMISSION_ALREADY_REJECTED(CONFLICT, "AD003", "이미 반려된 제출입니다."),
     SUBMISSION_ALREADY_DELETED(CONFLICT, "AD004", "이미 삭제된 제출입니다."),
+    SUBMISSION_ALREADY_SUBMITTED(CONFLICT, "AD010", "이미 제출된 기록입니다."),
+    SUBMISSION_INVALID_STATUS(BAD_REQUEST, "AD011", "잘못된 상태입니다."),
     REJECT_REASON_REQUIRED(UNPROCESSABLE_ENTITY, "AD005", "반려 사유를 입력해주세요."),
     EXPORT_NOT_FOUND(NOT_FOUND, "AD006", "내보내기 작업을 찾을 수 없습니다."),
     EXPORT_NOT_READY(UNPROCESSABLE_ENTITY, "AD007", "내보내기 파일이 아직 준비되지 않았습니다."),
@@ -18951,6 +21006,23 @@ public class UserQueryService {
         return q.replaceAll("[+\\-><()~\"@]+", " ").trim();
     }
 }
+
+
+================================================================================
+File Path: .\src\main\resources\data.sql
+================================================================================
+
+-- PostGIS 확장 활성화 (geometry 타입 사용을 위해 필요)
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+
+================================================================================
+File Path: .\src\main\resources\schema.sql
+================================================================================
+
+-- PostGIS 확장 활성화 (geometry 타입 사용을 위해 필요)
+-- Hibernate가 스키마를 생성하기 전에 실행되어야 함
+CREATE EXTENSION IF NOT EXISTS postgis;
 
 
 ================================================================================

--- a/src/main/java/com/ocean/piuda/admin/project_context.txt
+++ b/src/main/java/com/ocean/piuda/admin/project_context.txt
@@ -2198,6 +2198,7 @@ File Path: .\site\controller\SiteNameOptionController.java
 package com.ocean.piuda.admin.site.controller;
 
 import com.ocean.piuda.admin.site.dto.request.CreateSiteOptionRequest;
+import com.ocean.piuda.admin.site.dto.request.UpdateSiteOptionRequest;
 import com.ocean.piuda.admin.site.dto.response.SiteNameOptionResponse;
 import com.ocean.piuda.admin.site.service.SiteNameOptionService;
 import com.ocean.piuda.global.api.dto.ApiData;
@@ -2210,33 +2211,40 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @RestController
-@RequestMapping("/api/sites/options")
+@RequestMapping("/api/admin/site")
 @RequiredArgsConstructor
 @Tag(name = "Site Name Options", description = "현장 명칭 선택지 관리 API")
 public class SiteNameOptionController {
 
     private final SiteNameOptionService service;
 
-    @GetMapping("/api/sites/options")
+    @GetMapping
     @Operation(summary = "현장 명칭 목록 조회 (Active)", description = "작성 화면 드롭다운에 표시할 활성화된 현장 명칭 목록을 조회합니다.")
     public ApiData<List<SiteNameOptionResponse>> getOptions() {
         return ApiData.ok(service.getActiveOptions());
     }
 
-    @PostMapping("/api/admin/sites/options")
-    @Operation(summary = "현장 명칭 추가 (Admin)", description = "새로운 현장 명칭 선택지를 추가합니다.")
+    @PostMapping
+    @Operation(summary = "현장 명칭 추가", description = "새로운 현장 명칭 선택지를 추가합니다.")
     public ApiData<SiteNameOptionResponse> createOption(@RequestBody @Valid CreateSiteOptionRequest request) {
         return ApiData.ok(service.createOption(request));
     }
 
-    @DeleteMapping("/api/admin/sites/options/{optionId}")
-    @Operation(summary = "현장 명칭 비활성화 (Admin)", description = "해당 ID의 현장 명칭을 목록에서 숨김 처리합니다. (기존 기록은 유지됨)")
+    @DeleteMapping("/{optionId}")
+    @Operation(summary = "현장 명칭 비활성화", description = "해당 ID의 현장 명칭을 목록에서 숨김 처리합니다. (기존 기록은 유지됨)")
     public ApiData<Void> deleteOption(@PathVariable Long optionId) {
         service.deactivateOption(optionId);
         return ApiData.ok(null);
     }
-    // TODO:  patch API 추가
-}
+
+    @PatchMapping("/{optionId}")
+    @Operation(summary = "현장 명칭 수정", description = "현장 명칭을 변경하거나 활성/비활성 상태를 변경합니다. (변경할 필드만 보내면 됩니다)")
+    public ApiData<SiteNameOptionResponse> updateOption(
+            @PathVariable Long optionId,
+            @RequestBody @Valid UpdateSiteOptionRequest request
+    ) {
+        return ApiData.ok(service.updateOption(optionId, request));
+    }}
 
 
 ================================================================================
@@ -2250,6 +2258,22 @@ import jakarta.validation.constraints.NotBlank;
 public record CreateSiteOptionRequest(
         @NotBlank(message = "현장 명칭은 필수입니다.")
         String name
+) {}
+
+
+================================================================================
+File Path: .\site\dto\request\UpdateSiteOptionRequest.java
+================================================================================
+
+package com.ocean.piuda.admin.site.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record UpdateSiteOptionRequest(
+        @Size(min = 1, message = "현장 명칭은 최소 1글자 이상이어야 합니다.")
+        String name,
+
+        Boolean isActive
 ) {}
 
 
@@ -2344,6 +2368,7 @@ package com.ocean.piuda.admin.site.service;
 
 
 import com.ocean.piuda.admin.site.dto.request.CreateSiteOptionRequest;
+import com.ocean.piuda.admin.site.dto.request.UpdateSiteOptionRequest;
 import com.ocean.piuda.admin.site.dto.response.SiteNameOptionResponse;
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
 import com.ocean.piuda.admin.site.repository.SiteNameOptionRepository;
@@ -2364,7 +2389,7 @@ public class SiteNameOptionService {
     private final SiteNameOptionRepository siteNameOptionRepository;
 
     /**
-     * 활성화된 현장 명칭 목록 조회
+     * [user] 활성화된 현장 명칭 목록 조회
      */
     public List<SiteNameOptionResponse> getActiveOptions() {
         return siteNameOptionRepository.findAllByIsActiveTrueOrderByCreatedAtDesc().stream()
@@ -2373,7 +2398,7 @@ public class SiteNameOptionService {
     }
 
     /**
-     * 현장 명칭 추가
+     * [Admin] 현장 명칭 추가
      */
     @Transactional
     public SiteNameOptionResponse createOption(CreateSiteOptionRequest request) {
@@ -2398,6 +2423,27 @@ public class SiteNameOptionService {
                 .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
 
         option.deactivate();
+    }
+
+
+    /**
+     * [Admin] 현장 명칭 수정 (이름 변경 또는 활성 상태 변경)
+     */
+    @Transactional
+    public SiteNameOptionResponse updateOption(Long optionId, UpdateSiteOptionRequest request) {
+        SiteNameOption option = siteNameOptionRepository.findById(optionId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        // 이름 변경 요청이 있고, 기존 이름과 다를 경우 중복 체크 수행
+        if (request.name() != null && !request.name().equals(option.getName())) {
+            if (siteNameOptionRepository.existsByName(request.name())) {
+                throw new BusinessException(ExceptionType.DUPLICATE_VALUE_ERROR);
+            }
+        }
+
+        option.update(request.name(), request.isActive());
+
+        return SiteNameOptionResponse.from(option);
     }
 }
 
@@ -3251,6 +3297,7 @@ import java.util.stream.Collectors;
 public record SubmissionDetailResponse(
         Long submissionId,
         String siteName,
+        Long siteNameOptionId,
         ActivityType activityType,
         LocalDateTime submittedAt,
         SubmissionStatus status,
@@ -3298,6 +3345,7 @@ public record SubmissionDetailResponse(
         return new SubmissionDetailResponse(
                 submission.getSubmissionId(),
                 submission.getSiteName(),
+                submission.getSiteNameOption() != null ? submission.getSiteNameOption().getId() : null,
                 submission.getActivityType(),
                 submission.getSubmittedAt(),
                 submission.getStatus(),

--- a/src/main/java/com/ocean/piuda/admin/submission/controller/SubmissionController.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/controller/SubmissionController.java
@@ -41,7 +41,7 @@ public class SubmissionController {
     /**
      * 기록 바로 제출 (SUBMITTED)
      */
-    @PostMapping("/submit")
+    @PostMapping
     @Operation(
             summary = "기록 제출 (신규 등록)",
             description = "새로운 활동 기록을 제출합니다. 상태는 '제출됨(SUBMITTED)'으로 저장되며, 관리자 승인 대기 상태가 됩니다."
@@ -166,7 +166,7 @@ public class SubmissionController {
     /**
      * 단건 삭제
      */
-    @DeleteMapping("/{submissionId}")
+    @DeleteMapping("/{submissionId:[0-9]+}")
     @Operation(summary = "단건 삭제", description = "특정 제출 데이터를 영구 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "삭제 성공 (No Content)"),

--- a/src/main/java/com/ocean/piuda/admin/submission/dto/request/CreateSubmissionRequest.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/dto/request/CreateSubmissionRequest.java
@@ -42,9 +42,6 @@ public class CreateSubmissionRequest {
 
     private String workDescription;  // 작업 내용
 
-    private BigDecimal latitude;
-    private BigDecimal longitude;
-
     @Valid
     @NotNull(message = "기본 환경 정보는 필수입니다")
     private BasicEnvDto basicEnv;

--- a/src/main/java/com/ocean/piuda/admin/submission/dto/request/CreateSubmissionRequest.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/dto/request/CreateSubmissionRequest.java
@@ -35,11 +35,6 @@ public class CreateSubmissionRequest {
     @NotNull(message = "작업 유형은 필수입니다")
     private ActivityType activityType;
 
-    @NotBlank(message = "작성자명은 필수입니다")
-    private String authorName;
-
-    private String authorEmail;
-
     private String workDescription;  // 작업 내용
 
     @Valid

--- a/src/main/java/com/ocean/piuda/admin/submission/dto/response/SubmissionDetailResponse.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/dto/response/SubmissionDetailResponse.java
@@ -19,8 +19,6 @@ public record SubmissionDetailResponse(
         String authorEmail,
         Integer attachmentCount,
         String feedbackText,  // API 하위 호환성을 위해 필드명 유지 (내부적으로는 workDescription 사용)
-        BigDecimal latitude,
-        BigDecimal longitude,
         BasicEnvResponse basicEnv,
         ParticipantsResponse participants,
 
@@ -67,8 +65,6 @@ public record SubmissionDetailResponse(
                 submission.getAuthorEmail(),
                 submission.getAttachmentCount(),
                 submission.getWorkDescription(),
-                submission.getLatitude(),
-                submission.getLongitude(),
                 BasicEnvResponse.from(submission.getBasicEnv()),
                 new ParticipantsResponse(submission.getParticipantNames()),
 

--- a/src/main/java/com/ocean/piuda/admin/submission/entity/Submission.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/entity/Submission.java
@@ -93,12 +93,6 @@ public class Submission extends BaseEntity {
     @Column(name = "admin_memo", columnDefinition = "TEXT")
     private String adminMemo;  // 관리자 검수 메모
 
-    @Column(precision = 9, scale = 6)
-    private BigDecimal latitude;
-
-    @Column(precision = 9, scale = 6)
-    private BigDecimal longitude;
-
     @Column(name = "participant_names", columnDefinition = "TEXT")
     private String participantNames;
 

--- a/src/main/java/com/ocean/piuda/admin/submission/initializer/SubmissionDataInitializer.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/initializer/SubmissionDataInitializer.java
@@ -218,8 +218,6 @@ public class SubmissionDataInitializer implements CommandLineRunner {
                 .authorEmail(authorEmail)
                 .attachmentCount(attachmentCount)
                 .workDescription(workDescription)
-                .latitude(latitude)
-                .longitude(longitude)
                 .participantNames(participantNames)
                 .submittedAt(submittedAt)
                 .build();

--- a/src/main/java/com/ocean/piuda/admin/submission/service/SubmissionCommandService.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/service/SubmissionCommandService.java
@@ -95,8 +95,6 @@ public class SubmissionCommandService {
                 .authorName(request.getAuthorName())
                 .authorEmail(request.getAuthorEmail())
                 .workDescription(request.getWorkDescription())
-                .latitude(request.getLatitude())
-                .longitude(request.getLongitude())
                 .attachmentCount(0)
                 .build();
 

--- a/src/main/java/com/ocean/piuda/admin/submission/service/SubmissionCommandService.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/service/SubmissionCommandService.java
@@ -92,8 +92,8 @@ public class SubmissionCommandService {
                 .status(status)
                 .submittedAt(submittedAt)
                 .user(currentUser)
-                .authorName(request.getAuthorName())
-                .authorEmail(request.getAuthorEmail())
+                .authorName(currentUser.getNickname())
+                .authorEmail(currentUser.getEmail())
                 .workDescription(request.getWorkDescription())
                 .attachmentCount(0)
                 .build();

--- a/src/main/java/com/ocean/piuda/dashboard/project_context.txt
+++ b/src/main/java/com/ocean/piuda/dashboard/project_context.txt
@@ -87,6 +87,12 @@ public class DashboardController {
         return ApiData.ok(dashboardQueryService.getAreaSpeciesCandidates(id));
     }
 
+    @GetMapping("/areas/{id}/representative-species")
+    @Operation(summary = "작업 영역 현재 대표종 조회", description = "현재 설정된 대표종 정보를 반환합니다. 설정되지 않은 경우 null을 반환합니다.")
+    public ApiData<AreaSpeciesResponse> getRepresentativeSpecies(@PathVariable Long id) {
+        return ApiData.ok(dashboardQueryService.getRepresentativeSpecies(id));
+    }
+
 
     /**
      * TransplantLog
@@ -1200,6 +1206,7 @@ public record TimeSeriesChartDto(
         List<Double> values,    // y축 수치
         String unit,            // 단위
         String targetSpecies,   // 대상 종
+        Long targetSpeciesId,     // 대상 종의 ID
         String period           // 기간
 ) { }
 
@@ -1968,11 +1975,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
     }
 
     /**
-     * 포항 테스트 영역 1: 이식 + 성장(대표개체) + 환경 + 미디어 데이터 모두 포함
-     * - TransplantLog: recordDate, attachmentStatus 필수
-     * - GrowthLog: recordDate/attachmentRate/survivalRate/growthLength/status 필수
-     * - WaterLog: recordDate/temperature/dissolvedOxygen/nutrient + MarineStatus 4종 필수
-     * - MediaLog: recordDate/mediaUrl/category 필수
+     * 포항 테스트 영역 1
      */
     private void createPohangDemoArea1(Species gamtae, Species dasima, Species mojaban) {
         ProjectArea area = ProjectArea.builder()
@@ -1987,10 +1990,12 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .attachmentStatus(AreaAttachmentStatus.STABLE)
                 .build();
 
-        // setLocation(lat, lon) (내부에서 Point(lon, lat) 생성)
         area.setLocation(36.0762, 129.4432);
 
-        // -------- Transplant Logs (필수값: recordDate, attachmentStatus 포함) --------
+        // [설정] 포항 영역 대표종: 감태
+        area.setRepresentativeSpecies(gamtae);
+
+        // -------- Transplant Logs --------
         area.addTransplant(TransplantLog.builder()
                 .recordDate(LocalDate.of(2025, 3, 10))
                 .species(gamtae)
@@ -2018,7 +2023,6 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .attachmentStatus(SpeciesAttachmentStatus.GOOD)
                 .build());
 
-        // 같은 method의 최신 착생상태 쿼리 검증용으로 하나 더(날짜 최신)
         area.addTransplant(TransplantLog.builder()
                 .recordDate(LocalDate.of(2025, 6, 20))
                 .species(mojaban)
@@ -2028,7 +2032,8 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .attachmentStatus(SpeciesAttachmentStatus.NORMAL)
                 .build());
 
-        // -------- Growth Logs (대표개체, 필수값 모두 포함) --------
+        // -------- Growth Logs (대표종 차트 데이터 포함) --------
+        // 1. 대표종(감태) 데이터 - 차트에 표시됨
         area.addGrowth(GrowthLog.builder()
                 .species(gamtae)
                 .recordDate(LocalDate.of(2025, 5, 15))
@@ -2047,7 +2052,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .status(SpeciesAttachmentStatus.GOOD)
                 .build());
 
-        // 대표개체가 아닌 로그도 1개 추가(대표 차트 필터링 확인용)
+        // 2. 비대표종(다시마) 데이터 - 차트에 표시 안 됨 (필터링 테스트용)
         area.addGrowth(GrowthLog.builder()
                 .species(dasima)
                 .recordDate(LocalDate.of(2025, 6, 15))
@@ -2057,7 +2062,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .status(SpeciesAttachmentStatus.NORMAL)
                 .build());
 
-        // -------- Water Logs (필수값: recordDate, temperature, DO, nutrient + 상태값 4종) --------
+        // -------- Water Logs --------
         area.addWater(WaterLog.builder()
                 .recordDate(LocalDate.of(2025, 6, 1))
                 .temperature(18.2)
@@ -2080,7 +2085,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .wave(MarineStatus.NORMAL)
                 .build());
 
-        // -------- Media Logs (필수값: recordDate, mediaUrl, category) --------
+        // -------- Media Logs --------
         area.addMedia(MediaLog.builder()
                 .category(MediaCategory.BEFORE)
                 .mediaUrl(VALID_IMAGE_URL)
@@ -2106,7 +2111,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
     }
 
     /**
-     * 울진 테스트 영역 1: 마커/통계/nearest/bbox 테스트용으로 최소 구성 + 필수로그 몇 개
+     * 울진 테스트 영역 1
      */
     private void createUljinDemoArea1(Species gamtae, Species dasima) {
         ProjectArea area = ProjectArea.builder()
@@ -2122,7 +2127,10 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .build();
 
         area.setLocation(36.9950, 129.4020);
+
+        // [설정] 울진 영역 대표종: 감태
         area.setRepresentativeSpecies(gamtae);
+
         area.addTransplant(TransplantLog.builder()
                 .recordDate(LocalDate.of(2025, 8, 5))
                 .species(gamtae)
@@ -2139,6 +2147,25 @@ public class DashboardDataInitializer implements CommandLineRunner {
                 .count(15)
                 .areaSize(90.0)
                 .attachmentStatus(SpeciesAttachmentStatus.POOR)
+                .build());
+
+        // [추가] 대표종(감태) 성장 로그 데이터 추가 (차트 표시용)
+        area.addGrowth(GrowthLog.builder()
+                .species(gamtae)
+                .recordDate(LocalDate.of(2025, 8, 20))
+                .attachmentRate(75.0)
+                .survivalRate(85.0)
+                .growthLength(5.5)
+                .status(SpeciesAttachmentStatus.NORMAL)
+                .build());
+
+        area.addGrowth(GrowthLog.builder()
+                .species(gamtae)
+                .recordDate(LocalDate.of(2025, 9, 20))
+                .attachmentRate(78.0)
+                .survivalRate(82.0)
+                .growthLength(8.2)
+                .status(SpeciesAttachmentStatus.GOOD)
                 .build());
 
         area.addWater(WaterLog.builder()
@@ -3053,10 +3080,12 @@ public class DashboardAggregateBuilder {
                 })
                 .toList();
 
-        String targetSpeciesName = (area.getRepresentativeSpecies() != null)
-                ? area.getRepresentativeSpecies().getName()
-                : "미지정";
-
+        String targetSpeciesName = "미지정";
+        Long targetSpeciesId = null;
+        if (area.getRepresentativeSpecies() != null) {
+            targetSpeciesName = area.getRepresentativeSpecies().getName();
+            targetSpeciesId = area.getRepresentativeSpecies().getId();
+        }
         return AreaDetailResponse.EcologyTab.builder()
                 .attachmentStatuses(attachmentStatuses)
                 .survivalStatus(area.getAttachmentStatus() != null ? area.getAttachmentStatus().getName() : "안정")
@@ -3064,6 +3093,7 @@ public class DashboardAggregateBuilder {
                         .labels(repLogs.stream().map(GrowthLog::getRecordDate).toList())
                         .values(repLogs.stream().map(GrowthLog::getGrowthLength).toList())
                         .targetSpecies(targetSpeciesName)
+                        .targetSpeciesId(targetSpeciesId)
                         .unit("mm/월")
                         .build())
                 .build();
@@ -3785,6 +3815,17 @@ public class DashboardQueryService {
                 .stream()
                 .map(AreaSpeciesResponse::from)
                 .toList();
+    }
+
+    /**
+     * 영역의 현재 대표 종 조회
+     */
+    public AreaSpeciesResponse getRepresentativeSpecies(Long areaId) {
+        ProjectArea area = projectAreaRepository.findById(areaId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.RESOURCE_NOT_FOUND));
+
+        if (area.getRepresentativeSpecies() == null)  return null;
+        return AreaSpeciesResponse.from(area.getRepresentativeSpecies());
     }
 
 }

--- a/src/main/java/com/ocean/piuda/global/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/global/ProjectExporter.java
@@ -1,0 +1,137 @@
+package com.ocean.piuda.global;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ocean/piuda/security/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/security/ProjectExporter.java
@@ -1,0 +1,137 @@
+package com.ocean.piuda.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ocean/piuda/security/jwt/controller/AuthController.java
+++ b/src/main/java/com/ocean/piuda/security/jwt/controller/AuthController.java
@@ -89,7 +89,7 @@ public class AuthController {
             HttpServletResponse response
     ) {
         // 쿠키 삭제
-        ResponseCookie logoutCookie = tokenCookieFactory.buildLogoutCookie();
+        ResponseCookie logoutCookie = tokenCookieFactory.deleteAccessTokenCookie();
         response.addHeader(HttpHeaders.SET_COOKIE, logoutCookie.toString());
         
         return ResponseEntity.ok(ApiData.ok(null));

--- a/src/main/java/com/ocean/piuda/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/ocean/piuda/security/jwt/filter/JwtAuthenticationFilter.java
@@ -51,7 +51,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtTokenProvider.isValidToken(token)) {
             Long id =jwtTokenProvider.extractId(token);  // JWT에서 사용자명 추출
 
-            log.debug("[JwtAuthenticationFilter] deviceId from token: {}", id);
+            log.debug("[JwtAuthenticationFilter] userId from token: {}", id);
 
             // UserDetailsService 를 통해 사용자 정보 로드
             PrincipalDetails userDetails = (PrincipalDetails) customUserDetailsService.loadUserById(id);

--- a/src/main/java/com/ocean/piuda/security/jwt/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/ocean/piuda/security/jwt/handler/CustomAuthenticationEntryPoint.java
@@ -24,7 +24,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                          AuthenticationException authException) throws IOException {
 
 
-        ApiData<?> apiData = ApiData.error(ExceptionType.ACCESS_DENIED);
+        ApiData<?> apiData = ApiData.error(ExceptionType.UNAUTHORIZED_USER);
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");

--- a/src/main/java/com/ocean/piuda/security/jwt/util/TokenCookieFactory.java
+++ b/src/main/java/com/ocean/piuda/security/jwt/util/TokenCookieFactory.java
@@ -67,17 +67,5 @@ public class TokenCookieFactory {
         }
     }
 
-    /**
-     * 로그아웃용 쿠키 삭제 (maxAge=0)
-     */
-    public ResponseCookie buildLogoutCookie() {
-        return ResponseCookie.from(ACCESS_TOKEN_COOKIE, "")
-                .httpOnly(true)
-                .sameSite("None")
-                .secure(true)
-                .path("/")
-                .maxAge(0)  // 즉시 삭제
-                .build();
-    }
 
 }

--- a/src/main/java/com/ocean/piuda/user/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/user/ProjectExporter.java
@@ -1,0 +1,138 @@
+package com.ocean.piuda.user;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/ocean/piuda/user/controller/UserController.java
+++ b/src/main/java/com/ocean/piuda/user/controller/UserController.java
@@ -26,7 +26,7 @@ public class UserController {
     private final TokenUserService tokenUserService;
     private final UserAggregateBuilder aggregateBuilder;
 
-    @PatchMapping("/{deviceId}")
+    @PatchMapping("/{userId}")
     @Operation(summary = "유저 정보 수정", description = "특정 유저의 닉네임, 이메일, 전화번호 등 기본 정보를 수정합니다.")
     public ApiData<Boolean> patchUser(
             @PathVariable Long userId,
@@ -46,7 +46,7 @@ public class UserController {
         return ApiData.ok(userQueryService.searchByNicknameOrUsername(req));
     }
 
-    @GetMapping("/{deviceId}/info")
+    @GetMapping("/{userId}/info")
     @Operation(summary = "유저 상세 조회", description = "id 기반으로 특정 유저의 상세 정보를 조회합니다.")
     public ApiData<DetailedUserResponse> getUserById(@PathVariable Long userId) {
         return ApiData.ok(aggregateBuilder.build(userQueryService.getUserById(userId)));


### PR DESCRIPTION
## 💡 개요 (Summary)
- 추가된 로그아웃 구현( PR #33 )이 로그인 시 사용하던 토큰 쿠키 생성 정책(환경변수 기반 Domain/Secure/SameSite) 과 불일치하여, 로그아웃 시 쿠키가 정상적으로 삭제되지 않는 버그가 발생했습니다. 
- 이를 해결하기 위해 쿠키 삭제 로직을 기존 토큰 생성 정책과 일치하도록 통일했습니다. 또한, 작업 과정에서 발견된 유저 API의 매핑 오류를 수정하고, 미인증 접근에 대한 응답 코드를 HTTP 표준에 맞게 개선했습니다.

## 📝 작업 내용 (Key Changes)
### 1. 로그아웃 로직 리팩토링 및 버그 수정
- TokenCookieFactory: 기존 토큰 생성 정책과 맞지 않게 하드코딩되어 있던 buildLogoutCookie() 메서드를 제거했습니다.
- 정책 일원화: 로그인 시 쿠키를 생성하는 로직과 동일하게 환경변수(app.cookie.*)를 참조하여 Domain, Secure, SameSite 설정을 적용하는 deleteAccessTokenCookie() 메서드로 로그아웃 로직을 교체했습니다.
- AuthController: 로그아웃 API에서 수정된 쿠키 삭제 메서드를 호출하도록 변경했습니다.

### 2. 인증 예외 응답 개선
- CustomAuthenticationEntryPoint: 로그인하지 않은 사용자의 접근 시 기존 403 Forbidden 대신 401 Unauthorized (UNAUTHORIZED_USER) 를 반환하도록 수정했습니다.

### 3. User API 정합성 개선
- 유저 관련 API에서 path variable 사용을 명확히 하여 라우팅/요청 형식의 정합성을 확보하였습니다. (deviceId -> userId)

## 🛠️ 기술적 의사결정 (Technical Decisions)
### 1. 쿠키 삭제 로직의 정합성 확보 (Cookie Policy Consistency)
브라우저 보안 정책상 쿠키를 삭제(만료)하기 위해서는 쿠키 생성 시점과 동일한 Name, Path, Domain 속성을 가지고 있어야 합니다. 기존 하드코딩된 로그아웃 로직은 운영 환경(실제 도메인 사용)과 로컬 환경의 차이를 반영하지 못해, 로그아웃 요청 후에도 쿠키가 잔존하는 문제가 있었습니다. 따라서, 하드코딩된 메서드를 삭제하고 로그인 로직과 동일한 환경변수 설정을 공유하는 메서드로 통일하여, 환경에 관계없이 안정적으로 로그아웃이 수행되도록 개선했습니다.

### 2. 401 vs 403 응답 구분
로그인이 되어있지 않은 상태는 "권한 부족(Admin vs User)"의 문제보다 "신원 미확인"의 문제에 가깝습니다. 프론트엔드에서 로그인 페이지로의 리다이렉트 처리를 명확히 하기 위해 HTTP 표준 의미론에 더 적합한 401 상태 코드로 변경했습니다.

- 기존: 미인증 사용자에게 403 Forbidden 반환 (접근 권한 없음)
- 변경: 미인증 사용자에게 401 Unauthorized 반환 (인증 필요) 