### PR TITLE
refactor: Submission API 응답 필드 현행화 및 Species 도메인 경량화

### DIFF
--- a/project_context.txt
+++ b/project_context.txt
@@ -1,8 +1,5 @@
 
-================================================================================
-File Path: .\.github\ISSUE_TEMPLATE\default-issue-template.md
-================================================================================
-
+# File Path: .\.github\ISSUE_TEMPLATE\default-issue-template.md
 ---
 name: default issue template
 about: OCEAN-KIT 의 디폴트 이슈 템플릿 입니다.
@@ -25,10 +22,7 @@ assignees: ''
 관련 문서, 스크린샷, 또는 예시 등이 있다면 여기에 첨부해주세요
 
 
-================================================================================
-File Path: .\build.gradle
-================================================================================
-
+# File Path: .\build.gradle
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '3.5.6'
@@ -124,10 +118,7 @@ tasks.named('test') {
 }
 
 
-================================================================================
-File Path: .\docs\ADMIN_GUIDE.md
-================================================================================
-
+# File Path: .\docs\ADMIN_GUIDE.md
 # OceanCampus Admin API 문서
 
 ## 📋 목차
@@ -889,10 +880,7 @@ Authorization: Bearer {access_token}
 
 
 
-================================================================================
-File Path: .\docs\EXPORT_TEST_GUIDE.md
-================================================================================
-
+# File Path: .\docs\EXPORT_TEST_GUIDE.md
 # Export 기능 테스트 가이드
 
 ## 사전 준비
@@ -1183,10 +1171,7 @@ head -5 submissions_export.csv
 - [ ] Export 이력 조회 확인
 
 
-================================================================================
-File Path: .\docs\marin_guide.md
-================================================================================
-
+# File Path: .\docs\marin_guide.md
 # 해양 환경 요약 API 모듈
 
 OC Community(OC Underwater) 앱에서 사용하는 해양 환경 요약 정보를 제공하는 REST API 모듈입니다.
@@ -1601,10 +1586,7 @@ curl -X GET "http://localhost:8080/api/environment/summary?lat=36.3500&lon=129.7
 
 
 
-================================================================================
-File Path: .\ProjectExporter.java
-================================================================================
-
+# File Path: .\ProjectExporter.java
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
@@ -1745,10 +1727,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\REFCTORING_explain.md
-================================================================================
-
+# File Path: .\REFCTORING_explain.md
 # OC Diver App - Backend
 
 Spring Boot 기반 해양 활동 기록 관리 시스템 백엔드입니다.
@@ -2202,17 +2181,11 @@ PUT /api/admin/submissions/draft/1?submit=true
 [기여자 목록]
 
 
-================================================================================
-File Path: .\settings.gradle
-================================================================================
-
+# File Path: .\settings.gradle
 rootProject.name = 'piuda'
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ActivityType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ActivityType.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ActivityType {
@@ -2229,10 +2202,7 @@ public enum ActivityType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\AuditAction.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\AuditAction.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum AuditAction {
@@ -2244,10 +2214,7 @@ public enum AuditAction {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\BarrenExtent.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\BarrenExtent.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2267,10 +2234,7 @@ public enum BarrenExtent {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\CleanupMethodType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\CleanupMethodType.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2290,10 +2254,7 @@ public enum CleanupMethodType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\DensityLevel.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\DensityLevel.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2316,10 +2277,7 @@ public enum DensityLevel {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ExportFormat.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ExportFormat.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ExportFormat {
@@ -2328,10 +2286,7 @@ public enum ExportFormat {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ExportStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ExportStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ExportStatus {
@@ -2341,10 +2296,7 @@ public enum ExportStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\GrazerSpeciesType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\GrazerSpeciesType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2359,10 +2311,7 @@ public enum GrazerSpeciesType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\HealthStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\HealthStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2383,10 +2332,7 @@ public enum HealthStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\MarineCondition.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\MarineCondition.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2399,10 +2345,7 @@ public enum MarineCondition {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ParticipantRole.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\ParticipantRole.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ParticipantRole {
@@ -2413,10 +2356,7 @@ public enum ParticipantRole {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\RockFeature.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\RockFeature.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2438,10 +2378,7 @@ public enum RockFeature {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SeaweedHealthStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SeaweedHealthStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2461,10 +2398,7 @@ public enum SeaweedHealthStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SubmissionStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SubmissionStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum SubmissionStatus {
@@ -2475,10 +2409,7 @@ public enum SubmissionStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SubstrateTargetType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\SubstrateTargetType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2492,10 +2423,7 @@ public enum SubstrateTargetType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\Suitability.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\Suitability.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2514,10 +2442,7 @@ public enum Suitability {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TerrainType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TerrainType.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2538,10 +2463,7 @@ public enum TerrainType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantLocationType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantLocationType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2554,10 +2476,7 @@ public enum TransplantLocationType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantMethodType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantMethodType.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -2577,10 +2496,7 @@ public enum TransplantMethodType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantSpeciesType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\TransplantSpeciesType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2596,10 +2512,7 @@ public enum TransplantSpeciesType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\UncollectedScale.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\UncollectedScale.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2612,10 +2525,7 @@ public enum UncollectedScale {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\WasteType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\WasteType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2631,10 +2541,7 @@ public enum WasteType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\WorkScope.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\common\enums\WorkScope.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -2647,10 +2554,7 @@ public enum WorkScope {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\controller\AdminDashboardController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\controller\AdminDashboardController.java
 package com.ocean.piuda.admin.dashboard.controller;
 
 import com.ocean.piuda.admin.dashboard.dto.AdminDashboardSummaryResponse;
@@ -2693,10 +2597,7 @@ public class AdminDashboardController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\dto\AdminDashboardSummaryResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\dto\AdminDashboardSummaryResponse.java
 package com.ocean.piuda.admin.dashboard.dto;
 
 public record AdminDashboardSummaryResponse(
@@ -2718,10 +2619,7 @@ public record AdminDashboardSummaryResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\service\AdminDashboardService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\dashboard\service\AdminDashboardService.java
 package com.ocean.piuda.admin.dashboard.service;
 
 import com.ocean.piuda.admin.common.enums.SubmissionStatus;
@@ -2754,10 +2652,7 @@ public class AdminDashboardService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\controller\ExportController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\controller\ExportController.java
 package com.ocean.piuda.admin.export.controller;
 
 import com.ocean.piuda.admin.export.dto.request.ExportByIdsRequest;
@@ -2903,10 +2798,7 @@ public class ExportController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\dto\request\ExportByIdsRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\dto\request\ExportByIdsRequest.java
 package com.ocean.piuda.admin.export.dto.request;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -2931,10 +2823,7 @@ public class ExportByIdsRequest {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\dto\request\ExportRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\dto\request\ExportRequest.java
 package com.ocean.piuda.admin.export.dto.request;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -2968,10 +2857,7 @@ public class ExportRequest {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\dto\response\ExportJobResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\dto\response\ExportJobResponse.java
 package com.ocean.piuda.admin.export.dto.response;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -3013,10 +2899,7 @@ public class ExportJobResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\entity\ExportJob.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\entity\ExportJob.java
 package com.ocean.piuda.admin.export.entity;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -3063,10 +2946,7 @@ public class ExportJob extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\repository\ExportJobRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\repository\ExportJobRepository.java
 package com.ocean.piuda.admin.export.repository;
 
 import com.ocean.piuda.admin.export.entity.ExportJob;
@@ -3082,10 +2962,7 @@ public interface ExportJobRepository extends JpaRepository<ExportJob, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\export\service\ExportService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\export\service\ExportService.java
 package com.ocean.piuda.admin.export.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -3418,10 +3295,7 @@ public class ExportService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\initializer\AdminUserInitializer.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\initializer\AdminUserInitializer.java
 package com.ocean.piuda.admin.initializer;
 
 import com.ocean.piuda.security.jwt.enums.Role;
@@ -3475,10 +3349,7 @@ public class AdminUserInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\ProjectExporter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\ProjectExporter.java
 package com.ocean.piuda.admin;
 
 import java.io.IOException;
@@ -3621,10 +3492,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\controller\ReportDraftController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\controller\ReportDraftController.java
 //package com.ocean.piuda.admin.report.controller;
 //import org.springframework.http.ContentDisposition;
 //import org.springframework.http.HttpHeaders;
@@ -3719,10 +3587,7 @@ File Path: .\src\main\java\com\ocean\piuda\admin\report\controller\ReportDraftCo
 //}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\request\ReportDraftByIdsRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\request\ReportDraftByIdsRequest.java
 package com.ocean.piuda.admin.report.dto.request;
 
 import com.ocean.piuda.admin.report.enums.ReportDraftType;
@@ -3744,10 +3609,7 @@ public record ReportDraftByIdsRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\request\ReportDraftByPeriodRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\request\ReportDraftByPeriodRequest.java
 package com.ocean.piuda.admin.report.dto.request;
 
 import com.ocean.piuda.admin.report.enums.ReportDraftType;
@@ -3771,10 +3633,7 @@ public record ReportDraftByPeriodRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\response\ReportDraftResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\response\ReportDraftResponse.java
 package com.ocean.piuda.admin.report.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -3801,10 +3660,7 @@ public record ReportDraftResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\response\ReportPdfResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\dto\response\ReportPdfResponse.java
 package com.ocean.piuda.admin.report.dto.response;
 
 public record ReportPdfResponse(
@@ -3813,10 +3669,7 @@ public record ReportPdfResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\enums\ReportDraftType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\enums\ReportDraftType.java
 package com.ocean.piuda.admin.report.enums;
 
 public enum ReportDraftType {
@@ -3837,10 +3690,7 @@ public enum ReportDraftType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportDraftService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportDraftService.java
 /*
 package com.ocean.piuda.admin.report.service;
 
@@ -4128,10 +3978,7 @@ public class ReportDraftService {
  */
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportPdfService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportPdfService.java
 //
 //package com.ocean.piuda.admin.report.service;
 //
@@ -4339,10 +4186,7 @@ File Path: .\src\main\java\com\ocean\piuda\admin\report\service\ReportPdfService
 //
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\report\util\ReportPromptBuilder.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\report\util\ReportPromptBuilder.java
 package com.ocean.piuda.admin.report.util;
 
 import com.ocean.piuda.admin.report.enums.ReportDraftType;
@@ -4401,10 +4245,7 @@ public class ReportPromptBuilder {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\controller\SiteNameOptionController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\controller\SiteNameOptionController.java
 package com.ocean.piuda.admin.site.controller;
 
 import com.ocean.piuda.admin.site.dto.request.CreateSiteOptionRequest;
@@ -4457,10 +4298,7 @@ public class SiteNameOptionController {
     }}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\request\CreateSiteOptionRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\request\CreateSiteOptionRequest.java
 package com.ocean.piuda.admin.site.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
@@ -4471,10 +4309,7 @@ public record CreateSiteOptionRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\request\UpdateSiteOptionRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\request\UpdateSiteOptionRequest.java
 package com.ocean.piuda.admin.site.dto.request;
 
 import jakarta.validation.constraints.Size;
@@ -4487,10 +4322,7 @@ public record UpdateSiteOptionRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\response\SiteNameOptionResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\dto\response\SiteNameOptionResponse.java
 package com.ocean.piuda.admin.site.dto.response;
 
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
@@ -4505,10 +4337,7 @@ public record SiteNameOptionResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\entity\SiteNameOption.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\entity\SiteNameOption.java
 package com.ocean.piuda.admin.site.entity;
 
 import com.ocean.piuda.global.api.domain.BaseEntity;
@@ -4547,10 +4376,7 @@ public class SiteNameOption extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\repository\SiteNameOptionRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\repository\SiteNameOptionRepository.java
 package com.ocean.piuda.admin.site.repository;
 
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
@@ -4570,10 +4396,7 @@ public interface SiteNameOptionRepository extends JpaRepository<SiteNameOption, 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\site\service\SiteNameOptionService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\site\service\SiteNameOptionService.java
 package com.ocean.piuda.admin.site.service;
 
 
@@ -4658,10 +4481,7 @@ public class SiteNameOptionService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\controller\SubmissionController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\controller\SubmissionController.java
 package com.ocean.piuda.admin.submission.controller;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -4903,10 +4723,7 @@ public class SubmissionController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\BulkApproveRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\BulkApproveRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
@@ -4920,10 +4737,7 @@ public record BulkApproveRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\BulkDeleteRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\BulkDeleteRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
@@ -4939,10 +4753,7 @@ public record BulkDeleteRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\BulkRejectRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\BulkRejectRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.Valid;
@@ -4962,10 +4773,7 @@ public record BulkRejectRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\CreateSubmissionRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\CreateSubmissionRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -5284,10 +5092,7 @@ public class CreateSubmissionRequest {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\RejectReasonDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\RejectReasonDto.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 public record RejectReasonDto(
@@ -5297,10 +5102,7 @@ public record RejectReasonDto(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\SingleDeleteRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\SingleDeleteRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 public record SingleDeleteRequest(
@@ -5309,10 +5111,7 @@ public record SingleDeleteRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\SingleRejectRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\request\SingleRejectRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.Valid;
@@ -5326,10 +5125,7 @@ public record SingleRejectRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\AttachmentResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\AttachmentResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.submission.entity.Attachment;
@@ -5358,10 +5154,7 @@ public record AttachmentResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\AuditLogResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\AuditLogResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.AuditAction;
@@ -5389,10 +5182,7 @@ public record AuditLogResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BasicEnvResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BasicEnvResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.MarineCondition;
@@ -5427,10 +5217,7 @@ public record BasicEnvResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BulkApproveResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BulkApproveResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import java.util.List;
@@ -5441,10 +5228,7 @@ public record BulkApproveResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BulkDeleteResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BulkDeleteResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import java.util.List;
@@ -5455,10 +5239,7 @@ public record BulkDeleteResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BulkRejectResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\BulkRejectResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import java.util.List;
@@ -5469,10 +5250,7 @@ public record BulkRejectResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\ParticipantsResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\ParticipantsResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 
@@ -5482,10 +5260,7 @@ public record ParticipantsResponse(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\SubmissionDetailResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\SubmissionDetailResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -5678,10 +5453,7 @@ public record SubmissionDetailResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\SubmissionListResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\dto\response\SubmissionListResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -5716,10 +5488,7 @@ public record SubmissionListResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityGrazerRemoval.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityGrazerRemoval.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.DensityLevel;
@@ -5779,10 +5548,7 @@ public class ActivityGrazerRemoval {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityMarineCleanup.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityMarineCleanup.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.CleanupMethodType;
@@ -5839,10 +5605,7 @@ public class ActivityMarineCleanup {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityMonitoring.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityMonitoring.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -5927,10 +5690,7 @@ public class ActivityMonitoring {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivitySubstrateImprovement.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivitySubstrateImprovement.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.SubstrateTargetType;
@@ -5971,10 +5731,7 @@ public class ActivitySubstrateImprovement {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityTransplant.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\ActivityTransplant.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.HealthStatus;
@@ -6027,10 +5784,7 @@ public class ActivityTransplant {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\Attachment.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\Attachment.java
 package com.ocean.piuda.admin.submission.entity;
 
 import jakarta.persistence.*;
@@ -6078,10 +5832,7 @@ public class Attachment {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\AuditLog.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\AuditLog.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.AuditAction;
@@ -6123,10 +5874,7 @@ public class AuditLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\BasicEnv.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\BasicEnv.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.MarineCondition;
@@ -6188,10 +5936,7 @@ public class BasicEnv {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\RejectReason.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\RejectReason.java
 package com.ocean.piuda.admin.submission.entity;
 
 import jakarta.persistence.*;
@@ -6236,10 +5981,7 @@ public class RejectReason {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\Submission.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\entity\Submission.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -6464,10 +6206,7 @@ public class Submission extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\initializer\SubmissionDataInitializer.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\initializer\SubmissionDataInitializer.java
 package com.ocean.piuda.admin.submission.initializer;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -6812,10 +6551,7 @@ public class SubmissionDataInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\repository\AuditLogRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\repository\AuditLogRepository.java
 package com.ocean.piuda.admin.submission.repository;
 
 import com.ocean.piuda.admin.submission.entity.AuditLog;
@@ -6830,10 +6566,7 @@ public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\repository\SubmissionRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\repository\SubmissionRepository.java
 package com.ocean.piuda.admin.submission.repository;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -6935,10 +6668,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\service\SubmissionCommandService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\service\SubmissionCommandService.java
 package com.ocean.piuda.admin.submission.service;
 
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
@@ -7399,10 +7129,7 @@ public class SubmissionCommandService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\service\SubmissionQueryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\service\SubmissionQueryService.java
 package com.ocean.piuda.admin.submission.service;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -7493,10 +7220,7 @@ public class SubmissionQueryService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\validator\ActivityValidator.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\validator\ActivityValidator.java
 package com.ocean.piuda.admin.submission.validator;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -7598,10 +7322,7 @@ public class ActivityValidator {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\admin\submission\validator\SubmissionStatusValidator.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\admin\submission\validator\SubmissionStatusValidator.java
 package com.ocean.piuda.admin.submission.validator;
 
 import com.ocean.piuda.admin.common.enums.SubmissionStatus;
@@ -7664,10 +7385,7 @@ public class SubmissionStatusValidator {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\config\GeminiConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\config\GeminiConfig.java
 package com.ocean.piuda.ai.gemini.config;
 
 
@@ -7690,10 +7408,7 @@ public class GeminiConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\controller\GeminiTextController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\controller\GeminiTextController.java
 package com.ocean.piuda.ai.gemini.controller;
 
 import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
@@ -7729,10 +7444,7 @@ public class GeminiTextController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\controller\GeminiVisionController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\controller\GeminiVisionController.java
 package com.ocean.piuda.ai.gemini.controller;
 
 import com.ocean.piuda.ai.gemini.dto.request.GeminiRequest;
@@ -7786,10 +7498,7 @@ public class GeminiVisionController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\dto\request\GeminiRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\dto\request\GeminiRequest.java
 package com.ocean.piuda.ai.gemini.dto.request;
 
 
@@ -7806,10 +7515,7 @@ public record GeminiRequest(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\dto\response\GeminiMeta.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\dto\response\GeminiMeta.java
 package com.ocean.piuda.ai.gemini.dto.response;
 
 import lombok.Builder;
@@ -7823,10 +7529,7 @@ public record GeminiMeta(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\dto\response\GeminiResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\dto\response\GeminiResponse.java
 package com.ocean.piuda.ai.gemini.dto.response;
 
 
@@ -7839,10 +7542,7 @@ public record GeminiResponse(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\service\GeminiTextService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\service\GeminiTextService.java
 package com.ocean.piuda.ai.gemini.service;
 
 import com.google.genai.Client;
@@ -7963,10 +7663,7 @@ public class GeminiTextService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\service\GeminiVisionService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\service\GeminiVisionService.java
 package com.ocean.piuda.ai.gemini.service;
 
 import com.google.genai.Client;
@@ -8031,10 +7728,7 @@ public class GeminiVisionService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\gemini\util\GeminiSdkUtil.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\gemini\util\GeminiSdkUtil.java
 package com.ocean.piuda.ai.gemini.util;
 
 
@@ -8088,10 +7782,7 @@ public class GeminiSdkUtil {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\controller\GroqApiController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\controller\GroqApiController.java
 package com.ocean.piuda.ai.groq.controller;
 
 import com.ocean.piuda.ai.groq.dto.request.EvaluateHarmfulnessRequest;
@@ -8153,10 +7844,7 @@ public class GroqApiController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\request\EvaluateHarmfulnessRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\request\EvaluateHarmfulnessRequest.java
 package com.ocean.piuda.ai.groq.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
@@ -8170,10 +7858,7 @@ public record EvaluateHarmfulnessRequest (
 ){ }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\request\GroqPromptRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\request\GroqPromptRequest.java
 package com.ocean.piuda.ai.groq.dto.request;
 
 import jakarta.validation.constraints.*;
@@ -8191,10 +7876,7 @@ public record GroqPromptRequest(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\response\EvaluateHarmfulnessResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\response\EvaluateHarmfulnessResponse.java
 package com.ocean.piuda.ai.groq.dto.response;
 
 import lombok.Builder;
@@ -8208,10 +7890,7 @@ public record EvaluateHarmfulnessResponse(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\response\GroqMeta.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\response\GroqMeta.java
 package com.ocean.piuda.ai.groq.dto.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8235,10 +7914,7 @@ public record GroqMeta(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\response\GroqPromptResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\dto\response\GroqPromptResponse.java
 package com.ocean.piuda.ai.groq.dto.response;
 
 import lombok.Builder;
@@ -8250,10 +7926,7 @@ public record GroqPromptResponse(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\service\GroqApiService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\service\GroqApiService.java
 package com.ocean.piuda.ai.groq.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8363,10 +8036,7 @@ public class GroqApiService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\groq\util\GroqApiUtil.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\groq\util\GroqApiUtil.java
 package com.ocean.piuda.ai.groq.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8581,10 +8251,7 @@ public class GroqApiUtil {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\openAI\controller\OpenAIApiController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\openAI\controller\OpenAIApiController.java
 //package com.ocean.piuda.ai.openAI.controller;
 //
 //import com.ocean.piuda.ai.openAI.dto.request.OpenAIRequest;
@@ -8640,10 +8307,7 @@ File Path: .\src\main\java\com\ocean\piuda\ai\openAI\controller\OpenAIApiControl
 //}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\openAI\dto\request\OpenAIRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\openAI\dto\request\OpenAIRequest.java
 package com.ocean.piuda.ai.openAI.dto.request;
 
 import lombok.AllArgsConstructor;
@@ -8686,10 +8350,7 @@ public class OpenAIRequest {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\openAI\service\OpenAIApiService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\openAI\service\OpenAIApiService.java
 package com.ocean.piuda.ai.openAI.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -8840,10 +8501,7 @@ public class OpenAIApiService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\ai\ProjectExporter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\ai\ProjectExporter.java
 package com.ocean.piuda.ai;
 
 import java.io.IOException;
@@ -8985,10 +8643,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\aws\config\AwsCredentialConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\aws\config\AwsCredentialConfig.java
 package com.ocean.piuda.aws.config;
 
 import com.ocean.piuda.aws.properties.AwsConfigProperties;
@@ -9017,10 +8672,7 @@ public class AwsCredentialConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\aws\config\S3Config.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\aws\config\S3Config.java
 package com.ocean.piuda.aws.config;
 
 import com.ocean.piuda.aws.properties.AwsConfigProperties;
@@ -9069,10 +8721,7 @@ public class S3Config {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\aws\controller\ImageController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\aws\controller\ImageController.java
 package com.ocean.piuda.aws.controller;
 
 import com.ocean.piuda.aws.dto.response.GeneratePresignedPutUrlResponse;
@@ -9163,10 +8812,7 @@ public class ImageController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\aws\dto\response\GeneratePresignedPutUrlResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\aws\dto\response\GeneratePresignedPutUrlResponse.java
 package com.ocean.piuda.aws.dto.response;
 
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -9189,10 +8835,7 @@ public record GeneratePresignedPutUrlResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\aws\properties\AwsConfigProperties.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\aws\properties\AwsConfigProperties.java
 package com.ocean.piuda.aws.properties;
 
 import jakarta.validation.constraints.Min;
@@ -9250,10 +8893,7 @@ public class AwsConfigProperties {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\aws\service\S3Service.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\aws\service\S3Service.java
 package com.ocean.piuda.aws.service;
 
 import com.ocean.piuda.aws.dto.response.GeneratePresignedPutUrlResponse;
@@ -9346,10 +8986,7 @@ public class S3Service {
     }}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\controller\SpeciesController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\controller\SpeciesController.java
 package com.ocean.piuda.bio.controller;
 
 
@@ -9413,10 +9050,7 @@ public class SpeciesController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\dto\request\SpeciesRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\dto\request\SpeciesRequest.java
 package com.ocean.piuda.bio.dto.request;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -9427,23 +9061,16 @@ public class SpeciesRequest {
 
     public record Create(
             @NotBlank(message = "종 이름은 필수입니다")
-            String name,
-
-            @NotNull(message = "생물 그룹 분류는 필수입니다")
-            BioGroup category
+            String name
     ) {}
 
     public record Update(
-            String name,
-            BioGroup category
+            String name
     ) {}
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\dto\response\SpeciesResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\dto\response\SpeciesResponse.java
 package com.ocean.piuda.bio.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -9455,24 +9082,19 @@ import java.time.LocalDateTime;
 public record SpeciesResponse(
         Long id,
         String name,
-        BioGroup category,
         LocalDateTime createdAt
 ) {
     public static SpeciesResponse from(Species species) {
         return SpeciesResponse.builder()
                 .id(species.getId())
                 .name(species.getName())
-                .category(species.getCategory())
                 .createdAt(species.getCreatedAt())
                 .build();
     }
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\entity\Species.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\entity\Species.java
 package com.ocean.piuda.bio.entity;
 
 import jakarta.persistence.Entity;
@@ -9504,20 +9126,13 @@ public class Species extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name; // 국명 (예: 감태)
 
-    @Enumerated(EnumType.STRING)
-    private BioGroup category;
-
-    public void update(String name, BioGroup category) {
+    public void update(String name) {
         if (name != null && !name.isBlank())  this.name = name;
-        if (category != null) this.category = category;
     }
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\enums\BioGroup.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\enums\BioGroup.java
 package com.ocean.piuda.bio.enums;
 
 
@@ -9555,10 +9170,7 @@ public enum BioGroup {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\ProjectExporter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\ProjectExporter.java
 package com.ocean.piuda.bio;
 
 import java.io.IOException;
@@ -9679,9 +9291,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {
@@ -9700,10 +9310,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\repository\SpeciesRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\repository\SpeciesRepository.java
 package com.ocean.piuda.bio.repository;
 
 
@@ -9721,10 +9328,7 @@ public interface SpeciesRepository extends JpaRepository<Species, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\bio\service\SpeciesService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\bio\service\SpeciesService.java
 package com.ocean.piuda.bio.service;
 
 import com.ocean.piuda.bio.dto.request.SpeciesRequest;
@@ -9754,7 +9358,6 @@ public class SpeciesService {
 
         Species species = Species.builder()
                 .name(req.name())
-                .category(req.category())
                 .build();
 
         return SpeciesResponse.from(speciesRepository.save(species));
@@ -9788,7 +9391,7 @@ public class SpeciesService {
             });
         }
 
-        species.update(req.name(), req.category());
+        species.update(req.name());
     }
 
     public void deleteSpecies(Long id) {
@@ -9800,10 +9403,7 @@ public class SpeciesService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\controller\DashboardController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\controller\DashboardController.java
 package com.ocean.piuda.dashboard.controller;
 
 import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
@@ -10209,10 +9809,7 @@ public class DashboardController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\AreaPageRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\AreaPageRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.AreaSort;
@@ -10232,10 +9829,7 @@ public class AreaPageRequest extends PageRequest<AreaSort> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateGrowthLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateGrowthLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -10253,10 +9847,7 @@ public record CreateGrowthLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateMediaLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateMediaLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -10273,10 +9864,7 @@ public record CreateMediaLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateProjectAreaRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateProjectAreaRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.AreaAttachmentStatus;
@@ -10303,10 +9891,7 @@ public record CreateProjectAreaRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateTransplantLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateTransplantLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -10325,10 +9910,7 @@ public record CreateTransplantLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateWaterLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\CreateWaterLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MarineStatus;
@@ -10348,10 +9930,7 @@ public record CreateWaterLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\LogPageRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\LogPageRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.LogSort;
@@ -10372,10 +9951,7 @@ public class LogPageRequest extends PageRequest<LogSort> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\SetRepresentativeSpeciesRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\SetRepresentativeSpeciesRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import jakarta.validation.constraints.NotNull;
@@ -10386,10 +9962,7 @@ public record SetRepresentativeSpeciesRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateGrowthLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateGrowthLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -10406,10 +9979,7 @@ public record UpdateGrowthLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateMediaLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateMediaLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -10425,10 +9995,7 @@ public record UpdateMediaLogRequest(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateProjectAreaRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateProjectAreaRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -10457,10 +10024,7 @@ public record UpdateProjectAreaRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateTransplantLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateTransplantLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -10478,10 +10042,7 @@ public record UpdateTransplantLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateWaterLogRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\request\UpdateWaterLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MarineStatus;
@@ -10501,10 +10062,7 @@ public record UpdateWaterLogRequest(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaDetailResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaDetailResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.dto.TimeSeriesChartDto;
@@ -10648,10 +10206,7 @@ public class AreaDetailResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaMarkerResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaMarkerResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import lombok.AllArgsConstructor;
@@ -10687,10 +10242,7 @@ public class AreaMarkerResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaSpeciesResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaSpeciesResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -10712,10 +10264,7 @@ public class AreaSpeciesResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaStatResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\AreaStatResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import lombok.AllArgsConstructor;
@@ -10732,10 +10281,7 @@ public class AreaStatResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\GrowthLogResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\GrowthLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -10779,19 +10325,13 @@ public class GrowthLogResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\IdResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\IdResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 public record IdResponse(Long id) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\MediaLogResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\MediaLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.entity.MediaLog;
@@ -10824,10 +10364,7 @@ public class MediaLogResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\ProjectAreaListItemResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\ProjectAreaListItemResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.entity.ProjectArea;
@@ -10876,10 +10413,7 @@ public class ProjectAreaListItemResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\TransplantLogResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\TransplantLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -10933,10 +10467,7 @@ public class TransplantLogResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\WaterLogResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\response\WaterLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.entity.WaterLog;
@@ -10988,10 +10519,7 @@ public class WaterLogResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\TimeSeriesChartDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\dto\TimeSeriesChartDto.java
 package com.ocean.piuda.dashboard.dto;
 
 
@@ -11012,10 +10540,7 @@ public record TimeSeriesChartDto(
 ) { }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\BiodiversitySummary.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\BiodiversitySummary.java
 /**
  * 개편된 5개의 탭 구조에 맞춰 불필요한 "생물 다양성 요약 엔티티"는 사용하지 않습니다.
  */
@@ -11055,10 +10580,7 @@ public class BiodiversitySummary {
  */
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\GrowthLog.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\GrowthLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -11122,10 +10644,7 @@ public class GrowthLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\MediaLog.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\MediaLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -11175,10 +10694,7 @@ public class MediaLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\ProjectArea.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\ProjectArea.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -11339,10 +10855,7 @@ public class ProjectArea extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\TransplantLog.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\TransplantLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -11410,10 +10923,7 @@ public class TransplantLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\WaterLog.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\entity\WaterLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.dashboard.enums.MarineStatus;
@@ -11490,10 +11000,7 @@ public class WaterLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\AreaAttachmentStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\AreaAttachmentStatus.java
 package com.ocean.piuda.dashboard.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11509,10 +11016,7 @@ public enum AreaAttachmentStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\AreaSort.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\AreaSort.java
 package com.ocean.piuda.dashboard.enums;
 
 import com.ocean.piuda.global.enums.SortEnum;
@@ -11540,10 +11044,7 @@ public enum AreaSort implements SortEnum {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\HabitatType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\HabitatType.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -11560,10 +11061,7 @@ public enum HabitatType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\LogSort.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\LogSort.java
 package com.ocean.piuda.dashboard.enums;
 
 import com.ocean.piuda.global.enums.SortEnum;
@@ -11587,10 +11085,7 @@ public enum LogSort implements SortEnum {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\MarineStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\MarineStatus.java
 package com.ocean.piuda.dashboard.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -11606,10 +11101,7 @@ public enum MarineStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\MediaCategory.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\MediaCategory.java
 package com.ocean.piuda.dashboard.enums;
 
 
@@ -11627,10 +11119,7 @@ public enum MediaCategory {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\ProjectLevel.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\ProjectLevel.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -11649,10 +11138,7 @@ public enum ProjectLevel {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\RestorationRegion.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\RestorationRegion.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -11668,10 +11154,7 @@ public enum RestorationRegion {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\SpeciesAttachmentStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\SpeciesAttachmentStatus.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -11688,10 +11171,7 @@ public enum SpeciesAttachmentStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\TransplantMethod.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\enums\TransplantMethod.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -11712,10 +11192,7 @@ public enum TransplantMethod {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\initializer\DashboardDataInitializer.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\initializer\DashboardDataInitializer.java
 package com.ocean.piuda.dashboard.initializer;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -11754,9 +11231,9 @@ public class DashboardDataInitializer implements CommandLineRunner {
         log.info("OC DASHBOARD 실증용 데이터 초기화 시작");
 
         // 1) Species
-        Species gamtae = getOrCreateSpecies("감태", BioGroup.MACROALGAE);
-        Species dasima = getOrCreateSpecies("다시마", BioGroup.MACROALGAE);
-        Species mojaban = getOrCreateSpecies("모자반", BioGroup.MACROALGAE);
+        Species gamtae = getOrCreateSpecies("감태");
+        Species dasima = getOrCreateSpecies("다시마");
+        Species mojaban = getOrCreateSpecies("모자반");
 
         // 2) Areas
         createPohangDemoArea1(gamtae, dasima, mojaban);
@@ -11765,12 +11242,11 @@ public class DashboardDataInitializer implements CommandLineRunner {
         log.info("OC DASHBOARD 데이터 초기화 완료");
     }
 
-    private Species getOrCreateSpecies(String name, BioGroup category) {
+    private Species getOrCreateSpecies(String name) {
         return speciesRepository.findByName(name)
                 .orElseGet(() -> speciesRepository.save(
                         Species.builder()
                                 .name(name)
-                                .category(category)
                                 .build()
                 ));
     }
@@ -11992,10 +11468,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\ProjectExporter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\ProjectExporter.java
 package com.ocean.piuda.dashboard;
 
 import java.io.IOException;
@@ -12116,9 +11589,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {
@@ -12137,10 +11608,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\GrowthLogRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\GrowthLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.GrowthLog;
@@ -12174,10 +11642,7 @@ public interface GrowthLogRepository extends JpaRepository<GrowthLog, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\MediaLogRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\MediaLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.MediaLog;
@@ -12210,10 +11675,7 @@ public interface MediaLogRepository extends JpaRepository<MediaLog, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\ProjectAreaRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\ProjectAreaRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.ProjectArea;
@@ -12385,10 +11847,7 @@ public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AccumulatedStatsProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AccumulatedStatsProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -12400,10 +11859,7 @@ public interface AccumulatedStatsProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AreaMarkerProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AreaMarkerProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -12428,10 +11884,7 @@ public interface AreaMarkerProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AreaStatProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\AreaStatProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 public interface AreaStatProjection {
@@ -12441,10 +11894,7 @@ public interface AreaStatProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\EnvironmentSummaryProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\EnvironmentSummaryProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 public interface EnvironmentSummaryProjection {
@@ -12455,10 +11905,7 @@ public interface EnvironmentSummaryProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\MediaPointProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\MediaPointProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -12472,10 +11919,7 @@ public interface MediaPointProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\MethodAttachmentStatusProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\MethodAttachmentStatusProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 public interface MethodAttachmentStatusProjection {
@@ -12484,10 +11928,7 @@ public interface MethodAttachmentStatusProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\MethodDistributionProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\MethodDistributionProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import com.ocean.piuda.dashboard.enums.TransplantMethod;
@@ -12498,10 +11939,7 @@ public interface MethodDistributionProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\SpeciesStatusProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\SpeciesStatusProjection.java
 //package com.ocean.piuda.dashboard.repository.projection;
 //
 //public interface SpeciesStatusProjection {
@@ -12510,10 +11948,7 @@ File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\Speci
 //}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\TemperaturePointProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\TemperaturePointProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -12524,10 +11959,7 @@ public interface TemperaturePointProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\TransplantItemProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\TransplantItemProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import com.ocean.piuda.dashboard.enums.TransplantMethod;
@@ -12539,10 +11971,7 @@ public interface TransplantItemProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\WorkHistoryPointProjection.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\projection\WorkHistoryPointProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -12553,10 +11982,7 @@ public interface WorkHistoryPointProjection {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\TransplantLogRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\TransplantLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -12653,10 +12079,7 @@ public interface TransplantLogRepository extends JpaRepository<TransplantLog, Lo
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\WaterLogRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\repository\WaterLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.WaterLog;
@@ -12741,10 +12164,7 @@ public interface WaterLogRepository extends JpaRepository<WaterLog, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardAggregateBuilder.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardAggregateBuilder.java
 package com.ocean.piuda.dashboard.service;
 
 import com.ocean.piuda.dashboard.dto.TimeSeriesChartDto;
@@ -12949,10 +12369,7 @@ public class DashboardAggregateBuilder {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardCommandService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardCommandService.java
 package com.ocean.piuda.dashboard.service;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -13234,10 +12651,7 @@ public class DashboardCommandService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardQueryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\dashboard\service\DashboardQueryService.java
 package com.ocean.piuda.dashboard.service;
 import com.ocean.piuda.dashboard.dto.request.AreaPageRequest;
 import com.ocean.piuda.dashboard.enums.RestorationRegion;
@@ -13632,10 +13046,7 @@ public class DashboardQueryService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\divePoint\entity\DivePoint.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\divePoint\entity\DivePoint.java
 package com.ocean.piuda.divePoint.entity;
 
 import com.ocean.piuda.global.api.domain.BaseEntity;
@@ -13694,10 +13105,7 @@ public class DivePoint extends BaseEntity {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\divePoint\repository\DivePointRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\divePoint\repository\DivePointRepository.java
 package com.ocean.piuda.divePoint.repository;
 
 import com.ocean.piuda.divePoint.entity.DivePoint;
@@ -13710,10 +13118,7 @@ public interface DivePointRepository extends JpaRepository<DivePoint, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\client\dto\KhoaTideResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\client\dto\KhoaTideResponse.java
 package com.ocean.piuda.environment.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -13777,10 +13182,7 @@ public class KhoaTideResponse {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\client\dto\KmaSeaObsResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\client\dto\KmaSeaObsResponse.java
 package com.ocean.piuda.environment.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -13832,10 +13234,7 @@ public class KmaSeaObsResponse {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\client\dto\NifsRisaResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\client\dto\NifsRisaResponse.java
 package com.ocean.piuda.environment.client.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -13979,10 +13378,7 @@ public class NifsRisaResponse {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\client\KhoaTideClient.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\client\KhoaTideClient.java
 package com.ocean.piuda.environment.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14102,10 +13498,7 @@ public class KhoaTideClient {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\client\KmaSeaObsClient.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\client\KmaSeaObsClient.java
 package com.ocean.piuda.environment.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14287,10 +13680,7 @@ public class KmaSeaObsClient {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\client\NifsRisaClient.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\client\NifsRisaClient.java
 package com.ocean.piuda.environment.client;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -14441,10 +13831,7 @@ public class NifsRisaClient {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\config\MarineWebClientConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\config\MarineWebClientConfig.java
 package com.ocean.piuda.environment.config;
 
 import org.springframework.context.annotation.Bean;
@@ -14472,10 +13859,7 @@ public class MarineWebClientConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\controller\EnvironmentSummaryController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\controller\EnvironmentSummaryController.java
 package com.ocean.piuda.environment.controller;
 
 import com.ocean.piuda.environment.dto.EnvironmentSummaryRequest;
@@ -14520,10 +13904,7 @@ public class EnvironmentSummaryController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\domain\MarineStation.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\domain\MarineStation.java
 package com.ocean.piuda.environment.domain;
 
 import com.ocean.piuda.global.api.domain.BaseEntity;
@@ -14591,10 +13972,7 @@ public class MarineStation extends BaseEntity {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\domain\StationSource.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\domain\StationSource.java
 package com.ocean.piuda.environment.domain;
 
 /**
@@ -14608,10 +13986,7 @@ public enum StationSource {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\dto\EnvironmentSummaryRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\dto\EnvironmentSummaryRequest.java
 package com.ocean.piuda.environment.dto;
 
 import jakarta.validation.constraints.DecimalMax;
@@ -14659,10 +14034,7 @@ public record EnvironmentSummaryRequest(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\dto\EnvironmentSummaryResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\dto\EnvironmentSummaryResponse.java
 package com.ocean.piuda.environment.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
@@ -14736,10 +14108,7 @@ public record EnvironmentSummaryResponse(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\initializer\MarineStationInitializer.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\initializer\MarineStationInitializer.java
 package com.ocean.piuda.environment.initializer;
 
 import com.ocean.piuda.environment.client.KmaSeaObsClient;
@@ -15205,10 +14574,7 @@ public class MarineStationInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\ProjectExporter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\ProjectExporter.java
 package com.ocean.piuda.environment;
 
 import java.io.IOException;
@@ -15351,10 +14717,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\properties\MarineApiProperties.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\properties\MarineApiProperties.java
 package com.ocean.piuda.environment.properties;
 
 import lombok.Getter;
@@ -15439,10 +14802,7 @@ public class MarineApiProperties {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\repository\MarineStationRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\repository\MarineStationRepository.java
 package com.ocean.piuda.environment.repository;
 
 import com.ocean.piuda.environment.domain.MarineStation;
@@ -15476,10 +14836,7 @@ public interface MarineStationRepository extends JpaRepository<MarineStation, Lo
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\service\EnvironmentSummaryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\service\EnvironmentSummaryService.java
 package com.ocean.piuda.environment.service;
 
 import com.ocean.piuda.environment.dto.EnvironmentSummaryRequest;
@@ -15501,10 +14858,7 @@ public interface EnvironmentSummaryService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\service\EnvironmentSummaryServiceImpl.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\service\EnvironmentSummaryServiceImpl.java
 package com.ocean.piuda.environment.service;
 
 import com.ocean.piuda.environment.client.KhoaTideClient;
@@ -16010,10 +15364,7 @@ public class EnvironmentSummaryServiceImpl implements EnvironmentSummaryService 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\environment\util\DistanceCalculator.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\environment\util\DistanceCalculator.java
 package com.ocean.piuda.environment.util;
 
 /**
@@ -16061,10 +15412,7 @@ public class DistanceCalculator {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\controller\GarminActivityController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\controller\GarminActivityController.java
 package com.ocean.piuda.garmin.controller;
 
 
@@ -16158,10 +15506,7 @@ public class GarminActivityController {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\controller\WatchController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\controller\WatchController.java
 package com.ocean.piuda.garmin.controller;
 
 import com.ocean.piuda.garmin.dto.request.WatchPairRequest;
@@ -16214,10 +15559,7 @@ public class WatchController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\dto\request\ActivitySessionRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\dto\request\ActivitySessionRequest.java
 package com.ocean.piuda.garmin.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
@@ -16314,10 +15656,7 @@ public record ActivitySessionRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\dto\request\GarminActivityPageRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\dto\request\GarminActivityPageRequest.java
 package com.ocean.piuda.garmin.dto.request;
 
 import com.ocean.piuda.garmin.enums.GarminActivitySort;
@@ -16343,10 +15682,7 @@ public class GarminActivityPageRequest extends PageRequest<GarminActivitySort> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\dto\request\WatchPairRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\dto\request\WatchPairRequest.java
 package com.ocean.piuda.garmin.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
@@ -16357,10 +15693,7 @@ public record WatchPairRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\dto\response\ActivitySessionResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\dto\response\ActivitySessionResponse.java
 package com.ocean.piuda.garmin.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -16456,10 +15789,7 @@ public record ActivitySessionResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\dto\response\WatchPairResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\dto\response\WatchPairResponse.java
 package com.ocean.piuda.garmin.dto.response;
 
 
@@ -16469,10 +15799,7 @@ public record WatchPairResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\entity\GarminActivityLog.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\entity\GarminActivityLog.java
 package com.ocean.piuda.garmin.entity;
 
 import com.ocean.piuda.garmin.enums.GarminActivityType;
@@ -16534,10 +15861,7 @@ public class GarminActivityLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\enums\GarminActivitySort.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\enums\GarminActivitySort.java
 package com.ocean.piuda.garmin.enums;
 
 import com.ocean.piuda.global.enums.SortEnum;
@@ -16558,10 +15882,7 @@ public enum GarminActivitySort implements SortEnum {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\enums\GarminActivityType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\enums\GarminActivityType.java
 package com.ocean.piuda.garmin.enums;
 
 public enum GarminActivityType {
@@ -16571,10 +15892,7 @@ public enum GarminActivityType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\enums\TransplantStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\enums\TransplantStatus.java
 package com.ocean.piuda.garmin.enums;
 
 public enum TransplantStatus {
@@ -16582,10 +15900,7 @@ public enum TransplantStatus {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\repository\GarminActivityLogRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\repository\GarminActivityLogRepository.java
 package com.ocean.piuda.garmin.repository;
 
 import com.ocean.piuda.garmin.entity.GarminActivityLog;
@@ -16629,10 +15944,7 @@ public interface GarminActivityLogRepository extends JpaRepository<GarminActivit
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\service\GarminActivityCommandService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\service\GarminActivityCommandService.java
 package com.ocean.piuda.garmin.service;
 
 import com.ocean.piuda.garmin.dto.request.ActivitySessionRequest;
@@ -16704,10 +16016,7 @@ public class GarminActivityCommandService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\service\GarminActivityQueryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\service\GarminActivityQueryService.java
 package com.ocean.piuda.garmin.service;
 
 
@@ -16790,10 +16099,7 @@ public class GarminActivityQueryService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\service\WatchPairingCommandService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\service\WatchPairingCommandService.java
 package com.ocean.piuda.garmin.service;
 
 
@@ -16845,10 +16151,7 @@ public class WatchPairingCommandService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\service\WatchPairingQueryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\service\WatchPairingQueryService.java
 package com.ocean.piuda.garmin.service;
 
 
@@ -16881,10 +16184,7 @@ public class WatchPairingQueryService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\util\GarminUtils.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\util\GarminUtils.java
 package com.ocean.piuda.garmin.util;
 
 import com.ocean.piuda.global.api.exception.BusinessException;
@@ -16991,10 +16291,7 @@ public final class GarminUtils {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\garmin\util\WatchApiKeyValidator.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\garmin\util\WatchApiKeyValidator.java
 package com.ocean.piuda.garmin.util;
 
 
@@ -17020,10 +16317,7 @@ public class WatchApiKeyValidator {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\domain\BaseEntity.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\domain\BaseEntity.java
 package com.ocean.piuda.global.api.domain;
 
 
@@ -17057,10 +16351,7 @@ public abstract class BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\dto\ApiData.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\dto\ApiData.java
 package com.ocean.piuda.global.api.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17177,10 +16468,7 @@ public class ApiData<T> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\dto\ApiDataAdvice.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\dto\ApiDataAdvice.java
 package com.ocean.piuda.global.api.dto;
 
 import com.ocean.piuda.global.api.exception.BusinessException;
@@ -17233,10 +16521,7 @@ public class ApiDataAdvice implements ResponseBodyAdvice<Object> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\dto\ApiHeader.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\dto\ApiHeader.java
 package com.ocean.piuda.global.api.dto;
 
 public record ApiHeader(
@@ -17250,10 +16535,7 @@ public record ApiHeader(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\dto\PageRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\dto\PageRequest.java
 package com.ocean.piuda.global.api.dto;
 
 import com.ocean.piuda.global.enums.SortEnum;
@@ -17295,10 +16577,7 @@ public class PageRequest<T extends Enum<T> & SortEnum> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\dto\PageResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\dto\PageResponse.java
 package com.ocean.piuda.global.api.dto;
 
 import org.springframework.data.domain.Page;
@@ -17332,10 +16611,7 @@ public record PageResponse<T>(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\exception\BusinessException.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\exception\BusinessException.java
 package com.ocean.piuda.global.api.exception;
 
 
@@ -17366,10 +16642,7 @@ public class BusinessException extends RuntimeException {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\exception\ExceptionType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\exception\ExceptionType.java
 package com.ocean.piuda.global.api.exception;
 
 import lombok.AllArgsConstructor;
@@ -17449,10 +16722,7 @@ public enum ExceptionType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\api\exception\GlobalExceptionHandler.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\api\exception\GlobalExceptionHandler.java
 package com.ocean.piuda.global.api.exception;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17601,10 +16871,7 @@ public class GlobalExceptionHandler {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\config\JpaConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\config\JpaConfig.java
 package com.ocean.piuda.global.config;
 
 import org.springframework.context.annotation.Configuration;
@@ -17616,10 +16883,7 @@ public class JpaConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\config\RestClientConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\config\RestClientConfig.java
 package com.ocean.piuda.global.config;
 
 import org.springframework.context.annotation.Bean;
@@ -17636,10 +16900,7 @@ public class RestClientConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\config\RestTemplateConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\config\RestTemplateConfig.java
 package com.ocean.piuda.global.config;
 
 import org.springframework.boot.web.client.RestTemplateBuilder;
@@ -17657,10 +16918,7 @@ public class RestTemplateConfig {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\config\SwaggerConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\config\SwaggerConfig.java
 package com.ocean.piuda.global.config;
 
 
@@ -17695,10 +16953,7 @@ public class SwaggerConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\config\WebClientConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\config\WebClientConfig.java
 package com.ocean.piuda.global.config;
 
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -17722,10 +16977,7 @@ public class WebClientConfig {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\enums\SortEnum.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\enums\SortEnum.java
 package com.ocean.piuda.global.enums;
 
 import org.springframework.data.domain.Sort;
@@ -17744,10 +16996,147 @@ public interface SortEnum {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\util\GeometryUtils.java
-================================================================================
+# File Path: .\src\main\java\com\ocean\piuda\global\ProjectExporter.java
+package com.ocean.piuda.global;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+# File Path: .\src\main\java\com\ocean\piuda\global\util\GeometryUtils.java
 package com.ocean.piuda.global.util;
 
 import org.locationtech.jts.geom.Coordinate;
@@ -17771,10 +17160,7 @@ public class GeometryUtils {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\global\util\MultipartJackson2HttpMessageConverter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\global\util\MultipartJackson2HttpMessageConverter.java
 package com.ocean.piuda.global.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.MediaType;
@@ -17813,10 +17199,7 @@ public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpM
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\controller\MissionController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\controller\MissionController.java
 package com.ocean.piuda.mission.controller;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -17907,10 +17290,7 @@ public class MissionController {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\domain\Mission.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\domain\Mission.java
 package com.ocean.piuda.mission.domain;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -18012,10 +17392,7 @@ public class Mission extends BaseEntity {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionCreateRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionCreateRequest.java
 package com.ocean.piuda.mission.dto;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -18069,10 +17446,7 @@ public record MissionCreateRequest(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionResponse.java
 package com.ocean.piuda.mission.dto;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -18118,10 +17492,7 @@ public record MissionResponse(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionSearchCondition.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionSearchCondition.java
 package com.ocean.piuda.mission.dto;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -18137,10 +17508,7 @@ public record MissionSearchCondition(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionUpdateRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\dto\MissionUpdateRequest.java
 package com.ocean.piuda.mission.dto;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -18162,10 +17530,7 @@ public record MissionUpdateRequest(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\enums\MissionStatus.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\enums\MissionStatus.java
 package com.ocean.piuda.mission.enums;
 
 public enum MissionStatus {
@@ -18176,10 +17541,7 @@ public enum MissionStatus {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\ProjectExporter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\ProjectExporter.java
 package com.ocean.piuda.mission;
 
 import java.io.IOException;
@@ -18321,10 +17683,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\repository\MissionRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\repository\MissionRepository.java
 package com.ocean.piuda.mission.repository;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -18344,10 +17703,7 @@ public interface MissionRepository extends JpaRepository<Mission, Long>, JpaSpec
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\service\MissionService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\service\MissionService.java
 package com.ocean.piuda.mission.service;
 
 import com.ocean.piuda.mission.dto.*;
@@ -18384,10 +17740,7 @@ public interface MissionService {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\mission\service\MissionServiceImpl.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\mission\service\MissionServiceImpl.java
 package com.ocean.piuda.mission.service;
 
 import com.ocean.piuda.global.api.exception.BusinessException;
@@ -18523,10 +17876,7 @@ public class MissionServiceImpl implements MissionService {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\config\FirebaseConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\config\FirebaseConfig.java
 package com.ocean.piuda.notification.config;
 
 import com.google.auth.oauth2.GoogleCredentials;
@@ -18568,10 +17918,7 @@ public class FirebaseConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\controller\FcmController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\controller\FcmController.java
 package com.ocean.piuda.notification.controller;
 
 import com.ocean.piuda.global.api.dto.ApiData;
@@ -18676,10 +18023,7 @@ public class FcmController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\dto\request\SaveTokenRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\dto\request\SaveTokenRequest.java
 package com.ocean.piuda.notification.dto.request;
 
 
@@ -18692,10 +18036,7 @@ public record SaveTokenRequest(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\dto\request\SendNotificationRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\dto\request\SendNotificationRequest.java
 package com.ocean.piuda.notification.dto.request;
 
 import java.util.List;
@@ -18710,10 +18051,7 @@ public record SendNotificationRequest(
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\dto\response\FcmTokenResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\dto\response\FcmTokenResponse.java
 package com.ocean.piuda.notification.dto.response;
 
 
@@ -18737,10 +18075,7 @@ public record FcmTokenResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\dto\response\FcmTokensResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\dto\response\FcmTokensResponse.java
 package com.ocean.piuda.notification.dto.response;
 
 import com.ocean.piuda.notification.entity.FcmToken;
@@ -18764,10 +18099,7 @@ public record FcmTokensResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\dto\response\SendResultResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\dto\response\SendResultResponse.java
 package com.ocean.piuda.notification.dto.response;
 
 import lombok.Builder;
@@ -18782,10 +18114,7 @@ public record SendResultResponse(
 ) {}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\entity\FcmToken.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\entity\FcmToken.java
 package com.ocean.piuda.notification.entity;
 
 
@@ -18839,10 +18168,7 @@ public class FcmToken extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\enums\Platform.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\enums\Platform.java
 package com.ocean.piuda.notification.enums;
 
 public enum Platform {
@@ -18850,10 +18176,7 @@ public enum Platform {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\repository\FcmTokenRepository.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\repository\FcmTokenRepository.java
 package com.ocean.piuda.notification.repository;
 
 
@@ -18872,10 +18195,7 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\service\FcmCommandService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\service\FcmCommandService.java
 package com.ocean.piuda.notification.service;
 
 import com.google.firebase.messaging.*;
@@ -19049,10 +18369,7 @@ public class FcmCommandService {
 
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\notification\service\FcmQueryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\notification\service\FcmQueryService.java
 package com.ocean.piuda.notification.service;
 
 import com.ocean.piuda.notification.entity.FcmToken;
@@ -19077,10 +18394,7 @@ public class FcmQueryService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\PiudaApplication.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\PiudaApplication.java
 package com.ocean.piuda;
 
 import org.springframework.boot.SpringApplication;
@@ -19096,10 +18410,7 @@ public class PiudaApplication {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\config\PasswordConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\config\PasswordConfig.java
 package com.ocean.piuda.security.jwt.config;
 
 import org.springframework.context.annotation.Bean;
@@ -19116,10 +18427,7 @@ public class PasswordConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\config\SecurityConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\config\SecurityConfig.java
 package com.ocean.piuda.security.jwt.config;
 
 import com.ocean.piuda.security.jwt.util.JwtTokenProvider;
@@ -19201,10 +18509,7 @@ public class SecurityConfig {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\config\WebConfig.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\config\WebConfig.java
 package com.ocean.piuda.security.jwt.config;
 
 import org.springframework.context.annotation.Configuration;
@@ -19227,10 +18532,7 @@ public class WebConfig implements WebMvcConfigurer {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\controller\AuthController.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\controller\AuthController.java
 package com.ocean.piuda.security.jwt.controller;
 
 import com.ocean.piuda.global.api.dto.ApiData;
@@ -19322,7 +18624,7 @@ public class AuthController {
             HttpServletResponse response
     ) {
         // 쿠키 삭제
-        ResponseCookie logoutCookie = tokenCookieFactory.buildLogoutCookie();
+        ResponseCookie logoutCookie = tokenCookieFactory.deleteAccessTokenCookie();
         response.addHeader(HttpHeaders.SET_COOKIE, logoutCookie.toString());
         
         return ResponseEntity.ok(ApiData.ok(null));
@@ -19331,10 +18633,7 @@ public class AuthController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\request\SignUpRequestDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\request\SignUpRequestDto.java
 package com.ocean.piuda.security.jwt.dto.request;
 
 
@@ -19364,10 +18663,7 @@ public class SignUpRequestDto {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\request\UsernameLoginRequestDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\request\UsernameLoginRequestDto.java
 package com.ocean.piuda.security.jwt.dto.request;
 
 import lombok.*;
@@ -19387,10 +18683,7 @@ public class UsernameLoginRequestDto {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\request\UserUpdateRequestDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\request\UserUpdateRequestDto.java
 package com.ocean.piuda.security.jwt.dto.request;
 
 import lombok.*;
@@ -19411,10 +18704,7 @@ public class UserUpdateRequestDto {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\response\SignUpResponseDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\response\SignUpResponseDto.java
 package com.ocean.piuda.security.jwt.dto.response;
 
 import lombok.Builder;
@@ -19436,10 +18726,7 @@ public class SignUpResponseDto {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\response\TokenResponseDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\response\TokenResponseDto.java
 package com.ocean.piuda.security.jwt.dto.response;
 
 import lombok.AllArgsConstructor;
@@ -19454,10 +18741,7 @@ public class TokenResponseDto {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\response\UsernameLoginResponseDto.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\dto\response\UsernameLoginResponseDto.java
 package com.ocean.piuda.security.jwt.dto.response;
 
 
@@ -19478,10 +18762,7 @@ public class UsernameLoginResponseDto {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\enums\Role.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\enums\Role.java
 package com.ocean.piuda.security.jwt.enums;
 
 import lombok.Getter;
@@ -19506,10 +18787,7 @@ public enum Role {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\filter\JwtAuthenticationFilter.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\filter\JwtAuthenticationFilter.java
 package com.ocean.piuda.security.jwt.filter;
 
 
@@ -19563,7 +18841,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (token != null && jwtTokenProvider.isValidToken(token)) {
             Long id =jwtTokenProvider.extractId(token);  // JWT에서 사용자명 추출
 
-            log.debug("[JwtAuthenticationFilter] deviceId from token: {}", id);
+            log.debug("[JwtAuthenticationFilter] userId from token: {}", id);
 
             // UserDetailsService 를 통해 사용자 정보 로드
             PrincipalDetails userDetails = (PrincipalDetails) customUserDetailsService.loadUserById(id);
@@ -19582,10 +18860,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\handler\CustomAccessDeniedHandler.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\handler\CustomAccessDeniedHandler.java
 package com.ocean.piuda.security.jwt.handler;
 
 
@@ -19625,10 +18900,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\handler\CustomAuthenticationEntryPoint.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\handler\CustomAuthenticationEntryPoint.java
 package com.ocean.piuda.security.jwt.handler;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -19655,7 +18927,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                          AuthenticationException authException) throws IOException {
 
 
-        ApiData<?> apiData = ApiData.error(ExceptionType.ACCESS_DENIED);
+        ApiData<?> apiData = ApiData.error(ExceptionType.UNAUTHORIZED_USER);
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
@@ -19666,10 +18938,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\principal\CustomUserDetails.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\principal\CustomUserDetails.java
 package com.ocean.piuda.security.jwt.principal;
 
 
@@ -19708,10 +18977,7 @@ package com.ocean.piuda.security.jwt.principal;
 //
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\service\AuthService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\service\AuthService.java
 package com.ocean.piuda.security.jwt.service;
 
 import com.ocean.piuda.global.api.exception.BusinessException;
@@ -19830,10 +19096,7 @@ public class AuthService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\service\CustomUserDetailsService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\service\CustomUserDetailsService.java
 package com.ocean.piuda.security.jwt.service;
 
 
@@ -19874,10 +19137,7 @@ public class CustomUserDetailsService implements UserDetailsService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\service\TokenUserService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\service\TokenUserService.java
 package com.ocean.piuda.security.jwt.service;
 
 
@@ -19954,10 +19214,7 @@ public class TokenUserService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\util\JwtTokenProvider.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\util\JwtTokenProvider.java
 package com.ocean.piuda.security.jwt.util;
 
 
@@ -20053,10 +19310,7 @@ public class JwtTokenProvider {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\jwt\util\TokenCookieFactory.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\jwt\util\TokenCookieFactory.java
 package com.ocean.piuda.security.jwt.util;
 
 import lombok.RequiredArgsConstructor;
@@ -20126,26 +19380,11 @@ public class TokenCookieFactory {
         }
     }
 
-    /**
-     * 로그아웃용 쿠키 삭제 (maxAge=0)
-     */
-    public ResponseCookie buildLogoutCookie() {
-        return ResponseCookie.from(ACCESS_TOKEN_COOKIE, "")
-                .httpOnly(true)
-                .sameSite("None")
-                .secure(true)
-                .path("/")
-                .maxAge(0)  // 즉시 삭제
-                .build();
-    }
 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\enums\ProviderType.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\enums\ProviderType.java
 package com.ocean.piuda.security.oauth2.enums;
 
 import java.util.Arrays;
@@ -20168,10 +19407,7 @@ public enum ProviderType {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\handler\OAuth2FailureHandler.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\handler\OAuth2FailureHandler.java
 package com.ocean.piuda.security.oauth2.handler;
 
 import jakarta.servlet.ServletException;
@@ -20207,10 +19443,7 @@ public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\handler\OAuth2SuccessHandler.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\handler\OAuth2SuccessHandler.java
 package com.ocean.piuda.security.oauth2.handler;
 
 import com.ocean.piuda.security.jwt.util.TokenCookieFactory;
@@ -20311,10 +19544,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\info\OAuth2UserInfo.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\info\OAuth2UserInfo.java
 package com.ocean.piuda.security.oauth2.info;
 
 import com.ocean.piuda.security.oauth2.enums.ProviderType;
@@ -20361,10 +19591,7 @@ public class OAuth2UserInfo {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\info\OAuth2UserInfoFactory.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\info\OAuth2UserInfoFactory.java
 package com.ocean.piuda.security.oauth2.info;
 
 
@@ -20422,10 +19649,7 @@ public class OAuth2UserInfoFactory {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\principal\PrincipalDetails.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\principal\PrincipalDetails.java
 package com.ocean.piuda.security.oauth2.principal;
 
 import com.ocean.piuda.user.entity.User;
@@ -20495,10 +19719,7 @@ public class PrincipalDetails implements OAuth2User, UserDetails {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\principal\UserPrincipal.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\principal\UserPrincipal.java
 package com.ocean.piuda.security.oauth2.principal;
 
 
@@ -20531,10 +19752,7 @@ package com.ocean.piuda.security.oauth2.principal;
 //}
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\security\oauth2\service\CustomOAuth2UserService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\security\oauth2\service\CustomOAuth2UserService.java
 package com.ocean.piuda.security.oauth2.service;
 
 
@@ -20624,10 +19842,147 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\controller\UserController.java
-================================================================================
+# File Path: .\src\main\java\com\ocean\piuda\security\ProjectExporter.java
+package com.ocean.piuda.security;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+# File Path: .\src\main\java\com\ocean\piuda\user\controller\UserController.java
 package com.ocean.piuda.user.controller;
 
 import com.ocean.piuda.global.api.dto.ApiData;
@@ -20656,7 +20011,7 @@ public class UserController {
     private final TokenUserService tokenUserService;
     private final UserAggregateBuilder aggregateBuilder;
 
-    @PatchMapping("/{deviceId}")
+    @PatchMapping("/{userId}")
     @Operation(summary = "유저 정보 수정", description = "특정 유저의 닉네임, 이메일, 전화번호 등 기본 정보를 수정합니다.")
     public ApiData<Boolean> patchUser(
             @PathVariable Long userId,
@@ -20676,7 +20031,7 @@ public class UserController {
         return ApiData.ok(userQueryService.searchByNicknameOrUsername(req));
     }
 
-    @GetMapping("/{deviceId}/info")
+    @GetMapping("/{userId}/info")
     @Operation(summary = "유저 상세 조회", description = "id 기반으로 특정 유저의 상세 정보를 조회합니다.")
     public ApiData<DetailedUserResponse> getUserById(@PathVariable Long userId) {
         return ApiData.ok(aggregateBuilder.build(userQueryService.getUserById(userId)));
@@ -20692,10 +20047,7 @@ public class UserController {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\dto\request\UserSearchRequest.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\user\dto\request\UserSearchRequest.java
 package com.ocean.piuda.user.dto.request;
 
 import lombok.Builder;
@@ -20713,10 +20065,7 @@ public record UserSearchRequest(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\dto\response\DetailedUserResponse.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\user\dto\response\DetailedUserResponse.java
 package com.ocean.piuda.user.dto.response;
 
 import com.ocean.piuda.user.entity.User;
@@ -20750,10 +20099,7 @@ public record DetailedUserResponse(
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\entity\User.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\user\entity\User.java
 package com.ocean.piuda.user.entity;
 
 import com.ocean.piuda.global.api.domain.BaseEntity;
@@ -20828,10 +20174,148 @@ public class User extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\repository\UserRepository.java
-================================================================================
+# File Path: .\src\main\java\com\ocean\piuda\user\ProjectExporter.java
+package com.ocean.piuda.user;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+# File Path: .\src\main\java\com\ocean\piuda\user\repository\UserRepository.java
 package com.ocean.piuda.user.repository;
 
 import com.ocean.piuda.security.oauth2.enums.ProviderType;
@@ -20877,10 +20361,7 @@ public interface UserRepository extends JpaRepository<User , Long> {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\service\UserAggregateBuilder.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\user\service\UserAggregateBuilder.java
 package com.ocean.piuda.user.service;
 
 import com.ocean.piuda.user.dto.response.DetailedUserResponse;
@@ -20913,10 +20394,7 @@ public class UserAggregateBuilder {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\service\UserCommandService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\user\service\UserCommandService.java
 package com.ocean.piuda.user.service;
 
 import com.ocean.piuda.security.jwt.dto.request.UserUpdateRequestDto;
@@ -20949,10 +20427,7 @@ public class UserCommandService {
 }
 
 
-================================================================================
-File Path: .\src\main\java\com\ocean\piuda\user\service\UserQueryService.java
-================================================================================
-
+# File Path: .\src\main\java\com\ocean\piuda\user\service\UserQueryService.java
 package com.ocean.piuda.user.service;
 
 import com.ocean.piuda.global.api.exception.BusinessException;
@@ -21008,27 +20483,18 @@ public class UserQueryService {
 }
 
 
-================================================================================
-File Path: .\src\main\resources\data.sql
-================================================================================
-
+# File Path: .\src\main\resources\data.sql
 -- PostGIS 확장 활성화 (geometry 타입 사용을 위해 필요)
 CREATE EXTENSION IF NOT EXISTS postgis;
 
 
-================================================================================
-File Path: .\src\main\resources\schema.sql
-================================================================================
-
+# File Path: .\src\main\resources\schema.sql
 -- PostGIS 확장 활성화 (geometry 타입 사용을 위해 필요)
 -- Hibernate가 스키마를 생성하기 전에 실행되어야 함
 CREATE EXTENSION IF NOT EXISTS postgis;
 
 
-================================================================================
-File Path: .\src\test\java\com\ocean\piuda\PiudaApplicationTests.java
-================================================================================
-
+# File Path: .\src\test\java\com\ocean\piuda\PiudaApplicationTests.java
 package com.ocean.piuda;
 
 import org.junit.jupiter.api.Test;

--- a/src/main/java/com/ocean/piuda/admin/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/admin/ProjectExporter.java
@@ -5,7 +5,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ProjectExporter {
@@ -119,9 +118,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {

--- a/src/main/java/com/ocean/piuda/admin/project_context.txt
+++ b/src/main/java/com/ocean/piuda/admin/project_context.txt
@@ -1,8 +1,5 @@
 
-================================================================================
-File Path: .\common\enums\ActivityType.java
-================================================================================
-
+# File Path: .\common\enums\ActivityType.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ActivityType {
@@ -19,10 +16,7 @@ public enum ActivityType {
 }
 
 
-================================================================================
-File Path: .\common\enums\AuditAction.java
-================================================================================
-
+# File Path: .\common\enums\AuditAction.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum AuditAction {
@@ -34,10 +28,7 @@ public enum AuditAction {
 }
 
 
-================================================================================
-File Path: .\common\enums\BarrenExtent.java
-================================================================================
-
+# File Path: .\common\enums\BarrenExtent.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -57,10 +48,7 @@ public enum BarrenExtent {
 }
 
 
-================================================================================
-File Path: .\common\enums\CleanupMethodType.java
-================================================================================
-
+# File Path: .\common\enums\CleanupMethodType.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -80,10 +68,7 @@ public enum CleanupMethodType {
 }
 
 
-================================================================================
-File Path: .\common\enums\DensityLevel.java
-================================================================================
-
+# File Path: .\common\enums\DensityLevel.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -106,10 +91,7 @@ public enum DensityLevel {
 }
 
 
-================================================================================
-File Path: .\common\enums\ExportFormat.java
-================================================================================
-
+# File Path: .\common\enums\ExportFormat.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ExportFormat {
@@ -118,10 +100,7 @@ public enum ExportFormat {
 }
 
 
-================================================================================
-File Path: .\common\enums\ExportStatus.java
-================================================================================
-
+# File Path: .\common\enums\ExportStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ExportStatus {
@@ -131,10 +110,7 @@ public enum ExportStatus {
 }
 
 
-================================================================================
-File Path: .\common\enums\GrazerSpeciesType.java
-================================================================================
-
+# File Path: .\common\enums\GrazerSpeciesType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -149,10 +125,7 @@ public enum GrazerSpeciesType {
 }
 
 
-================================================================================
-File Path: .\common\enums\HealthStatus.java
-================================================================================
-
+# File Path: .\common\enums\HealthStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -173,10 +146,7 @@ public enum HealthStatus {
 }
 
 
-================================================================================
-File Path: .\common\enums\MarineCondition.java
-================================================================================
-
+# File Path: .\common\enums\MarineCondition.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -189,10 +159,7 @@ public enum MarineCondition {
 }
 
 
-================================================================================
-File Path: .\common\enums\ParticipantRole.java
-================================================================================
-
+# File Path: .\common\enums\ParticipantRole.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum ParticipantRole {
@@ -203,10 +170,7 @@ public enum ParticipantRole {
 }
 
 
-================================================================================
-File Path: .\common\enums\RockFeature.java
-================================================================================
-
+# File Path: .\common\enums\RockFeature.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -228,10 +192,7 @@ public enum RockFeature {
 }
 
 
-================================================================================
-File Path: .\common\enums\SeaweedHealthStatus.java
-================================================================================
-
+# File Path: .\common\enums\SeaweedHealthStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -251,10 +212,7 @@ public enum SeaweedHealthStatus {
 }
 
 
-================================================================================
-File Path: .\common\enums\SubmissionStatus.java
-================================================================================
-
+# File Path: .\common\enums\SubmissionStatus.java
 package com.ocean.piuda.admin.common.enums;
 
 public enum SubmissionStatus {
@@ -265,10 +223,7 @@ public enum SubmissionStatus {
 }
 
 
-================================================================================
-File Path: .\common\enums\SubstrateTargetType.java
-================================================================================
-
+# File Path: .\common\enums\SubstrateTargetType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -282,10 +237,7 @@ public enum SubstrateTargetType {
 }
 
 
-================================================================================
-File Path: .\common\enums\Suitability.java
-================================================================================
-
+# File Path: .\common\enums\Suitability.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -304,10 +256,7 @@ public enum Suitability {
 }
 
 
-================================================================================
-File Path: .\common\enums\TerrainType.java
-================================================================================
-
+# File Path: .\common\enums\TerrainType.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -328,10 +277,7 @@ public enum TerrainType {
 }
 
 
-================================================================================
-File Path: .\common\enums\TransplantLocationType.java
-================================================================================
-
+# File Path: .\common\enums\TransplantLocationType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -344,10 +290,7 @@ public enum TransplantLocationType {
 }
 
 
-================================================================================
-File Path: .\common\enums\TransplantMethodType.java
-================================================================================
-
+# File Path: .\common\enums\TransplantMethodType.java
 package com.ocean.piuda.admin.common.enums;
 
 import lombok.Getter;
@@ -367,10 +310,7 @@ public enum TransplantMethodType {
 }
 
 
-================================================================================
-File Path: .\common\enums\TransplantSpeciesType.java
-================================================================================
-
+# File Path: .\common\enums\TransplantSpeciesType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -386,10 +326,7 @@ public enum TransplantSpeciesType {
 }
 
 
-================================================================================
-File Path: .\common\enums\UncollectedScale.java
-================================================================================
-
+# File Path: .\common\enums\UncollectedScale.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -402,10 +339,7 @@ public enum UncollectedScale {
 }
 
 
-================================================================================
-File Path: .\common\enums\WasteType.java
-================================================================================
-
+# File Path: .\common\enums\WasteType.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -421,10 +355,7 @@ public enum WasteType {
 }
 
 
-================================================================================
-File Path: .\common\enums\WorkScope.java
-================================================================================
-
+# File Path: .\common\enums\WorkScope.java
 package com.ocean.piuda.admin.common.enums;
 
 /**
@@ -437,10 +368,7 @@ public enum WorkScope {
 }
 
 
-================================================================================
-File Path: .\dashboard\controller\AdminDashboardController.java
-================================================================================
-
+# File Path: .\dashboard\controller\AdminDashboardController.java
 package com.ocean.piuda.admin.dashboard.controller;
 
 import com.ocean.piuda.admin.dashboard.dto.AdminDashboardSummaryResponse;
@@ -483,10 +411,7 @@ public class AdminDashboardController {
 }
 
 
-================================================================================
-File Path: .\dashboard\dto\AdminDashboardSummaryResponse.java
-================================================================================
-
+# File Path: .\dashboard\dto\AdminDashboardSummaryResponse.java
 package com.ocean.piuda.admin.dashboard.dto;
 
 public record AdminDashboardSummaryResponse(
@@ -508,10 +433,7 @@ public record AdminDashboardSummaryResponse(
 }
 
 
-================================================================================
-File Path: .\dashboard\service\AdminDashboardService.java
-================================================================================
-
+# File Path: .\dashboard\service\AdminDashboardService.java
 package com.ocean.piuda.admin.dashboard.service;
 
 import com.ocean.piuda.admin.common.enums.SubmissionStatus;
@@ -544,10 +466,7 @@ public class AdminDashboardService {
 }
 
 
-================================================================================
-File Path: .\export\controller\ExportController.java
-================================================================================
-
+# File Path: .\export\controller\ExportController.java
 package com.ocean.piuda.admin.export.controller;
 
 import com.ocean.piuda.admin.export.dto.request.ExportByIdsRequest;
@@ -693,10 +612,7 @@ public class ExportController {
 }
 
 
-================================================================================
-File Path: .\export\dto\request\ExportByIdsRequest.java
-================================================================================
-
+# File Path: .\export\dto\request\ExportByIdsRequest.java
 package com.ocean.piuda.admin.export.dto.request;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -721,10 +637,7 @@ public class ExportByIdsRequest {
 }
 
 
-================================================================================
-File Path: .\export\dto\request\ExportRequest.java
-================================================================================
-
+# File Path: .\export\dto\request\ExportRequest.java
 package com.ocean.piuda.admin.export.dto.request;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -758,10 +671,7 @@ public class ExportRequest {
 }
 
 
-================================================================================
-File Path: .\export\dto\response\ExportJobResponse.java
-================================================================================
-
+# File Path: .\export\dto\response\ExportJobResponse.java
 package com.ocean.piuda.admin.export.dto.response;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -803,10 +713,7 @@ public class ExportJobResponse {
 }
 
 
-================================================================================
-File Path: .\export\entity\ExportJob.java
-================================================================================
-
+# File Path: .\export\entity\ExportJob.java
 package com.ocean.piuda.admin.export.entity;
 
 import com.ocean.piuda.admin.common.enums.ExportFormat;
@@ -853,10 +760,7 @@ public class ExportJob extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\export\repository\ExportJobRepository.java
-================================================================================
-
+# File Path: .\export\repository\ExportJobRepository.java
 package com.ocean.piuda.admin.export.repository;
 
 import com.ocean.piuda.admin.export.entity.ExportJob;
@@ -872,10 +776,7 @@ public interface ExportJobRepository extends JpaRepository<ExportJob, Long> {
 }
 
 
-================================================================================
-File Path: .\export\service\ExportService.java
-================================================================================
-
+# File Path: .\export\service\ExportService.java
 package com.ocean.piuda.admin.export.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1208,10 +1109,7 @@ public class ExportService {
 }
 
 
-================================================================================
-File Path: .\initializer\AdminUserInitializer.java
-================================================================================
-
+# File Path: .\initializer\AdminUserInitializer.java
 package com.ocean.piuda.admin.initializer;
 
 import com.ocean.piuda.security.jwt.enums.Role;
@@ -1265,10 +1163,7 @@ public class AdminUserInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\ProjectExporter.java
-================================================================================
-
+# File Path: .\ProjectExporter.java
 package com.ocean.piuda.admin;
 
 import java.io.IOException;
@@ -1276,7 +1171,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 public class ProjectExporter {
@@ -1390,9 +1284,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {
@@ -1411,10 +1303,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\report\controller\ReportDraftController.java
-================================================================================
-
+# File Path: .\report\controller\ReportDraftController.java
 //package com.ocean.piuda.admin.report.controller;
 //import org.springframework.http.ContentDisposition;
 //import org.springframework.http.HttpHeaders;
@@ -1509,10 +1398,7 @@ File Path: .\report\controller\ReportDraftController.java
 //}
 
 
-================================================================================
-File Path: .\report\dto\request\ReportDraftByIdsRequest.java
-================================================================================
-
+# File Path: .\report\dto\request\ReportDraftByIdsRequest.java
 package com.ocean.piuda.admin.report.dto.request;
 
 import com.ocean.piuda.admin.report.enums.ReportDraftType;
@@ -1534,10 +1420,7 @@ public record ReportDraftByIdsRequest(
 ) {}
 
 
-================================================================================
-File Path: .\report\dto\request\ReportDraftByPeriodRequest.java
-================================================================================
-
+# File Path: .\report\dto\request\ReportDraftByPeriodRequest.java
 package com.ocean.piuda.admin.report.dto.request;
 
 import com.ocean.piuda.admin.report.enums.ReportDraftType;
@@ -1561,10 +1444,7 @@ public record ReportDraftByPeriodRequest(
 ) {}
 
 
-================================================================================
-File Path: .\report\dto\response\ReportDraftResponse.java
-================================================================================
-
+# File Path: .\report\dto\response\ReportDraftResponse.java
 package com.ocean.piuda.admin.report.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
@@ -1591,10 +1471,7 @@ public record ReportDraftResponse(
 ) {}
 
 
-================================================================================
-File Path: .\report\dto\response\ReportPdfResponse.java
-================================================================================
-
+# File Path: .\report\dto\response\ReportPdfResponse.java
 package com.ocean.piuda.admin.report.dto.response;
 
 public record ReportPdfResponse(
@@ -1603,10 +1480,7 @@ public record ReportPdfResponse(
 ) {}
 
 
-================================================================================
-File Path: .\report\enums\ReportDraftType.java
-================================================================================
-
+# File Path: .\report\enums\ReportDraftType.java
 package com.ocean.piuda.admin.report.enums;
 
 public enum ReportDraftType {
@@ -1627,10 +1501,7 @@ public enum ReportDraftType {
 }
 
 
-================================================================================
-File Path: .\report\service\ReportDraftService.java
-================================================================================
-
+# File Path: .\report\service\ReportDraftService.java
 /*
 package com.ocean.piuda.admin.report.service;
 
@@ -1918,10 +1789,7 @@ public class ReportDraftService {
  */
 
 
-================================================================================
-File Path: .\report\service\ReportPdfService.java
-================================================================================
-
+# File Path: .\report\service\ReportPdfService.java
 //
 //package com.ocean.piuda.admin.report.service;
 //
@@ -2129,10 +1997,7 @@ File Path: .\report\service\ReportPdfService.java
 //
 
 
-================================================================================
-File Path: .\report\util\ReportPromptBuilder.java
-================================================================================
-
+# File Path: .\report\util\ReportPromptBuilder.java
 package com.ocean.piuda.admin.report.util;
 
 import com.ocean.piuda.admin.report.enums.ReportDraftType;
@@ -2191,10 +2056,7 @@ public class ReportPromptBuilder {
 }
 
 
-================================================================================
-File Path: .\site\controller\SiteNameOptionController.java
-================================================================================
-
+# File Path: .\site\controller\SiteNameOptionController.java
 package com.ocean.piuda.admin.site.controller;
 
 import com.ocean.piuda.admin.site.dto.request.CreateSiteOptionRequest;
@@ -2247,10 +2109,7 @@ public class SiteNameOptionController {
     }}
 
 
-================================================================================
-File Path: .\site\dto\request\CreateSiteOptionRequest.java
-================================================================================
-
+# File Path: .\site\dto\request\CreateSiteOptionRequest.java
 package com.ocean.piuda.admin.site.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
@@ -2261,10 +2120,7 @@ public record CreateSiteOptionRequest(
 ) {}
 
 
-================================================================================
-File Path: .\site\dto\request\UpdateSiteOptionRequest.java
-================================================================================
-
+# File Path: .\site\dto\request\UpdateSiteOptionRequest.java
 package com.ocean.piuda.admin.site.dto.request;
 
 import jakarta.validation.constraints.Size;
@@ -2277,10 +2133,7 @@ public record UpdateSiteOptionRequest(
 ) {}
 
 
-================================================================================
-File Path: .\site\dto\response\SiteNameOptionResponse.java
-================================================================================
-
+# File Path: .\site\dto\response\SiteNameOptionResponse.java
 package com.ocean.piuda.admin.site.dto.response;
 
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
@@ -2295,10 +2148,7 @@ public record SiteNameOptionResponse(
 }
 
 
-================================================================================
-File Path: .\site\entity\SiteNameOption.java
-================================================================================
-
+# File Path: .\site\entity\SiteNameOption.java
 package com.ocean.piuda.admin.site.entity;
 
 import com.ocean.piuda.global.api.domain.BaseEntity;
@@ -2337,10 +2187,7 @@ public class SiteNameOption extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\site\repository\SiteNameOptionRepository.java
-================================================================================
-
+# File Path: .\site\repository\SiteNameOptionRepository.java
 package com.ocean.piuda.admin.site.repository;
 
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
@@ -2360,10 +2207,7 @@ public interface SiteNameOptionRepository extends JpaRepository<SiteNameOption, 
 }
 
 
-================================================================================
-File Path: .\site\service\SiteNameOptionService.java
-================================================================================
-
+# File Path: .\site\service\SiteNameOptionService.java
 package com.ocean.piuda.admin.site.service;
 
 
@@ -2448,10 +2292,7 @@ public class SiteNameOptionService {
 }
 
 
-================================================================================
-File Path: .\submission\controller\SubmissionController.java
-================================================================================
-
+# File Path: .\submission\controller\SubmissionController.java
 package com.ocean.piuda.admin.submission.controller;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -2495,7 +2336,7 @@ public class SubmissionController {
     /**
      * 기록 바로 제출 (SUBMITTED)
      */
-    @PostMapping("/submit")
+    @PostMapping
     @Operation(
             summary = "기록 제출 (신규 등록)",
             description = "새로운 활동 기록을 제출합니다. 상태는 '제출됨(SUBMITTED)'으로 저장되며, 관리자 승인 대기 상태가 됩니다."
@@ -2620,7 +2461,7 @@ public class SubmissionController {
     /**
      * 단건 삭제
      */
-    @DeleteMapping("/{submissionId}")
+    @DeleteMapping("/{submissionId:[0-9]+}")
     @Operation(summary = "단건 삭제", description = "특정 제출 데이터를 영구 삭제합니다.")
     @ApiResponses({
             @ApiResponse(responseCode = "204", description = "삭제 성공 (No Content)"),
@@ -2693,10 +2534,7 @@ public class SubmissionController {
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\BulkApproveRequest.java
-================================================================================
-
+# File Path: .\submission\dto\request\BulkApproveRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
@@ -2710,10 +2548,7 @@ public record BulkApproveRequest(
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\BulkDeleteRequest.java
-================================================================================
-
+# File Path: .\submission\dto\request\BulkDeleteRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.constraints.NotEmpty;
@@ -2729,10 +2564,7 @@ public record BulkDeleteRequest(
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\BulkRejectRequest.java
-================================================================================
-
+# File Path: .\submission\dto\request\BulkRejectRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.Valid;
@@ -2752,10 +2584,7 @@ public record BulkRejectRequest(
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\CreateSubmissionRequest.java
-================================================================================
-
+# File Path: .\submission\dto\request\CreateSubmissionRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -2793,15 +2622,7 @@ public class CreateSubmissionRequest {
     @NotNull(message = "작업 유형은 필수입니다")
     private ActivityType activityType;
 
-    @NotBlank(message = "작성자명은 필수입니다")
-    private String authorName;
-
-    private String authorEmail;
-
     private String workDescription;  // 작업 내용
-
-    private BigDecimal latitude;
-    private BigDecimal longitude;
 
     @Valid
     @NotNull(message = "기본 환경 정보는 필수입니다")
@@ -3082,10 +2903,7 @@ public class CreateSubmissionRequest {
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\RejectReasonDto.java
-================================================================================
-
+# File Path: .\submission\dto\request\RejectReasonDto.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 public record RejectReasonDto(
@@ -3095,10 +2913,7 @@ public record RejectReasonDto(
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\SingleDeleteRequest.java
-================================================================================
-
+# File Path: .\submission\dto\request\SingleDeleteRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 public record SingleDeleteRequest(
@@ -3107,10 +2922,7 @@ public record SingleDeleteRequest(
 }
 
 
-================================================================================
-File Path: .\submission\dto\request\SingleRejectRequest.java
-================================================================================
-
+# File Path: .\submission\dto\request\SingleRejectRequest.java
 package com.ocean.piuda.admin.submission.dto.request;
 
 import jakarta.validation.Valid;
@@ -3124,10 +2936,7 @@ public record SingleRejectRequest(
 }
 
 
-================================================================================
-File Path: .\submission\dto\response\AttachmentResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\AttachmentResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.submission.entity.Attachment;
@@ -3156,10 +2965,7 @@ public record AttachmentResponse(
 }
 
 
-================================================================================
-File Path: .\submission\dto\response\AuditLogResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\AuditLogResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.AuditAction;
@@ -3187,10 +2993,7 @@ public record AuditLogResponse(
 }
 
 
-================================================================================
-File Path: .\submission\dto\response\BasicEnvResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\BasicEnvResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.MarineCondition;
@@ -3225,10 +3028,7 @@ public record BasicEnvResponse(
 }
 
 
-================================================================================
-File Path: .\submission\dto\response\BulkApproveResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\BulkApproveResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import java.util.List;
@@ -3239,10 +3039,7 @@ public record BulkApproveResponse(
 ) {}
 
 
-================================================================================
-File Path: .\submission\dto\response\BulkDeleteResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\BulkDeleteResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import java.util.List;
@@ -3253,10 +3050,7 @@ public record BulkDeleteResponse(
 ) {}
 
 
-================================================================================
-File Path: .\submission\dto\response\BulkRejectResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\BulkRejectResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import java.util.List;
@@ -3267,10 +3061,7 @@ public record BulkRejectResponse(
 ) {}
 
 
-================================================================================
-File Path: .\submission\dto\response\ParticipantsResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\ParticipantsResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 
@@ -3280,10 +3071,7 @@ public record ParticipantsResponse(
 ) { }
 
 
-================================================================================
-File Path: .\submission\dto\response\SubmissionDetailResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\SubmissionDetailResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -3305,8 +3093,6 @@ public record SubmissionDetailResponse(
         String authorEmail,
         Integer attachmentCount,
         String feedbackText,  // API 하위 호환성을 위해 필드명 유지 (내부적으로는 workDescription 사용)
-        BigDecimal latitude,
-        BigDecimal longitude,
         BasicEnvResponse basicEnv,
         ParticipantsResponse participants,
 
@@ -3353,8 +3139,6 @@ public record SubmissionDetailResponse(
                 submission.getAuthorEmail(),
                 submission.getAttachmentCount(),
                 submission.getWorkDescription(),
-                submission.getLatitude(),
-                submission.getLongitude(),
                 BasicEnvResponse.from(submission.getBasicEnv()),
                 new ParticipantsResponse(submission.getParticipantNames()),
 
@@ -3480,10 +3264,7 @@ public record SubmissionDetailResponse(
 }
 
 
-================================================================================
-File Path: .\submission\dto\response\SubmissionListResponse.java
-================================================================================
-
+# File Path: .\submission\dto\response\SubmissionListResponse.java
 package com.ocean.piuda.admin.submission.dto.response;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -3518,10 +3299,7 @@ public record SubmissionListResponse(
 }
 
 
-================================================================================
-File Path: .\submission\entity\ActivityGrazerRemoval.java
-================================================================================
-
+# File Path: .\submission\entity\ActivityGrazerRemoval.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.DensityLevel;
@@ -3581,10 +3359,7 @@ public class ActivityGrazerRemoval {
 }
 
 
-================================================================================
-File Path: .\submission\entity\ActivityMarineCleanup.java
-================================================================================
-
+# File Path: .\submission\entity\ActivityMarineCleanup.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.CleanupMethodType;
@@ -3641,10 +3416,7 @@ public class ActivityMarineCleanup {
 }
 
 
-================================================================================
-File Path: .\submission\entity\ActivityMonitoring.java
-================================================================================
-
+# File Path: .\submission\entity\ActivityMonitoring.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -3729,10 +3501,7 @@ public class ActivityMonitoring {
 }
 
 
-================================================================================
-File Path: .\submission\entity\ActivitySubstrateImprovement.java
-================================================================================
-
+# File Path: .\submission\entity\ActivitySubstrateImprovement.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.SubstrateTargetType;
@@ -3773,10 +3542,7 @@ public class ActivitySubstrateImprovement {
 }
 
 
-================================================================================
-File Path: .\submission\entity\ActivityTransplant.java
-================================================================================
-
+# File Path: .\submission\entity\ActivityTransplant.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.HealthStatus;
@@ -3829,10 +3595,7 @@ public class ActivityTransplant {
 }
 
 
-================================================================================
-File Path: .\submission\entity\Attachment.java
-================================================================================
-
+# File Path: .\submission\entity\Attachment.java
 package com.ocean.piuda.admin.submission.entity;
 
 import jakarta.persistence.*;
@@ -3880,10 +3643,7 @@ public class Attachment {
 }
 
 
-================================================================================
-File Path: .\submission\entity\AuditLog.java
-================================================================================
-
+# File Path: .\submission\entity\AuditLog.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.AuditAction;
@@ -3925,10 +3685,7 @@ public class AuditLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\submission\entity\BasicEnv.java
-================================================================================
-
+# File Path: .\submission\entity\BasicEnv.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.MarineCondition;
@@ -3990,10 +3747,7 @@ public class BasicEnv {
 }
 
 
-================================================================================
-File Path: .\submission\entity\RejectReason.java
-================================================================================
-
+# File Path: .\submission\entity\RejectReason.java
 package com.ocean.piuda.admin.submission.entity;
 
 import jakarta.persistence.*;
@@ -4038,10 +3792,7 @@ public class RejectReason {
 }
 
 
-================================================================================
-File Path: .\submission\entity\Submission.java
-================================================================================
-
+# File Path: .\submission\entity\Submission.java
 package com.ocean.piuda.admin.submission.entity;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -4136,12 +3887,6 @@ public class Submission extends BaseEntity {
 
     @Column(name = "admin_memo", columnDefinition = "TEXT")
     private String adminMemo;  // 관리자 검수 메모
-
-    @Column(precision = 9, scale = 6)
-    private BigDecimal latitude;
-
-    @Column(precision = 9, scale = 6)
-    private BigDecimal longitude;
 
     @Column(name = "participant_names", columnDefinition = "TEXT")
     private String participantNames;
@@ -4272,10 +4017,7 @@ public class Submission extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\submission\initializer\SubmissionDataInitializer.java
-================================================================================
-
+# File Path: .\submission\initializer\SubmissionDataInitializer.java
 package com.ocean.piuda.admin.submission.initializer;
 
 import com.ocean.piuda.admin.common.enums.*;
@@ -4496,8 +4238,6 @@ public class SubmissionDataInitializer implements CommandLineRunner {
                 .authorEmail(authorEmail)
                 .attachmentCount(attachmentCount)
                 .workDescription(workDescription)
-                .latitude(latitude)
-                .longitude(longitude)
                 .participantNames(participantNames)
                 .submittedAt(submittedAt)
                 .build();
@@ -4622,10 +4362,7 @@ public class SubmissionDataInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\submission\repository\AuditLogRepository.java
-================================================================================
-
+# File Path: .\submission\repository\AuditLogRepository.java
 package com.ocean.piuda.admin.submission.repository;
 
 import com.ocean.piuda.admin.submission.entity.AuditLog;
@@ -4640,10 +4377,7 @@ public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
 }
 
 
-================================================================================
-File Path: .\submission\repository\SubmissionRepository.java
-================================================================================
-
+# File Path: .\submission\repository\SubmissionRepository.java
 package com.ocean.piuda.admin.submission.repository;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -4745,10 +4479,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, Long> {
 }
 
 
-================================================================================
-File Path: .\submission\service\SubmissionCommandService.java
-================================================================================
-
+# File Path: .\submission\service\SubmissionCommandService.java
 package com.ocean.piuda.admin.submission.service;
 
 import com.ocean.piuda.admin.site.entity.SiteNameOption;
@@ -4843,11 +4574,9 @@ public class SubmissionCommandService {
                 .status(status)
                 .submittedAt(submittedAt)
                 .user(currentUser)
-                .authorName(request.getAuthorName())
-                .authorEmail(request.getAuthorEmail())
+                .authorName(currentUser.getNickname())
+                .authorEmail(currentUser.getEmail())
                 .workDescription(request.getWorkDescription())
-                .latitude(request.getLatitude())
-                .longitude(request.getLongitude())
                 .attachmentCount(0)
                 .build();
 
@@ -5211,10 +4940,7 @@ public class SubmissionCommandService {
 }
 
 
-================================================================================
-File Path: .\submission\service\SubmissionQueryService.java
-================================================================================
-
+# File Path: .\submission\service\SubmissionQueryService.java
 package com.ocean.piuda.admin.submission.service;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -5305,10 +5031,7 @@ public class SubmissionQueryService {
 }
 
 
-================================================================================
-File Path: .\submission\validator\ActivityValidator.java
-================================================================================
-
+# File Path: .\submission\validator\ActivityValidator.java
 package com.ocean.piuda.admin.submission.validator;
 
 import com.ocean.piuda.admin.common.enums.ActivityType;
@@ -5410,10 +5133,7 @@ public class ActivityValidator {
 }
 
 
-================================================================================
-File Path: .\submission\validator\SubmissionStatusValidator.java
-================================================================================
-
+# File Path: .\submission\validator\SubmissionStatusValidator.java
 package com.ocean.piuda.admin.submission.validator;
 
 import com.ocean.piuda.admin.common.enums.SubmissionStatus;

--- a/src/main/java/com/ocean/piuda/admin/submission/dto/response/SubmissionDetailResponse.java
+++ b/src/main/java/com/ocean/piuda/admin/submission/dto/response/SubmissionDetailResponse.java
@@ -12,13 +12,14 @@ public record SubmissionDetailResponse(
         Long submissionId,
         String siteName,
         Long siteNameOptionId,
+        Integer divingRound,
         ActivityType activityType,
         LocalDateTime submittedAt,
         SubmissionStatus status,
         String authorName,
         String authorEmail,
         Integer attachmentCount,
-        String feedbackText,  // API 하위 호환성을 위해 필드명 유지 (내부적으로는 workDescription 사용)
+        String workDescription,
         BasicEnvResponse basicEnv,
         ParticipantsResponse participants,
 
@@ -58,6 +59,7 @@ public record SubmissionDetailResponse(
                 submission.getSubmissionId(),
                 submission.getSiteName(),
                 submission.getSiteNameOption() != null ? submission.getSiteNameOption().getId() : null,
+                submission.getDivingRound(),
                 submission.getActivityType(),
                 submission.getSubmittedAt(),
                 submission.getStatus(),
@@ -65,6 +67,7 @@ public record SubmissionDetailResponse(
                 submission.getAuthorEmail(),
                 submission.getAttachmentCount(),
                 submission.getWorkDescription(),
+
                 BasicEnvResponse.from(submission.getBasicEnv()),
                 new ParticipantsResponse(submission.getParticipantNames()),
 

--- a/src/main/java/com/ocean/piuda/bio/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/bio/ProjectExporter.java
@@ -118,9 +118,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {

--- a/src/main/java/com/ocean/piuda/bio/dto/request/SpeciesRequest.java
+++ b/src/main/java/com/ocean/piuda/bio/dto/request/SpeciesRequest.java
@@ -1,21 +1,15 @@
 package com.ocean.piuda.bio.dto.request;
 
-import com.ocean.piuda.bio.enums.BioGroup;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public class SpeciesRequest {
 
     public record Create(
             @NotBlank(message = "종 이름은 필수입니다")
-            String name,
-
-            @NotNull(message = "생물 그룹 분류는 필수입니다")
-            BioGroup category
+            String name
     ) {}
 
     public record Update(
-            String name,
-            BioGroup category
+            String name
     ) {}
 }

--- a/src/main/java/com/ocean/piuda/bio/dto/response/SpeciesResponse.java
+++ b/src/main/java/com/ocean/piuda/bio/dto/response/SpeciesResponse.java
@@ -1,7 +1,6 @@
 package com.ocean.piuda.bio.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
-import com.ocean.piuda.bio.enums.BioGroup;
 import lombok.Builder;
 import java.time.LocalDateTime;
 
@@ -9,14 +8,12 @@ import java.time.LocalDateTime;
 public record SpeciesResponse(
         Long id,
         String name,
-        BioGroup category,
         LocalDateTime createdAt
 ) {
     public static SpeciesResponse from(Species species) {
         return SpeciesResponse.builder()
                 .id(species.getId())
                 .name(species.getName())
-                .category(species.getCategory())
                 .createdAt(species.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/ocean/piuda/bio/entity/Species.java
+++ b/src/main/java/com/ocean/piuda/bio/entity/Species.java
@@ -4,7 +4,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import lombok.Getter;
 
-import com.ocean.piuda.bio.enums.BioGroup;
 import com.ocean.piuda.global.api.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -29,11 +28,7 @@ public class Species extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name; // 국명 (예: 감태)
 
-    @Enumerated(EnumType.STRING)
-    private BioGroup category;
-
-    public void update(String name, BioGroup category) {
+    public void update(String name) {
         if (name != null && !name.isBlank())  this.name = name;
-        if (category != null) this.category = category;
     }
 }

--- a/src/main/java/com/ocean/piuda/bio/project_context.txt
+++ b/src/main/java/com/ocean/piuda/bio/project_context.txt
@@ -1,8 +1,5 @@
 
-================================================================================
-File Path: .\controller\SpeciesController.java
-================================================================================
-
+# File Path: .\controller\SpeciesController.java
 package com.ocean.piuda.bio.controller;
 
 
@@ -66,10 +63,7 @@ public class SpeciesController {
 }
 
 
-================================================================================
-File Path: .\dto\request\SpeciesRequest.java
-================================================================================
-
+# File Path: .\dto\request\SpeciesRequest.java
 package com.ocean.piuda.bio.dto.request;
 
 import com.ocean.piuda.bio.enums.BioGroup;
@@ -80,23 +74,16 @@ public class SpeciesRequest {
 
     public record Create(
             @NotBlank(message = "종 이름은 필수입니다")
-            String name,
-
-            @NotNull(message = "생물 그룹 분류는 필수입니다")
-            BioGroup category
+            String name
     ) {}
 
     public record Update(
-            String name,
-            BioGroup category
+            String name
     ) {}
 }
 
 
-================================================================================
-File Path: .\dto\response\SpeciesResponse.java
-================================================================================
-
+# File Path: .\dto\response\SpeciesResponse.java
 package com.ocean.piuda.bio.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -108,24 +95,19 @@ import java.time.LocalDateTime;
 public record SpeciesResponse(
         Long id,
         String name,
-        BioGroup category,
         LocalDateTime createdAt
 ) {
     public static SpeciesResponse from(Species species) {
         return SpeciesResponse.builder()
                 .id(species.getId())
                 .name(species.getName())
-                .category(species.getCategory())
                 .createdAt(species.getCreatedAt())
                 .build();
     }
 }
 
 
-================================================================================
-File Path: .\entity\Species.java
-================================================================================
-
+# File Path: .\entity\Species.java
 package com.ocean.piuda.bio.entity;
 
 import jakarta.persistence.Entity;
@@ -157,20 +139,13 @@ public class Species extends BaseEntity {
     @Column(nullable = false, unique = true)
     private String name; // 국명 (예: 감태)
 
-    @Enumerated(EnumType.STRING)
-    private BioGroup category;
-
-    public void update(String name, BioGroup category) {
+    public void update(String name) {
         if (name != null && !name.isBlank())  this.name = name;
-        if (category != null) this.category = category;
     }
 }
 
 
-================================================================================
-File Path: .\enums\BioGroup.java
-================================================================================
-
+# File Path: .\enums\BioGroup.java
 package com.ocean.piuda.bio.enums;
 
 
@@ -208,10 +183,7 @@ public enum BioGroup {
 
 
 
-================================================================================
-File Path: .\ProjectExporter.java
-================================================================================
-
+# File Path: .\ProjectExporter.java
 package com.ocean.piuda.bio;
 
 import java.io.IOException;
@@ -332,9 +304,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {
@@ -353,10 +323,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\repository\SpeciesRepository.java
-================================================================================
-
+# File Path: .\repository\SpeciesRepository.java
 package com.ocean.piuda.bio.repository;
 
 
@@ -374,10 +341,7 @@ public interface SpeciesRepository extends JpaRepository<Species, Long> {
 }
 
 
-================================================================================
-File Path: .\service\SpeciesService.java
-================================================================================
-
+# File Path: .\service\SpeciesService.java
 package com.ocean.piuda.bio.service;
 
 import com.ocean.piuda.bio.dto.request.SpeciesRequest;
@@ -407,7 +371,6 @@ public class SpeciesService {
 
         Species species = Species.builder()
                 .name(req.name())
-                .category(req.category())
                 .build();
 
         return SpeciesResponse.from(speciesRepository.save(species));
@@ -441,7 +404,7 @@ public class SpeciesService {
             });
         }
 
-        species.update(req.name(), req.category());
+        species.update(req.name());
     }
 
     public void deleteSpecies(Long id) {

--- a/src/main/java/com/ocean/piuda/bio/service/SpeciesService.java
+++ b/src/main/java/com/ocean/piuda/bio/service/SpeciesService.java
@@ -27,7 +27,6 @@ public class SpeciesService {
 
         Species species = Species.builder()
                 .name(req.name())
-                .category(req.category())
                 .build();
 
         return SpeciesResponse.from(speciesRepository.save(species));
@@ -61,7 +60,7 @@ public class SpeciesService {
             });
         }
 
-        species.update(req.name(), req.category());
+        species.update(req.name());
     }
 
     public void deleteSpecies(Long id) {

--- a/src/main/java/com/ocean/piuda/dashboard/ProjectExporter.java
+++ b/src/main/java/com/ocean/piuda/dashboard/ProjectExporter.java
@@ -118,9 +118,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {

--- a/src/main/java/com/ocean/piuda/dashboard/initializer/DashboardDataInitializer.java
+++ b/src/main/java/com/ocean/piuda/dashboard/initializer/DashboardDataInitializer.java
@@ -1,7 +1,6 @@
 package com.ocean.piuda.dashboard.initializer;
 
 import com.ocean.piuda.bio.entity.Species;
-import com.ocean.piuda.bio.enums.BioGroup;
 import com.ocean.piuda.bio.repository.SpeciesRepository;
 import com.ocean.piuda.dashboard.entity.*;
 import com.ocean.piuda.dashboard.enums.*;
@@ -36,9 +35,9 @@ public class DashboardDataInitializer implements CommandLineRunner {
         log.info("OC DASHBOARD 실증용 데이터 초기화 시작");
 
         // 1) Species
-        Species gamtae = getOrCreateSpecies("감태", BioGroup.MACROALGAE);
-        Species dasima = getOrCreateSpecies("다시마", BioGroup.MACROALGAE);
-        Species mojaban = getOrCreateSpecies("모자반", BioGroup.MACROALGAE);
+        Species gamtae = getOrCreateSpecies("감태");
+        Species dasima = getOrCreateSpecies("다시마");
+        Species mojaban = getOrCreateSpecies("모자반");
 
         // 2) Areas
         createPohangDemoArea1(gamtae, dasima, mojaban);
@@ -47,12 +46,11 @@ public class DashboardDataInitializer implements CommandLineRunner {
         log.info("OC DASHBOARD 데이터 초기화 완료");
     }
 
-    private Species getOrCreateSpecies(String name, BioGroup category) {
+    private Species getOrCreateSpecies(String name) {
         return speciesRepository.findByName(name)
                 .orElseGet(() -> speciesRepository.save(
                         Species.builder()
                                 .name(name)
-                                .category(category)
                                 .build()
                 ));
     }

--- a/src/main/java/com/ocean/piuda/dashboard/project_context.txt
+++ b/src/main/java/com/ocean/piuda/dashboard/project_context.txt
@@ -1,8 +1,5 @@
 
-================================================================================
-File Path: .\controller\DashboardController.java
-================================================================================
-
+# File Path: .\controller\DashboardController.java
 package com.ocean.piuda.dashboard.controller;
 
 import com.ocean.piuda.dashboard.dto.response.AreaDetailResponse;
@@ -408,10 +405,7 @@ public class DashboardController {
 }
 
 
-================================================================================
-File Path: .\dto\request\AreaPageRequest.java
-================================================================================
-
+# File Path: .\dto\request\AreaPageRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.AreaSort;
@@ -431,10 +425,7 @@ public class AreaPageRequest extends PageRequest<AreaSort> {
 }
 
 
-================================================================================
-File Path: .\dto\request\CreateGrowthLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\CreateGrowthLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -452,10 +443,7 @@ public record CreateGrowthLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\CreateMediaLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\CreateMediaLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -472,10 +460,7 @@ public record CreateMediaLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\CreateProjectAreaRequest.java
-================================================================================
-
+# File Path: .\dto\request\CreateProjectAreaRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.AreaAttachmentStatus;
@@ -502,10 +487,7 @@ public record CreateProjectAreaRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\CreateTransplantLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\CreateTransplantLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -524,10 +506,7 @@ public record CreateTransplantLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\CreateWaterLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\CreateWaterLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MarineStatus;
@@ -547,10 +526,7 @@ public record CreateWaterLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\LogPageRequest.java
-================================================================================
-
+# File Path: .\dto\request\LogPageRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.LogSort;
@@ -571,10 +547,7 @@ public class LogPageRequest extends PageRequest<LogSort> {
 }
 
 
-================================================================================
-File Path: .\dto\request\SetRepresentativeSpeciesRequest.java
-================================================================================
-
+# File Path: .\dto\request\SetRepresentativeSpeciesRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import jakarta.validation.constraints.NotNull;
@@ -585,10 +558,7 @@ public record SetRepresentativeSpeciesRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\UpdateGrowthLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\UpdateGrowthLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -605,10 +575,7 @@ public record UpdateGrowthLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\UpdateMediaLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\UpdateMediaLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -624,10 +591,7 @@ public record UpdateMediaLogRequest(
 
 
 
-================================================================================
-File Path: .\dto\request\UpdateProjectAreaRequest.java
-================================================================================
-
+# File Path: .\dto\request\UpdateProjectAreaRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -656,10 +620,7 @@ public record UpdateProjectAreaRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\UpdateTransplantLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\UpdateTransplantLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.SpeciesAttachmentStatus;
@@ -677,10 +638,7 @@ public record UpdateTransplantLogRequest(
 ) {}
 
 
-================================================================================
-File Path: .\dto\request\UpdateWaterLogRequest.java
-================================================================================
-
+# File Path: .\dto\request\UpdateWaterLogRequest.java
 package com.ocean.piuda.dashboard.dto.request;
 
 import com.ocean.piuda.dashboard.enums.MarineStatus;
@@ -700,10 +658,7 @@ public record UpdateWaterLogRequest(
 
 
 
-================================================================================
-File Path: .\dto\response\AreaDetailResponse.java
-================================================================================
-
+# File Path: .\dto\response\AreaDetailResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.dto.TimeSeriesChartDto;
@@ -847,10 +802,7 @@ public class AreaDetailResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\AreaMarkerResponse.java
-================================================================================
-
+# File Path: .\dto\response\AreaMarkerResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import lombok.AllArgsConstructor;
@@ -886,10 +838,7 @@ public class AreaMarkerResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\AreaSpeciesResponse.java
-================================================================================
-
+# File Path: .\dto\response\AreaSpeciesResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -911,10 +860,7 @@ public class AreaSpeciesResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\AreaStatResponse.java
-================================================================================
-
+# File Path: .\dto\response\AreaStatResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import lombok.AllArgsConstructor;
@@ -931,10 +877,7 @@ public class AreaStatResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\GrowthLogResponse.java
-================================================================================
-
+# File Path: .\dto\response\GrowthLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -978,19 +921,13 @@ public class GrowthLogResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\IdResponse.java
-================================================================================
-
+# File Path: .\dto\response\IdResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 public record IdResponse(Long id) {}
 
 
-================================================================================
-File Path: .\dto\response\MediaLogResponse.java
-================================================================================
-
+# File Path: .\dto\response\MediaLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.entity.MediaLog;
@@ -1023,10 +960,7 @@ public class MediaLogResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\ProjectAreaListItemResponse.java
-================================================================================
-
+# File Path: .\dto\response\ProjectAreaListItemResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.entity.ProjectArea;
@@ -1075,10 +1009,7 @@ public class ProjectAreaListItemResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\TransplantLogResponse.java
-================================================================================
-
+# File Path: .\dto\response\TransplantLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -1132,10 +1063,7 @@ public class TransplantLogResponse {
 }
 
 
-================================================================================
-File Path: .\dto\response\WaterLogResponse.java
-================================================================================
-
+# File Path: .\dto\response\WaterLogResponse.java
 package com.ocean.piuda.dashboard.dto.response;
 
 import com.ocean.piuda.dashboard.entity.WaterLog;
@@ -1187,10 +1115,7 @@ public class WaterLogResponse {
 }
 
 
-================================================================================
-File Path: .\dto\TimeSeriesChartDto.java
-================================================================================
-
+# File Path: .\dto\TimeSeriesChartDto.java
 package com.ocean.piuda.dashboard.dto;
 
 
@@ -1211,10 +1136,7 @@ public record TimeSeriesChartDto(
 ) { }
 
 
-================================================================================
-File Path: .\entity\BiodiversitySummary.java
-================================================================================
-
+# File Path: .\entity\BiodiversitySummary.java
 /**
  * 개편된 5개의 탭 구조에 맞춰 불필요한 "생물 다양성 요약 엔티티"는 사용하지 않습니다.
  */
@@ -1254,10 +1176,7 @@ public class BiodiversitySummary {
  */
 
 
-================================================================================
-File Path: .\entity\GrowthLog.java
-================================================================================
-
+# File Path: .\entity\GrowthLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -1321,10 +1240,7 @@ public class GrowthLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\entity\MediaLog.java
-================================================================================
-
+# File Path: .\entity\MediaLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -1374,10 +1290,7 @@ public class MediaLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\entity\ProjectArea.java
-================================================================================
-
+# File Path: .\entity\ProjectArea.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -1538,10 +1451,7 @@ public class ProjectArea extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\entity\TransplantLog.java
-================================================================================
-
+# File Path: .\entity\TransplantLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -1609,10 +1519,7 @@ public class TransplantLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\entity\WaterLog.java
-================================================================================
-
+# File Path: .\entity\WaterLog.java
 package com.ocean.piuda.dashboard.entity;
 
 import com.ocean.piuda.dashboard.enums.MarineStatus;
@@ -1689,10 +1596,7 @@ public class WaterLog extends BaseEntity {
 }
 
 
-================================================================================
-File Path: .\enums\AreaAttachmentStatus.java
-================================================================================
-
+# File Path: .\enums\AreaAttachmentStatus.java
 package com.ocean.piuda.dashboard.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -1708,10 +1612,7 @@ public enum AreaAttachmentStatus {
 }
 
 
-================================================================================
-File Path: .\enums\AreaSort.java
-================================================================================
-
+# File Path: .\enums\AreaSort.java
 package com.ocean.piuda.dashboard.enums;
 
 import com.ocean.piuda.global.enums.SortEnum;
@@ -1739,10 +1640,7 @@ public enum AreaSort implements SortEnum {
 }
 
 
-================================================================================
-File Path: .\enums\HabitatType.java
-================================================================================
-
+# File Path: .\enums\HabitatType.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -1759,10 +1657,7 @@ public enum HabitatType {
 }
 
 
-================================================================================
-File Path: .\enums\LogSort.java
-================================================================================
-
+# File Path: .\enums\LogSort.java
 package com.ocean.piuda.dashboard.enums;
 
 import com.ocean.piuda.global.enums.SortEnum;
@@ -1786,10 +1681,7 @@ public enum LogSort implements SortEnum {
 }
 
 
-================================================================================
-File Path: .\enums\MarineStatus.java
-================================================================================
-
+# File Path: .\enums\MarineStatus.java
 package com.ocean.piuda.dashboard.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -1805,10 +1697,7 @@ public enum MarineStatus {
 }
 
 
-================================================================================
-File Path: .\enums\MediaCategory.java
-================================================================================
-
+# File Path: .\enums\MediaCategory.java
 package com.ocean.piuda.dashboard.enums;
 
 
@@ -1826,10 +1715,7 @@ public enum MediaCategory {
 }
 
 
-================================================================================
-File Path: .\enums\ProjectLevel.java
-================================================================================
-
+# File Path: .\enums\ProjectLevel.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -1848,10 +1734,7 @@ public enum ProjectLevel {
 }
 
 
-================================================================================
-File Path: .\enums\RestorationRegion.java
-================================================================================
-
+# File Path: .\enums\RestorationRegion.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -1867,10 +1750,7 @@ public enum RestorationRegion {
 }
 
 
-================================================================================
-File Path: .\enums\SpeciesAttachmentStatus.java
-================================================================================
-
+# File Path: .\enums\SpeciesAttachmentStatus.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -1887,10 +1767,7 @@ public enum SpeciesAttachmentStatus {
 }
 
 
-================================================================================
-File Path: .\enums\TransplantMethod.java
-================================================================================
-
+# File Path: .\enums\TransplantMethod.java
 package com.ocean.piuda.dashboard.enums;
 
 import lombok.Getter;
@@ -1911,10 +1788,7 @@ public enum TransplantMethod {
 }
 
 
-================================================================================
-File Path: .\initializer\DashboardDataInitializer.java
-================================================================================
-
+# File Path: .\initializer\DashboardDataInitializer.java
 package com.ocean.piuda.dashboard.initializer;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -1953,9 +1827,9 @@ public class DashboardDataInitializer implements CommandLineRunner {
         log.info("OC DASHBOARD 실증용 데이터 초기화 시작");
 
         // 1) Species
-        Species gamtae = getOrCreateSpecies("감태", BioGroup.MACROALGAE);
-        Species dasima = getOrCreateSpecies("다시마", BioGroup.MACROALGAE);
-        Species mojaban = getOrCreateSpecies("모자반", BioGroup.MACROALGAE);
+        Species gamtae = getOrCreateSpecies("감태");
+        Species dasima = getOrCreateSpecies("다시마");
+        Species mojaban = getOrCreateSpecies("모자반");
 
         // 2) Areas
         createPohangDemoArea1(gamtae, dasima, mojaban);
@@ -1964,12 +1838,11 @@ public class DashboardDataInitializer implements CommandLineRunner {
         log.info("OC DASHBOARD 데이터 초기화 완료");
     }
 
-    private Species getOrCreateSpecies(String name, BioGroup category) {
+    private Species getOrCreateSpecies(String name) {
         return speciesRepository.findByName(name)
                 .orElseGet(() -> speciesRepository.save(
                         Species.builder()
                                 .name(name)
-                                .category(category)
                                 .build()
                 ));
     }
@@ -2191,10 +2064,7 @@ public class DashboardDataInitializer implements CommandLineRunner {
 }
 
 
-================================================================================
-File Path: .\ProjectExporter.java
-================================================================================
-
+# File Path: .\ProjectExporter.java
 package com.ocean.piuda.dashboard;
 
 import java.io.IOException;
@@ -2315,9 +2185,7 @@ public class ProjectExporter {
 
     private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
         try {
-            writer.write("\n" + "=".repeat(80) + "\n");
-            writer.write("File Path: " + file.toString() + "\n");
-            writer.write("=".repeat(80) + "\n\n");
+            writer.write("\n# File Path: " + file.toString() + "\n");
 
             // 파일 내용을 한 번에 읽어서 쓰기
             Files.lines(file).forEach(line -> {
@@ -2336,10 +2204,7 @@ public class ProjectExporter {
 }
 
 
-================================================================================
-File Path: .\repository\GrowthLogRepository.java
-================================================================================
-
+# File Path: .\repository\GrowthLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.GrowthLog;
@@ -2373,10 +2238,7 @@ public interface GrowthLogRepository extends JpaRepository<GrowthLog, Long> {
 }
 
 
-================================================================================
-File Path: .\repository\MediaLogRepository.java
-================================================================================
-
+# File Path: .\repository\MediaLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.MediaLog;
@@ -2409,10 +2271,7 @@ public interface MediaLogRepository extends JpaRepository<MediaLog, Long> {
 }
 
 
-================================================================================
-File Path: .\repository\ProjectAreaRepository.java
-================================================================================
-
+# File Path: .\repository\ProjectAreaRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.ProjectArea;
@@ -2584,10 +2443,7 @@ public interface ProjectAreaRepository extends JpaRepository<ProjectArea, Long> 
 }
 
 
-================================================================================
-File Path: .\repository\projection\AccumulatedStatsProjection.java
-================================================================================
-
+# File Path: .\repository\projection\AccumulatedStatsProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -2599,10 +2455,7 @@ public interface AccumulatedStatsProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\AreaMarkerProjection.java
-================================================================================
-
+# File Path: .\repository\projection\AreaMarkerProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -2627,10 +2480,7 @@ public interface AreaMarkerProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\AreaStatProjection.java
-================================================================================
-
+# File Path: .\repository\projection\AreaStatProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 public interface AreaStatProjection {
@@ -2640,10 +2490,7 @@ public interface AreaStatProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\EnvironmentSummaryProjection.java
-================================================================================
-
+# File Path: .\repository\projection\EnvironmentSummaryProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 public interface EnvironmentSummaryProjection {
@@ -2654,10 +2501,7 @@ public interface EnvironmentSummaryProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\MediaPointProjection.java
-================================================================================
-
+# File Path: .\repository\projection\MediaPointProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import com.ocean.piuda.dashboard.enums.MediaCategory;
@@ -2671,10 +2515,7 @@ public interface MediaPointProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\MethodAttachmentStatusProjection.java
-================================================================================
-
+# File Path: .\repository\projection\MethodAttachmentStatusProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 public interface MethodAttachmentStatusProjection {
@@ -2683,10 +2524,7 @@ public interface MethodAttachmentStatusProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\MethodDistributionProjection.java
-================================================================================
-
+# File Path: .\repository\projection\MethodDistributionProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import com.ocean.piuda.dashboard.enums.TransplantMethod;
@@ -2697,10 +2535,7 @@ public interface MethodDistributionProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\SpeciesStatusProjection.java
-================================================================================
-
+# File Path: .\repository\projection\SpeciesStatusProjection.java
 //package com.ocean.piuda.dashboard.repository.projection;
 //
 //public interface SpeciesStatusProjection {
@@ -2709,10 +2544,7 @@ File Path: .\repository\projection\SpeciesStatusProjection.java
 //}
 
 
-================================================================================
-File Path: .\repository\projection\TemperaturePointProjection.java
-================================================================================
-
+# File Path: .\repository\projection\TemperaturePointProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -2723,10 +2555,7 @@ public interface TemperaturePointProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\TransplantItemProjection.java
-================================================================================
-
+# File Path: .\repository\projection\TransplantItemProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import com.ocean.piuda.dashboard.enums.TransplantMethod;
@@ -2738,10 +2567,7 @@ public interface TransplantItemProjection {
 }
 
 
-================================================================================
-File Path: .\repository\projection\WorkHistoryPointProjection.java
-================================================================================
-
+# File Path: .\repository\projection\WorkHistoryPointProjection.java
 package com.ocean.piuda.dashboard.repository.projection;
 
 import java.time.LocalDate;
@@ -2752,10 +2578,7 @@ public interface WorkHistoryPointProjection {
 }
 
 
-================================================================================
-File Path: .\repository\TransplantLogRepository.java
-================================================================================
-
+# File Path: .\repository\TransplantLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -2852,10 +2675,7 @@ public interface TransplantLogRepository extends JpaRepository<TransplantLog, Lo
 }
 
 
-================================================================================
-File Path: .\repository\WaterLogRepository.java
-================================================================================
-
+# File Path: .\repository\WaterLogRepository.java
 package com.ocean.piuda.dashboard.repository;
 
 import com.ocean.piuda.dashboard.entity.WaterLog;
@@ -2940,10 +2760,7 @@ public interface WaterLogRepository extends JpaRepository<WaterLog, Long> {
 }
 
 
-================================================================================
-File Path: .\service\DashboardAggregateBuilder.java
-================================================================================
-
+# File Path: .\service\DashboardAggregateBuilder.java
 package com.ocean.piuda.dashboard.service;
 
 import com.ocean.piuda.dashboard.dto.TimeSeriesChartDto;
@@ -3148,10 +2965,7 @@ public class DashboardAggregateBuilder {
 }
 
 
-================================================================================
-File Path: .\service\DashboardCommandService.java
-================================================================================
-
+# File Path: .\service\DashboardCommandService.java
 package com.ocean.piuda.dashboard.service;
 
 import com.ocean.piuda.bio.entity.Species;
@@ -3433,10 +3247,7 @@ public class DashboardCommandService {
 }
 
 
-================================================================================
-File Path: .\service\DashboardQueryService.java
-================================================================================
-
+# File Path: .\service\DashboardQueryService.java
 package com.ocean.piuda.dashboard.service;
 import com.ocean.piuda.dashboard.dto.request.AreaPageRequest;
 import com.ocean.piuda.dashboard.enums.RestorationRegion;

--- a/src/main/java/com/ocean/piuda/global/project_context.txt
+++ b/src/main/java/com/ocean/piuda/global/project_context.txt
@@ -1,0 +1,882 @@
+
+# File Path: .\api\domain\BaseEntity.java
+package com.ocean.piuda.global.api.domain;
+
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder(toBuilder = true)
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime modifiedAt;
+}
+
+
+# File Path: .\api\dto\ApiData.java
+package com.ocean.piuda.global.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * ApiData 는 JSON 처리 전용
+ * 기타 CSV 나 파일은 컨트롤러에서 byte[] 로 직접 반환 처리
+ */
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Builder
+@Getter
+@ToString
+public class ApiData<T> {
+
+  private static final String SUCCESS_CODE = "0";
+  private static final String SUCCESS_MESSAGE = "요청에 성공했습니다.";
+
+
+  @JsonIgnore
+  private HttpStatus httpStatus;
+
+  @JsonIgnore
+  private final List<ApiHeader> headers = new ArrayList<>();
+
+  @JsonIgnore
+  private MediaType contentType;
+
+  private boolean success;
+  private T data;
+  private Map<String, ?> errors;
+  private String code;
+  private Object message;
+
+
+  public static <T> ApiData<T> ok(T data) {
+    return ApiData.<T>builder()
+        .httpStatus(HttpStatus.OK)
+        .success(true)
+        .data(data)
+        .contentType(MediaType.APPLICATION_JSON)
+        .code(SUCCESS_CODE)
+        .message(SUCCESS_MESSAGE)
+        .build();
+  }
+
+  public static <T> ApiData<T> created(T data) {
+    return ApiData.<T>builder()
+        .httpStatus(HttpStatus.CREATED)
+        .success(true)
+        .data(data)
+        .contentType(MediaType.APPLICATION_JSON)
+        .code(SUCCESS_CODE)
+        .message(SUCCESS_MESSAGE)
+        .build();
+  }
+
+  public static ApiData<Void> noContent() {
+        return ApiData.<Void>builder()
+            .httpStatus(HttpStatus.NO_CONTENT)
+            .success(true)
+            .data(null)
+            .contentType(MediaType.APPLICATION_JSON)
+            .code(SUCCESS_CODE)
+            .message(SUCCESS_MESSAGE)
+            .build();
+    }
+
+
+  public static <T> ApiData<T> from(HttpStatus httpStatus, T data) {
+    return ApiData.<T>builder()
+        .httpStatus(httpStatus)
+        .success(true)
+        .data(data)
+        .contentType(MediaType.APPLICATION_JSON)
+        .code(SUCCESS_CODE)
+        .message(SUCCESS_MESSAGE)
+        .build();
+  }
+
+  public static ApiData<Void> error(ExceptionType exceptionType) {
+    return ApiData.error(exceptionType,Map.of());
+  }
+
+  public static ApiData<Void> error(ExceptionType exceptionType,Map<String, ?> details) {
+
+    return ApiData.<Void>builder()
+            .contentType(MediaType.APPLICATION_JSON)
+            .success(false)
+            .code(exceptionType.getCode())
+            .message(exceptionType.getMessage())
+            .httpStatus(exceptionType.getStatus())
+            .data(null)                // 실패는 data 비움
+            .errors(details == null ? Map.of() : details)
+            .build();
+
+  }
+
+
+
+}
+
+
+# File Path: .\api\dto\ApiDataAdvice.java
+package com.ocean.piuda.global.api.dto;
+
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice
+public class ApiDataAdvice implements ResponseBodyAdvice<Object> {
+
+  @Override
+  public boolean supports(MethodParameter returnType,
+      Class<? extends HttpMessageConverter<?>> converterType) {
+    return ApiData.class.isAssignableFrom(returnType.getParameterType());
+  }
+
+  @Override
+  public Object beforeBodyWrite(Object body,
+      MethodParameter returnType,
+      MediaType selectedContentType,
+      Class<? extends HttpMessageConverter<?>> selectedConverterType,
+      ServerHttpRequest request,
+      ServerHttpResponse response) {
+
+    if (!(body instanceof ApiData<?> apiResult)) return body;
+
+    response.setStatusCode(apiResult.getHttpStatus());
+    response.getHeaders().addAll(buildHeaders(apiResult));
+
+    if (apiResult.getContentType() != null &&
+            apiResult.getContentType().isCompatibleWith(MediaType.APPLICATION_JSON))  return apiResult;
+
+    throw new BusinessException(ExceptionType.MEDIA_TYPE_MISMATCHED);
+
+  }
+
+  private HttpHeaders buildHeaders(ApiData<?> apiResult) {
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentType(apiResult.getContentType());
+    apiResult.getHeaders().forEach(header -> headers.add(header.name(), header.value()));
+
+    return headers;
+  }
+}
+
+
+# File Path: .\api\dto\ApiHeader.java
+package com.ocean.piuda.global.api.dto;
+
+public record ApiHeader(
+    String name,
+    String value
+) {
+
+  public static ApiHeader of(String name, String value) {
+    return new ApiHeader(name, value);
+  }
+}
+
+
+# File Path: .\api\dto\PageRequest.java
+package com.ocean.piuda.global.api.dto;
+
+import com.ocean.piuda.global.enums.SortEnum;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Data;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+@Data
+public class PageRequest<T extends Enum<T> & SortEnum> {
+    
+    @Min(value = 1, message = "페이지는 1부터 시작합니다.")
+    private int page = 1;
+    
+    @Min(value = 1, message = "사이즈는 1 이상이어야 합니다.")
+    private int size = 10;
+    
+    @NotNull
+    private T sort;
+    
+    public PageRequest() {}
+    
+    public PageRequest(int page, int size, T sort) {
+        this.page = page;
+        this.size = size;
+        this.sort = sort;
+    }
+    
+    public Pageable toPageable() {
+        // 1-based page를 0-based로 변환
+        Sort springSort = sort.toSort();
+        return org.springframework.data.domain.PageRequest.of(page - 1, size, springSort);
+    }
+
+    public Pageable toPageableWithoutSort() {
+        return org.springframework.data.domain.PageRequest.of(page - 1, size);
+    }
+}
+
+
+# File Path: .\api\dto\PageResponse.java
+package com.ocean.piuda.global.api.dto;
+
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageResponse<T>(
+        List<T> content,
+        int page,        // 1부터 시작
+        int size,
+        int totalPages,
+        long totalElements,
+        boolean first,
+        boolean last,
+        boolean hasNext,
+        boolean hasPrevious
+) {
+    public static <T> PageResponse<T> of(Page<T> page) {
+        return new PageResponse<>(
+                page.getContent(),
+                page.getNumber() + 1, // 0-based를 1-based로 변환
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.isFirst(),
+                page.isLast(),
+                page.hasNext(),
+                page.hasPrevious()
+        );
+    }
+}
+
+
+# File Path: .\api\exception\BusinessException.java
+package com.ocean.piuda.global.api.exception;
+
+
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ExceptionType exceptionType;
+    private final Map<String, ?> details;
+
+
+    // details 없음
+    public BusinessException(ExceptionType exceptionType) {
+        this.exceptionType = exceptionType;
+        this.details = Map.of();
+    }
+
+
+    // details 있음
+    public BusinessException(ExceptionType exceptionType, Map<String, ?> details) {
+        this.exceptionType = exceptionType;
+        this.details = details;
+    }
+}
+
+
+
+# File Path: .\api\exception\ExceptionType.java
+package com.ocean.piuda.global.api.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionType {
+    // common
+    UNEXPECTED_SERVER_ERROR(INTERNAL_SERVER_ERROR, "C001", "예상치못한 서버에러 발생"),
+    BINDING_ERROR(BAD_REQUEST, "C002", "잘못된 바인딩/조합"),
+    ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수적인 필드 부재"),
+    INVALID_VALUE_ERROR(NOT_ACCEPTABLE , "C004","값이 유효하지 않음"),
+    DUPLICATE_VALUE_ERROR(NOT_ACCEPTABLE , "C005","값이 중복됨"),
+    NOT_VALID_REQUEST_FIELDS_ERROR(BAD_REQUEST , "C006","요청 필드 검증에 실패했습니다."),
+    MEDIA_TYPE_MISMATCHED(BAD_REQUEST, "C007","잘못된 콘텐츠 타입 사용"),
+    RESOURCE_NOT_FOUND(NOT_FOUND,"C008","해당 자원을 찾을 수 없습니다."),
+    INVALID_INPUT_VALUE(NOT_FOUND, "C009","입력값이 잘못되었습니다."),
+    // auth
+    INVALID_REFRESH_TOKEN(NOT_ACCEPTABLE , "A001","유효하지 않은 리프레시 토큰"),
+    REFRESH_TOKEN_EXPIRED(UNAUTHORIZED,"A002","리프레시 토큰 만료"),
+    PASSWORD_NOT_MATCHED(NOT_ACCEPTABLE , "A003","비밀번호 불일치"),
+    ACCESS_DENIED(FORBIDDEN, "A004", "요청한 리소스에 대한 권한이 없습니다."),
+    AUTH_PRINCIPAL_INVALID(UNAUTHORIZED,"A005","principal 관련 에러 발생"),
+
+    // oauth2
+    INVALID_PROVIDER_TYPE_ERROR(NOT_ACCEPTABLE , "O001","지원하지 않는 provider"),
+
+    // user
+    USER_NOT_FOUND(NOT_FOUND, "U001", "존재하지 않는 사용자"),
+    DUPLICATED_USER_ID(CONFLICT, "U002", "중복 아이디(PK)"),
+    DUPLICATED_USERNAME(CONFLICT, "U003", "중복 아이디(username)"),
+    ALREADY_REGISTERED_USER(NOT_ACCEPTABLE , "U006","이미 최종 회원 가입된 사용자"),
+    NOT_REGISTERED_USER(FORBIDDEN , "U007","최종 회원 가입 되지 않은 사용자"),
+    UNAUTHORIZED_USER(UNAUTHORIZED, "U005","로그인 되지 않은 사용자"),
+
+    //store
+    STORE_NOT_FOUND(NOT_FOUND, "S001", "존재하지 않는 가게"),
+
+    // admin
+    SUBMISSION_NOT_FOUND(NOT_FOUND, "AD001", "제출 데이터를 찾을 수 없습니다."),
+    SUBMISSION_ALREADY_APPROVED(CONFLICT, "AD002", "이미 승인된 제출입니다."),
+    SUBMISSION_ALREADY_REJECTED(CONFLICT, "AD003", "이미 반려된 제출입니다."),
+    SUBMISSION_ALREADY_DELETED(CONFLICT, "AD004", "이미 삭제된 제출입니다."),
+    SUBMISSION_ALREADY_SUBMITTED(CONFLICT, "AD010", "이미 제출된 기록입니다."),
+    SUBMISSION_INVALID_STATUS(BAD_REQUEST, "AD011", "잘못된 상태입니다."),
+    REJECT_REASON_REQUIRED(UNPROCESSABLE_ENTITY, "AD005", "반려 사유를 입력해주세요."),
+    EXPORT_NOT_FOUND(NOT_FOUND, "AD006", "내보내기 작업을 찾을 수 없습니다."),
+    EXPORT_NOT_READY(UNPROCESSABLE_ENTITY, "AD007", "내보내기 파일이 아직 준비되지 않았습니다."),
+    EXPORT_FAILED(INTERNAL_SERVER_ERROR, "AD008", "내보내기 생성에 실패했습니다."),
+
+    // report (admin)
+    REPORT_DRAFT_SOURCE_EMPTY(BAD_REQUEST, "AD009", "리포트 생성 대상으로 집계된 제출물이 0건입니다."),
+
+    // AI (Gemini)
+    AI_GEMINI_ERROR(BAD_GATEWAY, "AI001", "Gemini 호출 중 오류가 발생했습니다."),
+    AI_RATE_LIMIT(TOO_MANY_REQUESTS, "AI002", "Gemini 요청 한도 초과(잠시 후 재시도)"),
+
+    //mission
+    MISSION_ACCESS_DENIED(FORBIDDEN, "M001", "해당 미션에 대한 접근 권한이 없습니다."),
+    MISSION_NOT_FOUND(NOT_FOUND, "M002", "해당 미션을 찾을 수 없습니다."),
+
+    //garmin
+    WATCH_API_KEY_INVALID(UNAUTHORIZED, "W001", "유효하지 않은 시계 API 키"),
+    INVALID_PAYLOAD(BAD_REQUEST, "W002", "유효하지 않은 페이로드"),
+    WATCH_NOT_PAIRED(HttpStatus.FORBIDDEN, "WATCH_NOT_PAIRED", "해당 워치는 아직 계정에 등록되지 않았습니다."),
+    WATCH_ALREADY_PAIRED(HttpStatus.CONFLICT, "WATCH_ALREADY_PAIRED", "이미 페어링된 워치입니다."),
+    WATCH_DEVICE_NOT_FOUND(HttpStatus.NOT_FOUND, "WATCH_DEVICE_NOT_FOUND", "등록된 워치 정보를 찾을 수 없습니다.")
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}
+
+
+# File Path: .\api\exception\GlobalExceptionHandler.java
+package com.ocean.piuda.global.api.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocean.piuda.global.api.dto.ApiData;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.expression.EvaluationException;
+import org.springframework.expression.spel.SpelEvaluationException;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestControllerAdvice
+@Slf4j
+@RequiredArgsConstructor
+public class GlobalExceptionHandler {
+
+  private final ObjectMapper objectMapper;
+
+  @ExceptionHandler(BusinessException.class)
+  public Object handleApplicationException(
+          BusinessException e,
+          HttpServletRequest request,
+          HttpServletResponse response
+  ) {
+    ApiData<Void> body = ApiData.error(e.getExceptionType(), e.getDetails());
+
+    //  PDF Accept만 온 경우에도 JSON 바디를 강제로 내려줌(컨텐트 협상 우회)
+    if (wantsPdfOnly(request)) {
+      writeJson(response, e.getExceptionType().getStatus().value(), body);
+      return null;
+    }
+
+    return ResponseEntity
+            .status(e.getExceptionType().getStatus())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body);
+  }
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public Object handleMethodArgumentNotValidException(
+          MethodArgumentNotValidException e,
+          HttpServletRequest request,
+          HttpServletResponse response
+  ) {
+    Map<String, String> details = new HashMap<>();
+    List<FieldError> fieldErrors = e.getFieldErrors();
+    fieldErrors.forEach(fieldError -> details.put(fieldError.getField(), fieldError.getDefaultMessage()));
+
+    ApiData<Void> body = ApiData.error(ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR, details);
+
+    if (wantsPdfOnly(request)) {
+      writeJson(response, ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR.getStatus().value(), body);
+      return null;
+    }
+
+    return ResponseEntity
+            .status(ExceptionType.NOT_VALID_REQUEST_FIELDS_ERROR.getStatus())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body);
+  }
+
+  /** @AuthenticationPrincipal(expression=...) 평가/캐스팅 실패 */
+  @ExceptionHandler({ SpelEvaluationException.class, EvaluationException.class, ClassCastException.class, IllegalArgumentException.class })
+  public Object handleAuthPrincipalBinding(
+          Exception e,
+          HttpServletRequest request,
+          HttpServletResponse response
+  ) {
+    ApiData<Void> body = ApiData.error(ExceptionType.AUTH_PRINCIPAL_INVALID, Map.of("message", e.getMessage()));
+
+    if (wantsPdfOnly(request)) {
+      writeJson(response, ExceptionType.AUTH_PRINCIPAL_INVALID.getStatus().value(), body);
+      return null;
+    }
+
+    return ResponseEntity
+            .status(ExceptionType.AUTH_PRINCIPAL_INVALID.getStatus())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body);
+  }
+
+  @ExceptionHandler(Exception.class)
+  public Object exception(
+          Exception e,
+          HttpServletRequest request,
+          HttpServletResponse response
+  ) {
+    log.error("Unhandled exception", e);
+    ApiData<Void> body = ApiData.error(ExceptionType.UNEXPECTED_SERVER_ERROR, Map.of("message", e.getMessage()));
+
+    if (wantsPdfOnly(request)) {
+      writeJson(response, ExceptionType.UNEXPECTED_SERVER_ERROR.getStatus().value(), body);
+      return null;
+    }
+
+    return ResponseEntity
+            .status(ExceptionType.UNEXPECTED_SERVER_ERROR.getStatus())
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body);
+  }
+
+  private boolean wantsPdfOnly(HttpServletRequest request) {
+    String accept = request.getHeader(HttpHeaders.ACCEPT);
+    if (accept == null) return false;
+
+    String a = accept.toLowerCase();
+    boolean acceptsPdf = a.contains("application/pdf");
+    boolean acceptsJson = a.contains("application/json") || a.contains("*/*");
+
+    // pdf는 받겠는데 json은 안 받는 케이스(= Swagger에서 흔함)
+    return acceptsPdf && !acceptsJson;
+  }
+
+  private void writeJson(HttpServletResponse response, int statusCode, ApiData<Void> body) {
+    if (response.isCommitted()) return;
+
+    try {
+      response.setStatus(statusCode);
+      response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+      response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+
+      String json = objectMapper.writeValueAsString(body);
+      byte[] bytes = json.getBytes(StandardCharsets.UTF_8);
+
+      response.setContentLength(bytes.length);
+      response.getOutputStream().write(bytes);
+      response.getOutputStream().flush();
+    } catch (IOException io) {
+      // 여기서 또 예외 던지면 더 꼬일 수 있어서 로그만
+      log.error("Failed to write JSON error response", io);
+    }
+  }
+}
+
+
+# File Path: .\config\JpaConfig.java
+package com.ocean.piuda.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@EnableJpaAuditing
+@Configuration
+public class JpaConfig {
+}
+
+
+# File Path: .\config\RestClientConfig.java
+package com.ocean.piuda.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
+
+@Configuration
+public class RestClientConfig {
+
+    @Bean
+    public RestClient restClient() {
+        return RestClient.create();
+    }
+}
+
+
+# File Path: .\config\RestTemplateConfig.java
+package com.ocean.piuda.global.config;
+
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate(RestTemplateBuilder restTemplateBuilder) {
+        return restTemplateBuilder.build();
+    }
+}
+
+
+
+# File Path: .\config\SwaggerConfig.java
+package com.ocean.piuda.global.config;
+
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .addServersItem(new Server().url("/"))
+                .components(new Components().addSecuritySchemes(
+                        "bearerAuth",
+                        new SecurityScheme()
+                                .name("bearerAuth")
+                                .type(SecurityScheme.Type.HTTP)
+                                .scheme("bearer")
+                                .bearerFormat("JWT")
+                ))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .info(new Info().title("PIUDA API").version("v1.0.0"));
+    }
+}
+
+
+# File Path: .\config\WebClientConfig.java
+package com.ocean.piuda.global.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+
+    /**
+     * 공통 REST API 호출용 기본 WebClient
+     */
+    @Bean
+    @Qualifier("defaultWebClient")
+    public WebClient defaultWebClient(WebClient.Builder builder) {
+        return builder.build();
+    }
+}
+
+
+
+# File Path: .\enums\SortEnum.java
+package com.ocean.piuda.global.enums;
+
+import org.springframework.data.domain.Sort;
+
+/**
+ * 정렬 기준을 정의하는 인터페이스
+ * 각 도메인별로 이 인터페이스를 구현하여 고유한 정렬 기준을 정의할 수 있습니다.
+ */
+public interface SortEnum {
+
+    /**
+     * Spring Data의 Sort 객체로 변환합니다.
+     * @return Sort 객체
+     */
+    Sort toSort();
+}
+
+
+# File Path: .\ProjectExporter.java
+package com.ocean.piuda.global;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+# File Path: .\util\GeometryUtils.java
+package com.ocean.piuda.global.util;
+
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+public class GeometryUtils {
+    // SRID 4326 (WGS84)
+    private static final GeometryFactory geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+
+    /**
+     * 좌표를 받아 Point 객체 생성
+     * GIS 표준에 따라 (Longitude, Latitude) 순서로 입력받습니다.
+     * @param longitude 경도 (X)
+     * @param latitude  위도 (Y)
+     */
+    public static Point createPoint(double longitude, double latitude) {
+        return geometryFactory.createPoint(new Coordinate(longitude, latitude));
+    }
+}
+
+
+# File Path: .\util\MultipartJackson2HttpMessageConverter.java
+package com.ocean.piuda.global.util;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.AbstractJackson2HttpMessageConverter;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Type;
+
+/**
+ * Swagger가 multipart/form-data의 JSON 파트를 Content-Type 없이 보내
+ * application/octet-stream으로 처리되는 경우를 흡수하기 위한 컨버터.
+ * 읽기(read)만 지원하고 쓰기(write)는 막음.
+ */
+@Component
+public class MultipartJackson2HttpMessageConverter extends AbstractJackson2HttpMessageConverter {
+
+    public MultipartJackson2HttpMessageConverter(ObjectMapper objectMapper) {
+        // 이 컨버터가 처리할 미디어타입을 octet-stream으로 명시
+        super(objectMapper, MediaType.APPLICATION_OCTET_STREAM);
+    }
+
+    @Override
+    protected boolean canWrite(MediaType mediaType) {
+        return false; // 쓰기는 지원하지 않음
+    }
+
+    @Override
+    public boolean canWrite(Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+
+    @Override
+    public boolean canWrite(Type type, Class<?> clazz, MediaType mediaType) {
+        return false;
+    }
+}
+

--- a/src/main/java/com/ocean/piuda/security/project_context.txt
+++ b/src/main/java/com/ocean/piuda/security/project_context.txt
@@ -1,0 +1,1572 @@
+
+# File Path: .\jwt\config\PasswordConfig.java
+package com.ocean.piuda.security.jwt.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+@Configuration
+public class PasswordConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+
+
+# File Path: .\jwt\config\SecurityConfig.java
+package com.ocean.piuda.security.jwt.config;
+
+import com.ocean.piuda.security.jwt.util.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.security.jwt.filter.JwtAuthenticationFilter;
+import com.ocean.piuda.security.jwt.handler.CustomAccessDeniedHandler;
+import com.ocean.piuda.security.jwt.handler.CustomAuthenticationEntryPoint;
+import com.ocean.piuda.security.jwt.service.CustomUserDetailsService;
+import com.ocean.piuda.security.oauth2.handler.OAuth2FailureHandler;
+import com.ocean.piuda.security.oauth2.handler.OAuth2SuccessHandler;
+import com.ocean.piuda.security.oauth2.service.CustomOAuth2UserService;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+
+
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(withDefaults())
+                .csrf(csrf -> csrf.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .formLogin(form -> form.disable())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/auth/login", "/api/auth/sign-up").permitAll()
+                        .requestMatchers("/api/v1/activities").permitAll()
+                        .requestMatchers("/api/auth/complete-sign-up/**").hasAuthority(Role.NOT_REGISTERED.getKey())
+                        
+                        // Admin 전용 API
+                        .requestMatchers("/api/admin/**").hasAuthority(Role.ADMIN.getKey())
+                        
+        // 그 외 비로그인 사용자도 허용
+                        .anyRequest().permitAll()
+                )
+
+                // oauth2 설정
+                .oauth2Login(oauth -> oauth
+                        .userInfoEndpoint(c -> c.userService(customOAuth2UserService)) // 사용자 정보를 어디서 load 할지 설정
+                        .successHandler(oAuth2SuccessHandler) // 로그인 성공 시 핸들러
+                        .failureHandler(oAuth2FailureHandler) // 로그인 실패 시 핸들러
+                )
+
+                // jwt 설정
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserDetailsService), UsernamePasswordAuthenticationFilter.class);  // JWT 인증 필터 추가;
+
+
+        return http.build();
+    }
+
+
+}
+
+
+# File Path: .\jwt\config\WebConfig.java
+package com.ocean.piuda.security.jwt.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                // allowCredentials(true)일 때는 allowedOrigins("*") 대신 allowedOriginPatterns("*")를 사용해야 합니다.
+                .allowedOriginPatterns("*")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+
+}
+
+
+# File Path: .\jwt\controller\AuthController.java
+package com.ocean.piuda.security.jwt.controller;
+
+import com.ocean.piuda.global.api.dto.ApiData;
+import com.ocean.piuda.security.jwt.util.TokenCookieFactory;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import com.ocean.piuda.security.jwt.dto.request.SignUpRequestDto;
+import com.ocean.piuda.security.jwt.dto.request.UserUpdateRequestDto;
+import com.ocean.piuda.security.jwt.dto.request.UsernameLoginRequestDto;
+import com.ocean.piuda.security.jwt.dto.response.SignUpResponseDto;
+import com.ocean.piuda.security.jwt.dto.response.TokenResponseDto;
+import com.ocean.piuda.security.jwt.service.AuthService;
+import com.ocean.piuda.security.oauth2.principal.PrincipalDetails;
+
+@Tag(name = "Auth API", description = "유저 및 회원가입 관련 API")
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+    private final TokenCookieFactory tokenCookieFactory;
+
+
+    /** 자체 회원가입 유저의 로그인 (공개) */
+    @PostMapping("/login")
+    @Operation(summary = "로그인", description = "자체 회원가입 유저의 아이디/비밀번호 로그인")
+    public ApiData<TokenResponseDto> usernameLogin(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "로그인 요청 바디", required = true
+            )
+            @RequestBody UsernameLoginRequestDto request,
+            HttpServletResponse response
+    ) {
+        TokenResponseDto dto = authService.usernameLogin(request); // 서비스는 토큰만 생성/검증
+        ResponseCookie cookie = tokenCookieFactory.buildAccessTokenCookie(dto.getAccess());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        return ApiData.ok(dto);
+    }
+
+    /** 자체 회원 가입 (1차, 공개) */
+    @Operation(summary = "자체 회원가입 1단계", description = "자체 로그인 기반 회원가입 1단계 수행")
+    @PostMapping("/sign-up")
+    public ApiData<SignUpResponseDto> signup(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "회원가입 요청 바디", required = true
+            )
+            @RequestBody SignUpRequestDto requestDto
+    ) {
+        SignUpResponseDto responseDto = authService.signup(requestDto);
+        return ApiData.created(responseDto);
+    }
+
+    /** ROLE_USER 최종(2차) 회원가입 (보호) */
+    @PostMapping("/complete-sign-up/user")
+    @Operation(summary = "회원가입 2단계(일반 사용자)", description = "일반 사용자에 대한 최종 회원가입 완료")
+    @SecurityRequirement(name = "bearerAuth")
+    public ApiData<Void> completeUserSignup(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal PrincipalDetails principal,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "회원가입 2단계 요청 바디", required = true
+            )
+            @RequestBody UserUpdateRequestDto requestDto
+    ) {
+        authService.completeUserSignup(principal.getUser().getId(), requestDto);
+        return ApiData.created(null);
+    }
+
+    /** 로그아웃 */
+    @PostMapping("/logout")
+    @Operation(summary = "로그아웃", description = "사용자 로그아웃 처리. Access Token 쿠키를 삭제합니다.")
+    @SecurityRequirement(name = "bearerAuth")
+    public ResponseEntity<ApiData<Void>> logout(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal PrincipalDetails principal,
+            HttpServletResponse response
+    ) {
+        // 쿠키 삭제
+        ResponseCookie logoutCookie = tokenCookieFactory.deleteAccessTokenCookie();
+        response.addHeader(HttpHeaders.SET_COOKIE, logoutCookie.toString());
+        
+        return ResponseEntity.ok(ApiData.ok(null));
+    }
+
+}
+
+
+# File Path: .\jwt\dto\request\SignUpRequestDto.java
+package com.ocean.piuda.security.jwt.dto.request;
+
+
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.user.entity.User;
+import lombok.*;
+
+/**
+ * 자체 회원가입을 위한 dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SignUpRequestDto {
+    private String username;
+    private String password;
+
+    public User toEntity() {
+        return User.builder()
+                .username(username)
+                .password(password)
+                .role(Role.NOT_REGISTERED) // OAuth2 회원가입과 마찬가지로, 처음 기본 정보만으로는 완전한 회원가입 처리 시키진 않음
+                .build();
+    }
+}
+
+
+# File Path: .\jwt\dto\request\UsernameLoginRequestDto.java
+package com.ocean.piuda.security.jwt.dto.request;
+
+import lombok.*;
+
+
+/**
+ * 자체 로그인을 위한 dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UsernameLoginRequestDto {
+    private String username;
+    private String password;
+}
+
+
+# File Path: .\jwt\dto\request\UserUpdateRequestDto.java
+package com.ocean.piuda.security.jwt.dto.request;
+
+import lombok.*;
+
+
+/**
+ * 부가적인 정보의 업데이트를 위한 dto
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserUpdateRequestDto {
+    private String nickname;
+    private String email;
+    private String phone;
+}
+
+
+# File Path: .\jwt\dto\response\SignUpResponseDto.java
+package com.ocean.piuda.security.jwt.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import com.ocean.piuda.user.entity.User;
+
+@Getter
+@Builder
+public class SignUpResponseDto {
+    private Long id;
+    private String username;
+
+    public static SignUpResponseDto fromEntity(User user) {
+        return SignUpResponseDto.builder()
+                .id(user.getId())
+                .username(user.getUsername())
+                .build();
+    }
+}
+
+
+# File Path: .\jwt\dto\response\TokenResponseDto.java
+package com.ocean.piuda.security.jwt.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class TokenResponseDto {
+    private String access;
+}
+
+
+# File Path: .\jwt\dto\response\UsernameLoginResponseDto.java
+package com.ocean.piuda.security.jwt.dto.response;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+
+
+/**
+ * 자체 로그인을 위한 dto
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class UsernameLoginResponseDto {
+    private String access;
+}
+
+
+# File Path: .\jwt\enums\Role.java
+package com.ocean.piuda.security.jwt.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    /**
+     * NOT_REGISTERED 이면 -> 회원가입 페이지로 redirect
+     * NOT_REGISTERED가 아니면 -> 서비스 페이지로 redirect
+     */
+    NOT_REGISTERED("ROLE_NOT_REGISTERED", "회원가입 이전 유저"),
+    USER("ROLE_USER", "회원가입 완료된 일반 유저"),
+    DIVER("ROLE_DIVER", "회원가입 완료된 다이버 유저"),
+    RESEARCHER("ROLE_RESEARCHER", "회원가입 완료된 연구원 유저"),
+    ADMIN("ROLE_ADMIN", "애플리케이션 관리자");
+
+    private final String key;
+    private final String title;
+}
+
+
+# File Path: .\jwt\filter\JwtAuthenticationFilter.java
+package com.ocean.piuda.security.jwt.filter;
+
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import com.ocean.piuda.security.jwt.service.CustomUserDetailsService;
+import com.ocean.piuda.security.jwt.util.JwtTokenProvider;
+import com.ocean.piuda.security.oauth2.principal.PrincipalDetails;
+
+import java.io.IOException;
+
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final CustomUserDetailsService customUserDetailsService;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        String token = JwtTokenProvider.extractToken(request.getHeader("Authorization"));  // JWT 토큰 추출
+
+        log.debug("[JwtAuthenticationFilter] token: {}", token);
+
+        // 쿠키에서 ACCESS_TOKEN 찾기 (oauth2 리다이렉트 시 쿠키에 access token 저장)
+        if (token == null) {
+            if (request.getCookies() != null) {
+                for (Cookie c : request.getCookies()) {
+                    if ("ACCESS_TOKEN".equals(c.getName())) {
+                        token = c.getValue();
+                        break;
+                    }
+                }
+            }
+        }
+
+        // 임시/정식 access 토큰이 존재하고 유효한 경우
+        if (token != null && jwtTokenProvider.isValidToken(token)) {
+            Long id =jwtTokenProvider.extractId(token);  // JWT에서 사용자명 추출
+
+            log.debug("[JwtAuthenticationFilter] userId from token: {}", id);
+
+            // UserDetailsService 를 통해 사용자 정보 로드
+            PrincipalDetails userDetails = (PrincipalDetails) customUserDetailsService.loadUserById(id);
+
+            // 인증 객체 생성 및 SecurityContext에 설정
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+
+}
+
+
+# File Path: .\jwt\handler\CustomAccessDeniedHandler.java
+package com.ocean.piuda.security.jwt.handler;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocean.piuda.global.api.dto.ApiData;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 로그인은 했지만 권한이 부족하여 접근 튕길때의 처리 담당
+ * (예: NOT_REGISTERED 권한 사용자가 USER 권한 path 접근 시도하여 예외 발생 )
+ *
+ */
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        ApiData<?> apiData = ApiData.error(ExceptionType.ACCESS_DENIED);
+
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json;charset=UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(apiData));
+    }
+}
+
+
+# File Path: .\jwt\handler\CustomAuthenticationEntryPoint.java
+package com.ocean.piuda.security.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ocean.piuda.global.api.dto.ApiData;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 로그인 조차 안한 상태에서 접근 튕길때의 처리 담당
+ */
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+
+        ApiData<?> apiData = ApiData.error(ExceptionType.UNAUTHORIZED_USER);
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        response.getWriter().write(objectMapper.writeValueAsString(apiData));
+
+    }
+}
+
+
+# File Path: .\jwt\principal\CustomUserDetails.java
+package com.ocean.piuda.security.jwt.principal;
+
+
+/**
+ * 자체로그인만을 위한 principal 구현체,
+ * PrincipalDetails( 자체로그인 + oauth2 ) 로 퉁칩니다.
+ */
+//@Getter
+//@Builder
+//public class CustomUserDetails implements UserDetails {
+//    private final User user;
+//    private final Collection<? extends GrantedAuthority> authorities;
+//
+//    public CustomUserDetails(User user) {
+//        this.user = user;
+//        this.authorities = List.of(new SimpleGrantedAuthority(user.getRole().getKey()));
+//    }
+//
+//    @Override
+//    public String getUsername() {
+//        return user.getUsername();
+//    }
+//
+//    @Override
+//    public String getPassword() {
+//        return user.getPassword();
+//    }
+//
+//    @Override public boolean isAccountNonExpired() { return true; }
+//    @Override public boolean isAccountNonLocked() { return true; }
+//    @Override public boolean isCredentialsNonExpired() { return true; }
+//    @Override public boolean isEnabled() { return true; }
+//
+//}
+//
+//
+
+
+# File Path: .\jwt\service\AuthService.java
+package com.ocean.piuda.security.jwt.service;
+
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.ocean.piuda.user.entity.User;
+import com.ocean.piuda.user.repository.UserRepository;
+import com.ocean.piuda.security.jwt.dto.request.SignUpRequestDto;
+import com.ocean.piuda.security.jwt.dto.request.UserUpdateRequestDto;
+import com.ocean.piuda.security.jwt.dto.request.UsernameLoginRequestDto;
+import com.ocean.piuda.security.jwt.dto.response.SignUpResponseDto;
+import com.ocean.piuda.security.jwt.dto.response.TokenResponseDto;
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.security.jwt.util.JwtTokenProvider;
+
+
+@Transactional
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final PasswordEncoder passwordEncoder;
+
+
+
+    /**
+     * username, pw 를 통한 자체 로그인 로직
+     * @param request
+     * @return
+     */
+    public TokenResponseDto usernameLogin(UsernameLoginRequestDto request) {
+
+        /**
+         * 유효한 username, pw 을 통한 로그인인지 확인
+         * access token 신규 발급
+         */
+        User user = userRepository.findByUsername(request.getUsername())
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        // db 에 이미 암호화된 형태로 저장되있기에 request 에 담긴 비밀번호를 암호화 하여 비교 수행
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new BusinessException(ExceptionType.PASSWORD_NOT_MATCHED);
+        }
+
+        /**
+         * 최종 회원 가입까지 완료된 사용자가 아닌 경우 "임시" access token 발급
+         * 최종 회원 가입까지 완료된 사용자인 경우 "정식" access token 발급
+         */
+        return TokenResponseDto.builder()
+                .access(issueTokensFor(user.getId()))
+                .build();
+    }
+
+
+
+
+    /**
+     * 특정 유저에 대한 임시/정식 access token 발급
+     * @return
+     */
+    public String issueTokensFor(Long userId) {
+        return jwtTokenProvider.generateAccessToken(userId);
+    }
+
+
+
+
+
+    public SignUpResponseDto signup(SignUpRequestDto request) {
+        if (userRepository.findByUsername(request.getUsername()).isPresent()) {
+            throw new BusinessException(ExceptionType.DUPLICATED_USERNAME);
+        }
+
+        // 비밀번호 암호화 및 저장
+        request.setPassword(passwordEncoder.encode(request.getPassword()));
+        User user = request.toEntity();
+        user = userRepository.save(user);
+
+        return SignUpResponseDto.fromEntity(user);
+    }
+
+    public SignUpResponseDto completeUserSignup(Long userId, UserUpdateRequestDto request) {
+        User user = findAndUpdateUserForCompleteSignup(userId,request);
+        user.updateRole(Role.USER);// USER 권한으로 승격
+        return SignUpResponseDto.fromEntity(user);
+    }
+
+
+
+    private User findAndUpdateUserForCompleteSignup(Long userId, UserUpdateRequestDto request){
+        User user = userRepository
+                .findById(userId)
+                .orElseThrow(()->new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        if (user.getRole() != Role.NOT_REGISTERED) {
+            throw new BusinessException(ExceptionType.ALREADY_REGISTERED_USER);
+        }
+
+        // 최종 회원 가입을 위한 추가 작업 정의
+        user.update(request);
+        return user;
+
+
+    }
+
+
+
+
+
+}
+
+
+# File Path: .\jwt\service\CustomUserDetailsService.java
+package com.ocean.piuda.security.jwt.service;
+
+
+
+
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import com.ocean.piuda.user.entity.User;
+import com.ocean.piuda.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import com.ocean.piuda.security.oauth2.principal.PrincipalDetails;
+
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // 사실상 얘만 현재 사용
+    public UserDetails loadUserById(Long id) {
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+        return new PrincipalDetails(user);
+    }
+
+    // 필수 override
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+        return new PrincipalDetails(user);
+    }
+}
+
+
+# File Path: .\jwt\service\TokenUserService.java
+package com.ocean.piuda.security.jwt.service;
+
+
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import com.ocean.piuda.security.jwt.enums.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+import com.ocean.piuda.security.oauth2.principal.PrincipalDetails;
+import com.ocean.piuda.user.entity.User;
+
+/**
+ * 시큐리티 컨텍스트에서 현재 인증된 사용자 정보를 조회하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class TokenUserService {
+
+    /**
+     * 현재 인증된 사용자의 User 엔티티를 반환합니다.
+     */
+    public User getCurrentUser() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            throw new BusinessException(ExceptionType.UNAUTHORIZED_USER);
+        }
+
+        Object principal = authentication.getPrincipal();
+
+        if (!(principal instanceof PrincipalDetails principalDetails)) {
+            throw new BusinessException(ExceptionType.UNAUTHORIZED_USER);
+        }
+
+        return principalDetails.getUser();
+    }
+
+
+
+    /**
+     * 현재 인증된 사용자의 ID를 반환합니다.
+     */
+    public Long getCurrentUserId() {
+        return getCurrentUser().getId();
+    }
+
+
+
+    /**
+     * 현재 인증된 사용자의 ID를 반환합니다.
+     */
+    public Role getCurrentUserRole() {
+        return getCurrentUser().getRole();
+    }
+
+
+
+    /**
+     * 현재 사용자가 인증되어 있는지 확인합니다.
+     *
+     * @return 인증된 경우 true, 그렇지 않으면 false
+     */
+    public boolean isAuthenticated() {
+        try {
+            getCurrentUser();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+}
+
+
+# File Path: .\jwt\util\JwtTokenProvider.java
+package com.ocean.piuda.security.jwt.util;
+
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+
+@Component
+public class JwtTokenProvider {
+
+    @Value("${jwt.secret}")
+    private String secretKey;
+
+    @Value("${jwt.expiration.access}")
+    private long accessTokenExpiration;
+
+
+
+
+    // string key 기반 key 객체 생성
+    private SecretKey getSigningKey() {
+        return Keys.hmacShaKeyFor(secretKey.getBytes(StandardCharsets.UTF_8));
+    }
+
+
+    // AccessToken 생성
+    public String generateAccessToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(getSigningKey())
+                .compact();
+    }
+
+
+
+
+    public static String extractToken(String bearerToken) {
+        return bearerToken != null && bearerToken.toLowerCase().startsWith("bearer ")
+                ? bearerToken.substring(7)
+                : null;
+    }
+
+    // claims 파서
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(getSigningKey())
+                .build()
+                .parseSignedClaims(token) // 유효성 검증 및 파싱
+                .getPayload();
+    }
+
+    public boolean isValidToken(String token) {
+        try {
+            parseClaims(token); // 성공 시 유효
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+    /**
+     * claim 에서 특정 정보 추출하는 메서드들
+     * @param token
+     */
+    public Long extractId(String token) { return Long.parseLong(parseClaims(token).getSubject()); }
+
+    public LocalDateTime extractExpiration(String token) {
+        Date expiration = parseClaims(token).getExpiration();
+        return expiration.toInstant()
+                .atZone(ZoneId.systemDefault())
+                .toLocalDateTime();
+    }
+
+
+
+
+
+
+
+}
+
+
+# File Path: .\jwt\util\TokenCookieFactory.java
+package com.ocean.piuda.security.jwt.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
+public class TokenCookieFactory {
+    private final JwtTokenProvider jwtTokenProvider;
+    private static final String ACCESS_TOKEN_COOKIE = "ACCESS_TOKEN";
+    // 환경별 설정 (prod/dev 분리)
+    @Value("${app.cookie.domain:}")        // 예: jungjiyu.com  (앞에 점 붙이지 말 것!)
+    private String cookieDomain;
+
+    @Value("${app.cookie.secure:true}")    // prod: true, dev(http): false
+    private boolean cookieSecure;
+
+    @Value("${app.cookie.same-site:None}") // prod: None, dev: Lax
+    private String cookieSameSite;
+
+    public ResponseCookie buildAccessTokenCookie(String accessToken) {
+        ResponseCookie.ResponseCookieBuilder b = ResponseCookie
+                .from(ACCESS_TOKEN_COOKIE, accessToken)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)  // PWA 이슈 회피: None + Secure
+                .path("/")
+                .maxAge(computeMaxAgeSeconds(accessToken));
+
+        if (StringUtils.hasText(cookieDomain)) {
+            // "jungjiyu.com" 으로 넣어야 함 (".jungjiyu.com" 금지)
+            b = b.domain(cookieDomain);
+        }
+        return b.build();
+    }
+
+    public ResponseCookie deleteAccessTokenCookie() {
+        ResponseCookie.ResponseCookieBuilder b = ResponseCookie
+                .from(ACCESS_TOKEN_COOKIE, "")
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
+                .path("/")
+                .maxAge(0);
+
+        if (StringUtils.hasText(cookieDomain)) {
+            b = b.domain(cookieDomain);
+        }
+        return b.build();
+    }
+
+
+    private long computeMaxAgeSeconds(String accessToken) {
+        try {
+            LocalDateTime exp = jwtTokenProvider.extractExpiration(accessToken);
+            long seconds = Duration.between(LocalDateTime.now(ZoneId.systemDefault()), exp).getSeconds();
+            return Math.max(seconds, 1L); // 음수/0 방지
+        } catch (Exception e) {
+            return Duration.ofHours(1).getSeconds();  // 보수적으로 1시간로 설정
+        }
+    }
+
+
+}
+
+
+# File Path: .\oauth2\enums\ProviderType.java
+package com.ocean.piuda.security.oauth2.enums;
+
+import java.util.Arrays;
+
+public enum ProviderType {
+    KAKAO,
+    NAVER,
+    GOOGLE;
+
+    public static ProviderType from(String provider) {
+        String upperCastedProvider = provider.toUpperCase();
+
+        return Arrays.stream(ProviderType.values())
+                .filter(item -> item.name().equals(upperCastedProvider))
+                .findFirst()
+                .orElseThrow();
+    }
+
+
+}
+
+
+# File Path: .\oauth2\handler\OAuth2FailureHandler.java
+package com.ocean.piuda.security.oauth2.handler;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+public class OAuth2FailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Value("${oauth2.url.base}")
+    private String BASE_URL;
+
+    private final String ERROR_PARAM_PREFIX = "error";
+
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException, ServletException {
+        // 리다이렉트할 주소 생성, query string에 에러 메세지 추가
+        String redirectUrl = UriComponentsBuilder.fromUriString(BASE_URL)
+                .queryParam(ERROR_PARAM_PREFIX, exception.getLocalizedMessage())
+                .build()
+                .toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+}
+
+
+# File Path: .\oauth2\handler\OAuth2SuccessHandler.java
+package com.ocean.piuda.security.oauth2.handler;
+
+import com.ocean.piuda.security.jwt.util.TokenCookieFactory;
+import com.ocean.piuda.user.entity.User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.security.jwt.service.AuthService;
+import com.ocean.piuda.security.jwt.util.JwtTokenProvider;
+import com.ocean.piuda.security.oauth2.principal.PrincipalDetails;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Getter
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    @Value("${oauth2.url.base}")
+    private String BASE_URL;
+
+    @Value("${oauth2.url.path.signup}")
+    private String SIGNUP_PATH;
+
+    @Value("${oauth2.url.path.auth}")
+    private String AUTH_PATH;
+
+
+    private final AuthService authService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final TokenCookieFactory tokenCookieFactory;
+
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+        PrincipalDetails principalDetails = (PrincipalDetails) authentication.getPrincipal();
+
+        User user = principalDetails.getUser();
+
+        // 액세스 토큰 발급
+        String accessToken = authService.issueTokensFor(user.getId());
+
+        /**
+         * access token 을 쿠키로 전달
+         */
+        ResponseCookie cookie = tokenCookieFactory.buildAccessTokenCookie(accessToken);
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+
+        // 리다이렉트 URL 생성
+        String redirectUrl = getRedirectUrlByRole(user);
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+
+    }
+
+
+
+    private String getRedirectUrlByRole(User user) {
+        Role role = user.getRole();
+        Long userId = user.getId();
+
+
+        /**
+         * 최종 회원가입 이전의 사용자에 대한 리다이렉트
+         * 여기까지 왔는데 회원가입 되지 않았다의 의미 : provider 상에 등록 완료됬고, 우리 db에 저장까지 됬는데 추가적인 부가정보를 입력하지 않아 우리 애플리케이션 상에서 최종 회원가입 완료는 안된 상태
+         */
+        if (role == Role.NOT_REGISTERED) {
+            return UriComponentsBuilder
+                    .fromUriString(BASE_URL + SIGNUP_PATH) // fromUriString -> 상대경로 포함 가능
+                    .queryParam("id", userId)
+                    .build()
+                    .toUriString();
+        }
+
+        /**
+         * 최종 회원가입된 사용자에 대한 리다이렉트
+         */
+        return UriComponentsBuilder
+                .fromHttpUrl(BASE_URL + AUTH_PATH) // fromHttpUrl() -> 절대 경로만 허용
+                .queryParam("id", userId)
+                .build()
+                .toUriString();
+    }
+}
+
+
+# File Path: .\oauth2\info\OAuth2UserInfo.java
+package com.ocean.piuda.security.oauth2.info;
+
+import com.ocean.piuda.security.oauth2.enums.ProviderType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+
+/**
+ * provider 가 넘긴 정보 저장용 편의 OAuth2 객체. dto.
+ */
+@Getter
+@AllArgsConstructor
+@Builder
+public class OAuth2UserInfo {
+
+    public final ProviderType providerType; // provider 벤더명
+
+
+    // provider 가 넘긴 전체 정보
+    private Map<String, Object> attributes;
+
+    // 해당 provider 상의 식별자 값
+    private String providerId;
+
+
+
+
+    /**
+     * 이외의 추가적으로 단축 호출 원하는 정보에 대해 필드 추가
+     */
+    // 해당 provider 상의 사용자명
+    private String nickname;
+    private String email;
+
+
+
+
+
+
+
+}
+
+
+# File Path: .\oauth2\info\OAuth2UserInfoFactory.java
+package com.ocean.piuda.security.oauth2.info;
+
+
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import com.ocean.piuda.security.oauth2.enums.ProviderType;
+
+import java.util.Map;
+
+public class OAuth2UserInfoFactory {
+    public static OAuth2UserInfo getOAuth2UserInfo(ProviderType providerType, Map<String, Object> attributes) {
+        switch (providerType) {
+            case KAKAO -> {
+                // 카카오의 경우 attributes 에 바로 email 과 nickname 을 담지 않고 account 와 profile 내부에 담기에 account 와 profile 을 구해놔야됨
+                Map<String, Object> account = (Map<String, Object>) attributes.getOrDefault("kakao_account", Map.of());
+                Map<String, Object> profile = (Map<String, Object>) account.getOrDefault("profile", Map.of());
+
+
+
+                return OAuth2UserInfo.builder()
+                        .providerType(providerType)
+                        .attributes(attributes)
+                        .providerId(String.valueOf(attributes.get("id")))
+                        .nickname((String) profile.getOrDefault("nickname", ""))
+                        .email((String) account.getOrDefault("email", ""))
+                        .build();
+            }
+            case NAVER -> {
+                //  naver 의 경우 응답 자체가 response 내부에 있음
+                Map<String, Object> response = (Map<String, Object>) attributes.getOrDefault("response", Map.of());
+
+                return OAuth2UserInfo.builder()
+                        .providerType(providerType)
+                        .attributes(response)
+                        .providerId((String) response.getOrDefault("id", ""))
+                        .nickname((String) response.getOrDefault("name", ""))
+                        .email((String) response.getOrDefault("email", ""))
+                        .build();
+
+
+            }
+            case GOOGLE -> {
+                return OAuth2UserInfo.builder()
+                        .providerType(providerType)
+                        .attributes(attributes)
+                        .providerId((String) attributes.get("sub"))
+                        .nickname((String) attributes.get("name"))
+                        .email((String) attributes.get("email"))
+                        .build();
+            }
+        }
+        throw new BusinessException(ExceptionType.INVALID_PROVIDER_TYPE_ERROR);
+
+    }
+}
+
+
+# File Path: .\oauth2\principal\PrincipalDetails.java
+package com.ocean.piuda.security.oauth2.principal;
+
+import com.ocean.piuda.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * SecurityContext 저장용 자체로그인 + oauth2 객체
+ * jwt 만 사용한 자체로그인 시 UserDetails, Oauth2 만 사용한 로그인 시 OAuth2User 각각 만 implements 하고 이를 seucritycontext 에 저장해 사용하면 되는데
+ * 자체로그인과 OAuth2 를 둘 다 구현한 경우 @AuthenticationPrincipal 을 통해 쉽게 불러오기 위해선 둘 다 implements 하는게 좋다
+ */
+@Getter
+@Builder
+public class PrincipalDetails implements OAuth2User, UserDetails {
+    private User user;
+    private  Map<String, Object> attributes;
+
+    //일반 로그인 생성자
+    public PrincipalDetails(User user) {
+        this.user = user;
+    }
+
+    //OAuth 로그인 생성자
+    public PrincipalDetails(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+
+    @Override
+    public String getName() {
+        return user.getId() != null ? user.getId().toString() : "anonymous_name";
+    }
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority(user.getRole().getKey()));
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername() != null ? user.getUsername()  : "anonymous_username";
+    }
+
+    @Override public boolean isAccountNonExpired() { return true; }
+    @Override public boolean isAccountNonLocked() { return true; }
+    @Override public boolean isCredentialsNonExpired() { return true; }
+    @Override public boolean isEnabled() { return true; }
+
+
+
+}
+
+
+# File Path: .\oauth2\principal\UserPrincipal.java
+package com.ocean.piuda.security.oauth2.principal;
+
+
+/**
+ * SecurityContext 저장용 oauth2 객체.
+ * PrincipalDetails( 자체로그인 + oauth2 ) 로 퉁칩니다.
+ */
+//@Getter
+//@AllArgsConstructor
+//@Builder
+//public class CustomOAuth2User implements OAuth2User {
+//    private final User user;
+//    private final Map<String, Object> attributes;
+//
+//
+//
+//    @Override
+//    public String getName() {
+//        return user.getProviderId();  // provider 상의 식별자를 반환하도록 설정
+//    }
+//
+//
+//    @Override
+//    public Collection<? extends GrantedAuthority> getAuthorities() {
+//        return List.of(new SimpleGrantedAuthority(user.getRole().getKey()));
+//    }
+//
+//
+//
+//}
+
+
+# File Path: .\oauth2\service\CustomOAuth2UserService.java
+package com.ocean.piuda.security.oauth2.service;
+
+
+
+
+import com.ocean.piuda.user.entity.User;
+import com.ocean.piuda.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.security.oauth2.enums.ProviderType;
+import com.ocean.piuda.security.oauth2.info.OAuth2UserInfo;
+import com.ocean.piuda.security.oauth2.info.OAuth2UserInfoFactory;
+import com.ocean.piuda.security.oauth2.principal.PrincipalDetails;
+
+import java.util.Map;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(
+            OAuth2UserRequest userRequest // OAuth2UserRequest 에는 clientRegistration(설정 파일상 provider 측의 클라이언트,즉 우리의 등록 정보), accessToken 내장
+    ) throws OAuth2AuthenticationException {
+
+        // OAuth2UserRequest 에 내장된 clientRegistration 추출
+        String registrationId = userRequest.getClientRegistration().getRegistrationId(); // 해당 provider 명
+        ProviderType providerType = ProviderType.from(registrationId); // 쓰기 편하게 enum 화
+
+
+        // OAuth2UserRequest 에 내장된 accesstoken 을 활용해 provider 로부터 OAuth2User(유저 정보)를 response 로 받음
+        // OAuth2User 에는 attributes , authorities 내장
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // OAuth2User 에 내장된 attributes 추출
+        Map<String, Object> attributes = oAuth2User.getAttributes();
+
+
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(providerType, attributes);
+
+        User user = getOrSaveUser(providerType, oAuth2UserInfo);
+
+
+        // Security context에 저장할 객체 생성
+        return PrincipalDetails.builder()
+                .user(user)
+                .attributes(attributes)
+                .build();
+    }
+
+
+
+    private User getOrSaveUser(ProviderType providerType,  OAuth2UserInfo oAuth2UserInfo) {
+
+        String providerId = oAuth2UserInfo.getProviderId();
+
+        Optional<User> optionalUser = userRepository.findByOAuthInfo(providerType, providerId);
+
+        // db에 저장 안된. 즉, 신규 oauth2 회원 가입 유저이면
+        if (optionalUser.isEmpty()) {
+            User unregisteredUser = User.builder()
+                    .providerType(providerType)
+                    .providerId(providerId)
+                    .role(Role.NOT_REGISTERED) // NOT_REGISTERED == 최종 회원가입(2차)을 마치지 않은 유저
+                    .nickname(oAuth2UserInfo.getNickname())
+                    .email(oAuth2UserInfo.getEmail())
+                    .build();
+
+            return userRepository.save(unregisteredUser);
+        }
+
+        return optionalUser.get();
+
+    }
+}
+
+
+# File Path: .\ProjectExporter.java
+package com.ocean.piuda.security;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+

--- a/src/main/java/com/ocean/piuda/user/project_context.txt
+++ b/src/main/java/com/ocean/piuda/user/project_context.txt
@@ -1,0 +1,501 @@
+
+# File Path: .\controller\UserController.java
+package com.ocean.piuda.user.controller;
+
+import com.ocean.piuda.global.api.dto.ApiData;
+import com.ocean.piuda.security.jwt.dto.request.UserUpdateRequestDto;
+import com.ocean.piuda.security.jwt.service.TokenUserService;
+import com.ocean.piuda.user.dto.request.UserSearchRequest;
+import com.ocean.piuda.user.dto.response.DetailedUserResponse;
+import com.ocean.piuda.user.service.UserAggregateBuilder;
+import com.ocean.piuda.user.service.UserCommandService;
+import com.ocean.piuda.user.service.UserQueryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+@Tag(name = "유저 API", description = "유저 정보 조회, 검색, 수정 기능")
+public class UserController {
+
+    private final UserCommandService userCommandService;
+    private final UserQueryService userQueryService;
+    private final TokenUserService tokenUserService;
+    private final UserAggregateBuilder aggregateBuilder;
+
+    @PatchMapping("/{userId}")
+    @Operation(summary = "유저 정보 수정", description = "특정 유저의 닉네임, 이메일, 전화번호 등 기본 정보를 수정합니다.")
+    public ApiData<Boolean> patchUser(
+            @PathVariable Long userId,
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "수정할 유저 정보", required = true)
+            @RequestBody @Valid UserUpdateRequestDto req
+    ) {
+        userCommandService.patch(userId, req);
+        return ApiData.ok(true);
+    }
+
+    @PostMapping("/search")
+    @Operation(summary = "유저 검색", description = "닉네임 또는 username을 기준으로 유저를 검색합니다.")
+    public ApiData<Page<DetailedUserResponse>> searchByNicknameOrUsername(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "검색 요청 정보", required = true)
+            @RequestBody @Valid UserSearchRequest req
+    ) {
+        return ApiData.ok(userQueryService.searchByNicknameOrUsername(req));
+    }
+
+    @GetMapping("/{userId}/info")
+    @Operation(summary = "유저 상세 조회", description = "id 기반으로 특정 유저의 상세 정보를 조회합니다.")
+    public ApiData<DetailedUserResponse> getUserById(@PathVariable Long userId) {
+        return ApiData.ok(aggregateBuilder.build(userQueryService.getUserById(userId)));
+    }
+
+    @GetMapping("/my/info")
+    @Operation(summary = "내 정보 조회", description = "Access Token 기반으로 현재 로그인한 유저의 상세 정보를 조회합니다.")
+    public ApiData<DetailedUserResponse> getLoginedUser() {
+        return ApiData.ok(aggregateBuilder.build(tokenUserService.getCurrentUser()));
+    }
+
+
+}
+
+
+# File Path: .\dto\request\UserSearchRequest.java
+package com.ocean.piuda.user.dto.request;
+
+import lombok.Builder;
+
+@Builder
+public record UserSearchRequest(
+        String q,
+        Integer page,
+        Integer size
+) {
+
+    public int pageOrDefault() { return page == null ? 0 : Math.max(0, page); }
+    public int sizeOrDefault() { return size == null ? 20 : Math.max(1, size); }
+    public String qOrEmpty()    { return q == null ? "" : q; }
+}
+
+
+# File Path: .\dto\response\DetailedUserResponse.java
+package com.ocean.piuda.user.dto.response;
+
+import com.ocean.piuda.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record DetailedUserResponse(
+        Long id,
+        String nickname,
+        String email,
+        String phone,
+
+// TODO : 다른도메인에서 얻은 값들
+        String watchDeviceId   // 연동된 워치 암호화 ID
+
+) {
+
+    public static DetailedUserResponse fromEntity(
+            User u
+            // 추가한 다른 도메인 필드들에 대한 파라미터들
+    ){
+        return DetailedUserResponse.builder()
+                .id(u.getId())
+                .nickname(u.getNickname())
+                .email(u.getEmail())
+                .phone(u.getPhone())
+                // 그 파라미터들 대한 빌더 패턴
+                .watchDeviceId(u.getWatchDeviceId())
+                .build();
+    }
+}
+
+
+# File Path: .\entity\User.java
+package com.ocean.piuda.user.entity;
+
+import com.ocean.piuda.global.api.domain.BaseEntity;
+import com.ocean.piuda.security.jwt.dto.request.UserUpdateRequestDto;
+import com.ocean.piuda.security.jwt.enums.Role;
+import com.ocean.piuda.security.oauth2.enums.ProviderType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Table(name = "users")
+@Entity
+@Getter
+@NoArgsConstructor @AllArgsConstructor
+@Builder
+public class User extends BaseEntity {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    private ProviderType providerType;
+
+    private String providerId;
+
+    @Column(unique = true)
+    private String username;
+
+    @Column
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role role;
+
+    // 부가 정보
+    private String nickname;
+    private String email;
+    private String phone;
+
+    /**
+     * 한 유저당 최대 1개의 워치만 등록 (0개 허용)
+     * 암호화된 deviceId 기준으로 관리
+     */
+    @Column(name = "watch_device_id", length = 100, unique = true)
+    private String watchDeviceId;
+
+    public void updateRole(Role role){
+        this.role = role;
+    }
+
+    public void update(UserUpdateRequestDto dto) {
+        if (dto.getNickname() != null && !dto.getNickname().isBlank()) {
+            this.nickname = dto.getNickname();
+        }
+        if (dto.getEmail() != null && !dto.getEmail().isBlank()) {
+            this.email = dto.getEmail();
+        }
+        if (dto.getPhone() != null && !dto.getPhone().isBlank()) {
+            this.phone = dto.getPhone();
+        }
+    }
+
+    public void pairWatch(String watchDeviceId) {
+        this.watchDeviceId = watchDeviceId;
+    }
+
+    public void unpairWatch() {
+        this.watchDeviceId = null;
+    }
+}
+
+
+# File Path: .\ProjectExporter.java
+package com.ocean.piuda.user;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.*;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+public class ProjectExporter {
+
+    // 결과 파일명
+    private static final String OUTPUT_FILE = "project_context.txt";
+
+    // 기본적으로 제외할 디렉토리/파일 (gitignore가 없거나 놓칠 경우 대비)
+    private static final Set<String> DEFAULT_IGRORES = new HashSet<>(Arrays.asList(
+            ".git", ".idea", ".gradle", "build", "target", "out", ".mvn", "wrapper", "gradlew", "gradlew.bat", OUTPUT_FILE
+    ));
+
+    // 텍스트 파일로 간주할 확장자 (바이너리 제외용)
+    private static final Set<String> TEXT_EXTENSIONS = new HashSet<>(Arrays.asList(
+            "java", "xml", "yml", "yaml", "properties", "gradle", "sql", "md", "txt", "html", "css", "js", "json", "dockerfile"
+    ));
+
+    public static void main(String[] args) {
+        Path startPath = Paths.get(".");
+        Path outputPath = Paths.get(OUTPUT_FILE);
+        List<PathMatcher> gitIgnoreMatchers = loadGitIgnore(startPath);
+
+        try (java.io.BufferedWriter writer = Files.newBufferedWriter(outputPath, StandardCharsets.UTF_8)) {
+            System.out.println(" 프로젝트 추출을 시작합니다... (Target: " + OUTPUT_FILE + ")");
+
+            Files.walkFileTree(startPath, new SimpleFileVisitor<Path>() {
+                @Override
+                public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, dir, gitIgnoreMatchers)) {
+                        return FileVisitResult.SKIP_SUBTREE;
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+
+                @Override
+                public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                    if (shouldIgnore(startPath, file, gitIgnoreMatchers)) {
+                        return FileVisitResult.CONTINUE;
+                    }
+
+                    if (isTextFile(file)) {
+                        writeFileContent(writer, file);
+                    }
+                    return FileVisitResult.CONTINUE;
+                }
+            });
+
+            System.out.println("완료! '" + OUTPUT_FILE + "' 파일이 생성되었습니다.");
+
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    // .gitignore 파일 로드 및 PathMatcher 변환
+    private static List<PathMatcher> loadGitIgnore(Path rootPath) {
+        List<PathMatcher> matchers = new ArrayList<>();
+        Path gitIgnorePath = rootPath.resolve(".gitignore");
+        FileSystem fs = FileSystems.getDefault();
+
+        if (Files.exists(gitIgnorePath)) {
+            try (Stream<String> lines = Files.lines(gitIgnorePath)) {
+                lines.map(String::trim)
+                        .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                        .forEach(line -> {
+                            // 간단한 glob 패턴 변환 (폴더인 경우 /** 추가 등)
+                            String pattern = "glob:**/" + line;
+                            if (line.endsWith("/")) {
+                                pattern += "**";
+                            }
+                            try {
+                                matchers.add(fs.getPathMatcher(pattern));
+                            } catch (Exception e) {
+                                // 복잡한 정규식 패턴은 무시
+                            }
+                        });
+                System.out.println("ℹ .gitignore 파일을 발견하여 규칙을 적용합니다.");
+            } catch (IOException e) {
+                System.err.println("⚠ .gitignore 읽기 실패: " + e.getMessage());
+            }
+        }
+        return matchers;
+    }
+
+    // 제외 대상 확인 로직
+    private static boolean shouldIgnore(Path root, Path path, List<PathMatcher> gitIgnoreMatchers) {
+        String fileName = path.getFileName().toString();
+
+        // 1. 기본 제외 목록 확인
+        if (DEFAULT_IGRORES.contains(fileName)) return true;
+
+        // 2. .gitignore 규칙 확인
+        for (PathMatcher matcher : gitIgnoreMatchers) {
+            if (matcher.matches(path)) return true;
+        }
+
+        return false;
+    }
+
+    // 텍스트 파일 여부 확인 (확장자 기반)
+    private static boolean isTextFile(Path path) {
+        String fileName = path.getFileName().toString().toLowerCase();
+        if (fileName.equals("dockerfile")) return true;
+
+        int lastDot = fileName.lastIndexOf('.');
+        if (lastDot == -1) return false;
+
+        String ext = fileName.substring(lastDot + 1);
+        return TEXT_EXTENSIONS.contains(ext);
+    }
+
+    private static void writeFileContent(java.io.BufferedWriter writer, Path file) {
+        try {
+            writer.write("\n# File Path: " + file.toString() + "\n");
+
+            // 파일 내용을 한 번에 읽어서 쓰기
+            Files.lines(file).forEach(line -> {
+                try {
+                    writer.write(line);
+                    writer.newLine();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+            writer.write("\n");
+        } catch (Exception e) {
+            System.err.println(" 파일 읽기 실패 (" + file + "): " + e.getMessage());
+        }
+    }
+}
+
+
+# File Path: .\repository\UserRepository.java
+package com.ocean.piuda.user.repository;
+
+import com.ocean.piuda.security.oauth2.enums.ProviderType;
+import com.ocean.piuda.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User , Long> {
+    Optional<User> findByUsername(String username);
+
+    @Query("select u from User u where u.providerType = :providerType and u.providerId = :providerId " )
+    Optional<User> findByOAuthInfo(@Param("providerType") ProviderType providerType,
+                                   @Param("providerId") String providerId);
+
+    // 워치 암호화 ID 기준 조회
+    Optional<User> findByWatchDeviceId(String watchDeviceId);
+
+    @Query("""
+           SELECT u FROM User u
+           WHERE LOWER(u.nickname) LIKE LOWER(CONCAT('%', :q, '%'))
+           """)
+    Page<User> searchByNicknameFulltext(@Param("q") String q, Pageable pageable);
+
+    @Query("""
+           SELECT u FROM User u
+           WHERE LOWER(u.username) LIKE LOWER(CONCAT('%', :q, '%'))
+           """)
+    Page<User> searchByUsernameFulltext(@Param("q") String q, Pageable pageable);
+
+    @Query("""
+           SELECT u FROM User u
+           WHERE LOWER(u.nickname) LIKE LOWER(CONCAT('%', :q, '%'))
+              OR LOWER(u.username) LIKE LOWER(CONCAT('%', :q, '%'))
+           """)
+    Page<User> searchByNicknameOrUsernameFulltext(@Param("q") String q, Pageable pageable);
+}
+
+
+# File Path: .\service\UserAggregateBuilder.java
+package com.ocean.piuda.user.service;
+
+import com.ocean.piuda.user.dto.response.DetailedUserResponse;
+import com.ocean.piuda.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * 애플리케이션에서 user 와 관련된 종합적인 정보
+ * 한번에 반환하기 위한 builder.
+ * 해당 유저의 축약된 전반적인 정보 반환이 목적.
+ */
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class UserAggregateBuilder {
+
+
+    public DetailedUserResponse build(User user) {
+        // TODO: 다른 도메인 리파지토리 활용해 필요한 정보 얻기
+        return DetailedUserResponse.fromEntity(
+                user
+                // 여기에 얻은 정보들 대입
+        );
+    }
+}
+
+
+# File Path: .\service\UserCommandService.java
+package com.ocean.piuda.user.service;
+
+import com.ocean.piuda.security.jwt.dto.request.UserUpdateRequestDto;
+import com.ocean.piuda.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class UserCommandService {
+    private final UserQueryService userQueryService;
+
+    public void patch( Long userId, UserUpdateRequestDto req) {
+        User user = userQueryService.getUserById(userId);
+        user.update(req);
+    }
+
+
+
+
+
+
+
+
+
+
+
+}
+
+
+# File Path: .\service\UserQueryService.java
+package com.ocean.piuda.user.service;
+
+import com.ocean.piuda.global.api.exception.BusinessException;
+import com.ocean.piuda.global.api.exception.ExceptionType;
+import com.ocean.piuda.user.dto.request.UserSearchRequest;
+import com.ocean.piuda.user.dto.response.DetailedUserResponse;
+import com.ocean.piuda.user.entity.User;
+import com.ocean.piuda.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class UserQueryService {
+
+    private final UserRepository userRepository;
+    private final UserAggregateBuilder aggregateBuilder;
+
+    public User getUserById(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+    }
+
+    public Page<DetailedUserResponse> searchByNickname(UserSearchRequest req) {
+        String q = normalize(req.qOrEmpty());
+        var pageable = PageRequest.of(req.pageOrDefault(), req.sizeOrDefault());
+        Page<User> page = userRepository.searchByNicknameFulltext(q, pageable);
+        return page.map(aggregateBuilder::build);
+    }
+
+    public Page<DetailedUserResponse> searchByUsername(UserSearchRequest req) {
+        String q = normalize(req.qOrEmpty());
+        var pageable = PageRequest.of(req.pageOrDefault(), req.sizeOrDefault());
+        Page<User> page = userRepository.searchByUsernameFulltext(q, pageable);
+        return page.map(aggregateBuilder::build);
+    }
+
+    public Page<DetailedUserResponse> searchByNicknameOrUsername(UserSearchRequest req) {
+        String q = normalize(req.qOrEmpty());
+        var pageable = PageRequest.of(req.pageOrDefault(), req.sizeOrDefault());
+        Page<User> page = userRepository.searchByNicknameOrUsernameFulltext(q, pageable);
+        return page.map(aggregateBuilder::build);
+    }
+
+    private String normalize(String q) {
+        if (q == null) return "";
+        return q.replaceAll("[+\\-><()~\"@]+", " ").trim();
+    }
+}
+


### PR DESCRIPTION
## 💡 개요 (Summary)
- 도메인 모델 내 잔존해 있던 **미사용 분류 필드(Species)** 를 정리하고, 프론트엔드 로직 재작성에 맞춰 Submission 상세 조회 API의 응답 필드명과 구성을 현행화(Update)하였습니다.

## 📝 작업 내용 (Key Changes)
### 1. Submission API 응답 규격 변경
- 필드명 변경 (feedbackText → workDescription): 기존 레거시 프론트엔드 로직 호환성을 위해 유지하던 feedbackText 필드명을 제거하고, 내부 도메인 용어인 workDescription으로 통일했습니다.
- 회차 정보 추가 (divingRound): 상세 조회 응답(SubmissionDetailResponse)에 divingRound 필드를 추가하여, 클라이언트가 별도 계산 없이 회차 정보를 표시할 수 있도록 개선했습니다.

### 2. Species 도메인 경량화
- 불필요한 분류 필드 제거 (BioGroup): 기획 변경으로 인해 종(Species) 단위에서 더 이상 사용하지 않는 생물 분류군(BioGroup) 필드와 관련 로직(Entity, DTO, Init Data)을 모두 삭제하여 도메인 복잡도를 낮췄습니다.

## 🛠️ 기술적 의사결정 (Technical Decisions)
### 1. API 필드명 현실화 (feedbackText → workDescription)
기존에는 레거시 프론트엔드 코드와의 호환성을 위해 workDescription 데이터를 feedbackText라는 이름으로 매핑하여 반환했습니다. 하지만 프론트엔드 측에서 해당 로직을 전면 재작성하기로 결정함에 따라, 더 이상 레거시 필드명을 유지할 필요가 없어졌습니다. 이에 따라 API 필드명을 서버 도메인 모델과 일치하는 workDescription으로 변경하여 데이터의 의미를 명확히 하고 혼란을 제거했습니다. 

### 2. YAGNI 원칙 적용 (Species BioGroup 제거)
Species 엔티티의 BioGroup은 초기 기획 단계에서는 필요해 보였으나, 실제 비즈니스 로직에서는 전혀 참조되지 않는 필드였습니다. "You Aren't Gonna Need It" 원칙에 따라, 사용하지 않는 기능을 과감히 삭제하여 유지보수성을 높이고 데이터 구조를 간결하게 만들었습니다.

## 🔗 Related Issue
- #35 